### PR TITLE
Enhance the tag & default tag support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -235,13 +235,5 @@ pub trait Component {
 pub trait Path {
     fn path() -> &'static str;
 
-    fn path_item() -> openapi::path::PathItem;
-}
-
-pub trait DefaultTag {
-    fn tag() -> &'static str;
-}
-
-pub trait Tag {
-    fn tag() -> &'static str;
+    fn path_item(defalt_tag: Option<&str>) -> openapi::path::PathItem;
 }

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -123,15 +123,14 @@ fn derive_path_with_all_info_success() {
     }
 }
 
-test_api_fn! {
-    name: test_operation3,
-    module: derive_path_with_defaults,
-    operation: post,
-    path: "/foo/bar";
-}
-
 #[test]
 fn derive_path_with_defaults_success() {
+    test_api_fn! {
+        name: test_operation3,
+        module: derive_path_with_defaults,
+        operation: post,
+        path: "/foo/bar";
+    }
     let operation = test_api_fn_doc! {
         derive_path_with_defaults::test_operation3,
         operation: post,

--- a/tests/utoipa_gen_test.rs
+++ b/tests/utoipa_gen_test.rs
@@ -1,8 +1,6 @@
 #![cfg(feature = "actix_extras")]
 #![allow(dead_code)]
 
-use std::borrow::Cow;
-
 use serde::{Deserialize, Serialize};
 use utoipa::{Component, OpenApi};
 

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1,4 +1,8 @@
-//! This is private utoipa codegen library and is not used alone
+//! This is **private** utoipa codegen library and is not used alone
+//!
+//! The library contains macro implementations for utoipa library. Content
+//! of the libarary documentation is available through **utoipa** library itself.
+//! Consider browsing via the **utoipa** crate so all links will work correctly.
 
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]


### PR DESCRIPTION
* Remove Tag and DefaultTag traits along with the need for those traits
* Remove useless assert struct
* Make path to be more neutral about its location -> allows path macro attributed methods within methods where as previously they needed to exists only in module level