### PR TITLE
Fix utoipa-swagger-ui build

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -27,3 +27,5 @@ features = ["actix-web", "rocket"]
 
 [build-dependencies]
 zip = "0.6"
+regex = "1.5"  
+lazy_static = "1.4"

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -83,13 +83,16 @@
 //! [^actix]: **actix-web** feature need to be enabled.
 //!
 //! [^rocket]: **rocket** feature need to be enabled.
-use std::{borrow::Cow, error::Error, io::Cursor, sync::Arc};
+use std::{borrow::Cow, error::Error, sync::Arc};
 
 #[cfg(feature = "actix-web")]
 use actix_web::{
     dev::HttpServiceFactory, guard::Get, web, web::Data, HttpResponse, Resource,
     Responder as ActixResponder,
 };
+
+#[cfg(feature = "rocket")]
+use std::io::Cursor;
 
 #[cfg(feature = "rocket")]
 use rocket::{


### PR DESCRIPTION
* Remove need for filesystem dependency `sed` and replace it with Rust alternatives.