### PR TITLE
Add value_type to allow type override

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also awesome type of beer :be
 * **debug** Add extra traits such as debug traits to openapi definitions and elsewhere.
 * **chrono_types** Add support for _**chrono**_ `DateTime`, `Date` and `Duration` types. By default these types
   are parsed to `string` types without additional format. If you want to have formats added to the types
-  use **chrono_types_with_format** feature. This is useful because OpenAPI 3.1 spec does not have date-time formats.
+  use *chrono_types_with_format* feature. This is useful because OpenAPI 3.1 spec does not have date-time formats.
 * **chrono_types_with_format** Add support to _**chrono**_ types described above with additional `format`
   information type. `date-time` for `DateTime` and `date` for `Date` according
   [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14) as `ISO-8601`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@
 //! * **debug** Add extra traits such as debug traits to openapi definitions and elsewhere.
 //! * **chrono_types** Add support for _**chrono**_ `DateTime`, `Date` and `Duration` types. By default these types
 //!   are parsed to `string` types without
-//!   additional format. If you want to have formats added to the types use **chrono_with_format** feature.
+//!   additional format. If you want to have formats added to the types use _chrono_with_format_ feature.
 //!   This is useful because OpenAPI 3.1 spec does not have date-time formats.
 //! * **chrono_types_with_format** Add support to _**chrono**_ types described above with additional `format`
 //!   information type. `date-time` for `DateTime` and `date` for `Date` according

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -656,3 +656,83 @@ fn derive_component_with_chrono_types_with_chrono_feature() {
         "properties.value.format" = r#"null"#, "Post value format"
     }
 }
+
+#[test]
+fn derive_struct_component_field_type_override() {
+    let post = api_doc! {
+        struct Post {
+            id: i32,
+            #[component(value_type = String)]
+            value: i64,
+        }
+    };
+
+    assert_value! {post=>
+        "properties.id.type" = r#""integer""#, "Post id type"
+        "properties.id.format" = r#""int32""#, "Post id format"
+        "properties.value.type" = r#""string""#, "Post value type"
+        "properties.value.format" = r#"null"#, "Post value format"
+    }
+}
+
+#[test]
+fn derive_struct_component_field_type_override_with_format() {
+    let post = api_doc! {
+        struct Post {
+            id: i32,
+            #[component(value_type = String, format = ComponentFormat::Byte)]
+            value: i64,
+        }
+    };
+
+    assert_value! {post=>
+        "properties.id.type" = r#""integer""#, "Post id type"
+        "properties.id.format" = r#""int32""#, "Post id format"
+        "properties.value.type" = r#""string""#, "Post value type"
+        "properties.value.format" = r#""byte""#, "Post value format"
+    }
+}
+
+#[test]
+fn derive_struct_component_field_type_override_with_format_with_vec() {
+    let post = api_doc! {
+        struct Post {
+            id: i32,
+            #[component(value_type = String, format = ComponentFormat::Binary)]
+            value: Vec<u8>,
+        }
+    };
+
+    assert_value! {post=>
+        "properties.id.type" = r#""integer""#, "Post id type"
+        "properties.id.format" = r#""int32""#, "Post id format"
+        "properties.value.type" = r#""string""#, "Post value type"
+        "properties.value.format" = r#""binary""#, "Post value format"
+    }
+}
+
+#[test]
+fn derive_unnamed_struct_component_type_override() {
+    let value = api_doc! {
+        #[component(value_type = String)]
+        struct Value(i64);
+    };
+
+    assert_value! {value=>
+        "type" = r#""string""#, "Value type"
+        "format" = r#"null"#, "Value format"
+    }
+}
+
+#[test]
+fn derive_unnamed_struct_component_type_override_with_format() {
+    let value = api_doc! {
+        #[component(value_type = String, format = ComponentFormat::Byte)]
+        struct Value(i64);
+    };
+
+    assert_value! {value=>
+        "type" = r#""string""#, "Value type"
+        "format" = r#""byte""#, "Value format"
+    }
+}

--- a/utoipa-gen/src/component_type.rs
+++ b/utoipa-gen/src/component_type.rs
@@ -82,7 +82,6 @@ where
     }
 }
 
