### PR TITLE
Enhance actions support multimodules

### DIFF
--- a/.github/actions/gitlog/action.yaml
+++ b/.github/actions/gitlog/action.yaml
@@ -4,10 +4,17 @@ inputs:
   output-file:
     description: File path where to place the content of the changed commits
     required: true
+  crate:
+    description: Name of the crate to get git log for
+    required: true
+outputs:
+  last_release: 
+    description: Last release commit or first commit of history
+    value: ${{ steps.gitlog.outputs.last_release }}
 runs:
   using: composite
   steps:
     - shell: bash 
       id: gitlog
       run: |
-        ${{ github.action_path }}/gitlog.sh --output-file ${{ inputs.output-file }}
+        ${{ github.action_path }}/gitlog.sh --output-file ${{ inputs.output-file }} --crate ${{ inputs.crate }}

--- a/.github/actions/gitlog/gitlog.sh
+++ b/.github/actions/gitlog/gitlog.sh
@@ -2,10 +2,8 @@
 
 # This mangles git log entries for change lop purposes
 
-from_commit=HEAD
-last_release=$(git tag | sort -r | head -1) # get last tag
-
 output_file=""
+crate=""
 while true; do
   case $1 in
     "--output-file")
@@ -13,11 +11,31 @@ while true; do
       output_file="$1"
       shift
     ;;
+    "--crate")
+      shift
+      crate="$1"
+      shift
+    ;;
     *)
       break
     ;;
   esac
 done
+
+if [[ "$output_file" == "" ]]; then
+  echo "Missing --output-file <file> option argument, define path to file or - for stdout" && exit 1
+fi
+if [[ "$crate" == "" ]]; then
+  echo "Missing --crate <crate> option argument, need an explisit crate to get git log for" && exit 1
+fi
+
+from_commit=HEAD
+last_release=$(git tag | grep -E "$crate-[0-9]*\.[0-9]*\.[0-9]*" | sort -r | head -1)
+echo "Found tag: $last_release"
+if [[ "$last_release" == "" ]]; then
+  last_release=$(git tag | sort -r | head -1) # get last tag
+  echo "Using latest tag: $last_release"
+fi
 
 commit_range=""
 if [[ $last_release != "" ]]; then
@@ -33,10 +51,40 @@ fi
 
 mapfile -t log_lines < <(git log --pretty=format:'(%h) %s' $ancestry_path $commit_range)
 
+function is_crate_related {
+  commit="$1"
+  changes="$(git diff --name-only "$commit"~ "$commit" | awk -F / '{print $1}' | xargs)"
+  
+  is_related=false
+  if [[ "$crate" != "utoipa" ]] && [[ "$changes" == *"$crate"* ]]; then
+    is_related=true
+  fi
+  if [[ "$crate" == "utoipa" ]] && [[ ! $changes =~ (utoipa-gen|utoipa-swagger-ui) ]]; then
+    is_related=true
+  fi
+  
+  echo $is_related
+}
+
 log=""
 for line in "${log_lines[@]}"; do
-  log=$log"* $line\n"
+  commit=$(echo "$line" | awk -F ' ' '{print $1}')
+  commit=${commit//[\(\)]/}
+  
+  if [[ $(is_crate_related "$commit") == true ]]; then
+    log=$log"* $line\n"
+  fi
 done
+
 if [[ "$output_file" != "" ]]; then
-  echo -e "$log" > "$output_file"
+  if [[ "$output_file" == "-" ]]; then
+    echo -e "$log"
+  else
+    echo -e "$log" > "$output_file"
+  fi
 fi
+
+if [[ "$last_release" == "" ]]; then
+  last_release=$(git rev-list --reverse HEAD | head -1)
+fi
+echo "::set-output name=last_release::$last_release"

--- a/.github/actions/publish/action.yaml
+++ b/.github/actions/publish/action.yaml
@@ -4,10 +4,13 @@ inputs:
   token:
     description: Cargo login token to use the publish the crate
     required: true
+  ref:
+    description: "Github release tag ref"
+    required: true
 runs:
   using: composite
   steps:
     - shell: bash 
       id: publish_crate
       run: |
-        ${{ github.action_path }}/publish.sh --token ${{ inputs.token }}
+        ${{ github.action_path }}/publish.sh --token ${{ inputs.token }} --ref ${{ inputs.ref }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,10 +18,9 @@ jobs:
     strategy:
       matrix:
         testset: 
-          - default
-          - actix
-          - gen
-          - swagger
+          - utoipa
+          - utoipa-gen
+          - utoipa-swagger-ui
       fail-fast: true
     runs-on: ubuntu-latest
 
@@ -61,14 +60,13 @@ jobs:
 
     - name: Run tests
       run: |
-        if [[ "${{ matrix.testset }}" == "default" ]] && [[ ${{ steps.changes.outputs.root_changed }} == true ]]; then
+        if [[ "${{ matrix.testset }}" == "utoipa" ]] && [[ ${{ steps.changes.outputs.root_changed }} == true ]]; then
           cargo test
           cargo test --test path_response_derive_test_no_serde_json --no-default-features
           cargo test --test component_derive_no_serde_json --no-default-features
-        elif [[ "${{ matrix.testset }}" == "actix" ]] && [[ ${{ steps.changes.outputs.root_changed }} == true ]]; then
-          cargo test --features actix_extras
-        elif [[ "${{ matrix.testset }}" == "gen" ]] && [[ ${{ steps.changes.outputs.gen_changed }} == true ]]; then
+          cargo test --test path_derive_actix --test path_parameter_derive_actix --features actix_extras
+        elif [[ "${{ matrix.testset }}" == "utoipa-gen" ]] && [[ ${{ steps.changes.outputs.gen_changed }} == true ]]; then
           cargo test -p utoipa-gen --features actix_extras
-        elif [[ "${{ matrix.testset }}" == "swagger" ]] && [[ ${{ steps.changes.outputs.swagger_changed }} == true ]]; then
+        elif [[ "${{ matrix.testset }}" == "utoipa-swagger-ui" ]] && [[ ${{ steps.changes.outputs.swagger_changed }} == true ]]; then
           cargo test -p utoipa-swagger-ui --features actix-web
         fi

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -10,6 +10,13 @@ env:
 
 jobs:
   draft:
+    strategy:
+      matrix:
+        crate:
+          - utoipa
+          - utoipa-gen
+          - utoipa-swagger-ui
+      fail-fast: true
     runs-on: ubuntu-latest
 
     steps:
@@ -22,18 +29,22 @@ jobs:
       id: gitlog
       with:
         output-file: ./draft-gitlog.md
+        crate: ${{ matrix.crate }}
 
     - name: Prepare changes
       run: |
-        echo "# Changes in this Release" > ./draft-changes.md
+        echo "## What's New :gem: :new: :tada:" > ./draft-changes.md
         cat < ./draft-gitlog.md >> ./draft-changes.md
-
-        cat ./draft-changes.md
 
     - name: Get release info
       id: release_info
       run: |
-        version=$(cargo read-manifest | jq -r .version)
+        version=""
+        if [[ "${{ matrix.crate }}" == "utoipa" ]]; then
+          version=$(cargo read-manifest | jq -r .version)
+        else 
+          version=$(cargo read-manifest --manifest-path "${{ matrix.crate }}/Cargo.toml" | jq -r .version)
+        fi
 
         prerelease=false
         if [[ "$version" =~ .*-.* ]]; then
@@ -41,17 +52,21 @@ jobs:
         fi
         echo "::set-output name=is_prerelease::$prerelease"
         echo "::set-output name=version::$version"
+    
+    - name: Add full change log link
+      run: |
+        echo -e "#### Full [change log](${{ github.server_url }}/${{ github.repository }}/compare/${{ steps.gitlog.outputs.last_release }}...${{ matrix.crate }}-${{ steps.release_info.outputs.version }})" >> ./draft-changes.md
 
     - name: Check existing release
       run: |
-        if git tag | grep ${{ steps.release_info.outputs.version }} > /dev/null; then 
-          echo "Tag tag with ${{ steps.release_info.outputs.version }} already exists, cannot draft a release for already existing tag!, Consider upgrading versions to Cargo.toml file" && exit 1
+        if git tag | grep ${{ matrix.crate }}-${{ steps.release_info.outputs.version }} > /dev/null; then 
+          echo "Tag tag with ${{ matrix.crate }}-${{ steps.release_info.outputs.version }} already exists, cannot draft a release for already existing tag!, Consider upgrading versions to Cargo.toml file" && exit 1
         fi
 
     - name: Remove previous release
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token
-        gh release delete ${{ steps.release_info.outputs.version }} -y || true
+        gh release delete ${{ matrix.crate }}-${{ steps.release_info.outputs.version }} -y || true
 
     - name: Create release
       id: create_release
@@ -59,8 +74,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.release_info.outputs.version }}
-        release_name: Release ${{ steps.release_info.outputs.version }}
+        tag_name: ${{ matrix.crate }}-${{ steps.release_info.outputs.version }}
+        release_name: ${{ matrix.crate }}-${{ steps.release_info.outputs.version }}
         body_path: ./draft-changes.md
         draft: true
         prerelease: ${{ steps.release_info.outputs.is_prerelease }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,3 +20,4 @@ jobs:
       name: Cargo publish
       with:
         token: ${{ secrets.CARGO_LOGIN }}
+        ref: ${{ github.ref }}


### PR DESCRIPTION
* Update draft action to support multi module builds -> Now drafts in crate basis
* Update gitlog action to get only crate relevant changes
* Improve the looks of drafted release
* Add link to full change log to the release
* Update release action to support multi module releasing -> Now able to release appointed crate
* Update build pipeline -> combine acitix and default test run. Rename testsets according modules.