-// TODO add extendability to this so that custom types can also be tokenized?
 /// Tokenizes OpenAPI data type format correctly by given Rust type.
 pub(crate) struct ComponentFormat<T: Display>(pub(crate) T);
 

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -217,7 +217,7 @@ use ext::ArgumentResolver;
 /// # use utoipa::Component;
 /// #[derive(Component)]
 /// #[component(value_type = String)]
-/// struct Value(i62);
+/// struct Value(i64);
 /// ```
 ///
 /// [c]: trait.Component.html

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -61,9 +61,19 @@ use ext::ArgumentResolver;
 ///  
 /// [^json]: **json** feature need to be enabled for `json!(...)` type to work.
 ///
-/// # Enum & Unnamed Field Struct Optional Configuration Options
+/// # Enum Optional Configuration Options
 /// * **example** Can be method reference or literal value. [^json2]
 /// * **default** Can be method reference or literal value. [^json2]
+///
+/// # Unnamed Field Struct Optional Configuration Options
+/// * **example** Can be method reference or literal value. [^json2]
+/// * **default** Can be method reference or literal value. [^json2]
+/// * **format**  [`ComponentFormat`][format] to use for the property. By default the format is derived from
+///   the type of the property according OpenApi spec.
+/// * **value_type** Can be used to override default type derived from type of the field used in OpenAPI spec.
+///   This is useful in cases the where default type does not correspond to the actual type e.g. when
+///   any thrid-party types are used which are not components nor primitive types. With **value_type** we can enforce
+///   type used to certain type. Value type may only be [`primitive`][primitive] type or [`String`]. Generic types are not allowed.
 ///
 /// # Named Fields Optional Configuration Options
 /// * **example** Can be method reference or literal value. [^json2]
@@ -73,6 +83,10 @@ use ext::ArgumentResolver;
 /// * **write_only** Defines property is only used in **write** operations *POST,PUT,PATCH* but not in *GET*
 /// * **read_only** Defines property is only used in **read** operations *GET* but not in *POST,PUT,PATCH*
 /// * **xml** Can be used to define [`Xml`][xml] object properties applicable to named fields.
+/// * **value_type** Can be used to override default type derived from type of the field used in OpenAPI spec.
+///   This is useful in cases the where default type does not correspond to the actual type e.g. when
+///   any thrid-party types are used which are not components nor primitive types. With **value_type** we can enforce
+///   type used to certain type. Value type may only be [`primitive`][primitive] type or [`String`]. Generic types are not allowed.
 ///
 /// [^json2]: Values are converted to string if **json** feature is not enabled.
 ///
@@ -186,9 +200,31 @@ use ext::ArgumentResolver;
 /// }
 /// ```
 ///
+/// Enforce type being used in OpenAPI spec to String with `value_type` and set format to octect stream
+/// with [`ComponentFormat::Binary`][binary].
+/// ```rust
+/// # use utoipa::Component;
+/// #[derive(Component)]
+/// struct Post {
+///     id: i32,
+///     #[component(value_type = String, format = ComponentFormat::Binary)]
+///     value: Vec<u8>,
+/// }
+/// ```
+///
+/// Enforce type being used in OpenAPI spec to String with `value_type` option.
+/// ```rust
+/// # use utoipa::Component;
+/// #[derive(Component)]
+/// #[component(value_type = String)]
+/// struct Value(i62);
+/// ```
+///
 /// [c]: trait.Component.html
 /// [format]: openapi/schema/enum.ComponentFormat.html
+/// [binary]: openapi/schema/enum.ComponentFormat.html#variant.Binary
 /// [xml]: openapi/xml/struct.Xml.html
+/// [primitive]: https://doc.rust-lang.org/std/primitive/index.html
 pub fn derive_component(input: TokenStream) -> TokenStream {
     let DeriveInput {
         attrs,


### PR DESCRIPTION
Fix issue regarding thrid-party types which are not components nor they are primitive types. Since
the we cannot know what such types are by looking type type itself and those types possibly can be
presented in many forms we need to allow user to override the type in such cases.

* Add possibility to override type for named fields and unnamed field structs
* Add tests
* Update docs recardingly