### PR TITLE
Add IntoParams trait derive

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,7 @@ jobs:
           cargo test --test component_derive_test --features chrono_types_with_format
           cargo test --test path_derive_rocket --features rocket_extras,json
         elif [[ "${{ matrix.testset }}" == "utoipa-gen" ]] && [[ ${{ steps.changes.outputs.gen_changed }} == true ]]; then
-          cargo test -p utoipa-gen --features actix_extras
+          cargo test -p utoipa-gen --features utoipa/actix_extras
         elif [[ "${{ matrix.testset }}" == "utoipa-swagger-ui" ]] && [[ ${{ steps.changes.outputs.swagger_changed }} == true ]]; then
           cargo test -p utoipa-swagger-ui --features actix-web,rocket
         fi

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,7 +196,6 @@
 
 pub mod openapi;
 
-use openapi::path::{Parameter, ParameterBuilder};
 pub use utoipa_gen::*;
 
 /// Trait for implementing OpenAPI specification in Rust.
@@ -465,9 +464,13 @@ pub trait Modify {
 
 #[cfg(feature = "actix_extras")]
 pub trait IntoParams {
-    fn default_parameters_in() -> Option<openapi::path::ParameterIn> {
+    fn into_params() -> Vec<openapi::path::Parameter>;
+}
+
+#[cfg(feature = "actix_extras")]
+#[doc(hidden)]
+pub trait ParameterIn {
+    fn parameter_in() -> Option<openapi::path::ParameterIn> {
         None
     }
-
-    fn into_params() -> Vec<Parameter>;
 }

--- a/tests/path_derive_actix.rs
+++ b/tests/path_derive_actix.rs
@@ -418,7 +418,7 @@ fn derive_path_with_struct_variables_with_into_params() {
     struct Filter {
         /// Age filter for user
         #[deprecated]
-        age: Vec<String>,
+        age: Option<Vec<String>>,
     }
 
     #[utoipa::path(
@@ -460,7 +460,7 @@ fn derive_path_with_struct_variables_with_into_params() {
         "[2].in" = r#""query""#, "Parameter in"
         "[2].name" = r#""age""#, "Parameter name"
         "[2].description" = r#""Age filter for user""#, "Parameter description"
-        "[2].required" = r#"true"#, "Parameter required"
+        "[2].required" = r#"false"#, "Parameter required"
         "[2].deprecated" = r#"true"#, "Parameter deprecated"
         "[2].schema.type" = r#""array""#, "Parameter schema type"
         "[2].schema.items.type" = r#""string""#, "Parameter items schema type"

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -25,6 +25,7 @@ lazy_static = { version = "1.4", optional = true }
 [dev-dependencies]
 utoipa = { path = ".." }
 serde_json = "1"
+serde = "1"
 actix-web = { version = "4" }
 
 [features]

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -410,7 +410,7 @@ impl ToTokens for ComplexEnum<'_> {
     }
 }
 
-fn get_deprecated(attributes: &[Attribute]) -> Option<Deprecated> {
+pub(crate) fn get_deprecated(attributes: &[Attribute]) -> Option<Deprecated> {
     attributes.iter().find_map(|attribute| {
         if *attribute.path.get_ident().unwrap() == "deprecated" {
             Some(Deprecated::True)
@@ -423,15 +423,15 @@ fn get_deprecated(attributes: &[Attribute]) -> Option<Deprecated> {
 #[derive(PartialEq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 /// Linked list of implementing types of a field in a struct.
-struct ComponentPart<'a> {
-    ident: &'a Ident,
-    value_type: ValueType,
-    generic_type: Option<GenericType>,
-    child: Option<Rc<ComponentPart<'a>>>,
+pub struct ComponentPart<'a> {
+    pub ident: &'a Ident,
+    pub value_type: ValueType,
+    pub generic_type: Option<GenericType>,
+    pub child: Option<Rc<ComponentPart<'a>>>,
 }
 
 impl<'a> ComponentPart<'a> {
-    fn from_type(ty: &'a Type) -> ComponentPart<'a> {
+    pub fn from_type(ty: &'a Type) -> ComponentPart<'a> {
         ComponentPart::from_type_path(
             match ty {
                 Type::Path(path) => path,
@@ -544,14 +544,14 @@ impl<'a> ComponentPart<'a> {
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Clone, Copy, PartialEq)]
-enum ValueType {
+pub enum ValueType {
     Primitive,
     Object,
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(PartialEq, Clone, Copy)]
-enum GenericType {
+pub enum GenericType {
     Vec,
     Map,
     Option,

--- a/utoipa-gen/src/into_params.rs
+++ b/utoipa-gen/src/into_params.rs
@@ -1,0 +1,150 @@
+use proc_macro_error::abort;
+use quote::{quote, ToTokens};
+use syn::{Data, Field, Generics, Ident};
+
+use crate::{
+    component::{self, ComponentPart, GenericType, ValueType},
+    component_type::{ComponentFormat, ComponentType},
+    doc_comment::CommentAttributes,
+    Array, Required,
+};
+
+pub struct IntoParams {
+    pub generics: Generics,
+    pub data: Data,
+    pub ident: Ident,
+}
+
+impl ToTokens for IntoParams {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let ident = &self.ident;
+        let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
+
+        let params = self
+            .get_struct_fields()
+            .map(Param)
+            .collect::<Array<Param>>();
+
+        tokens.extend(quote! {
+            impl #impl_generics utoipa::IntoParams for #ident #ty_generics #where_clause {
+
+                fn into_params() -> Vec<utoipa::openapi::path::Parameter> {
+                    #params.to_vec()
+                }
+
+            }
+        });
+    }
+}
+
+impl IntoParams {
+    fn get_struct_fields(&self) -> impl Iterator<Item = &Field> {
+        let ident = &self.ident;
+        let abort = |help: &str| {
+            abort! {
+                ident.span(),
+                "unsupported data type, expected struct with named fields `struct {} {{...}}`",
+                ident.to_string();
+                help = help
+            }
+        };
+
+        match &self.data {
+            Data::Struct(data_struct) => match &data_struct.fields {
+                syn::Fields::Named(named_fields) => named_fields.named.iter(),
+                _ => abort("Only struct with named fields is supported"),
+            },
+            _ => abort("Only struct type is supported"),
+        }
+    }
+}
+
+struct Param<'a>(&'a Field);
+
+impl ToTokens for Param<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let field = self.0;
+        let ident = &field.ident;
+        let name = ident
+            .as_ref()
+            .map(|ident| ident.to_string())
+            .unwrap_or_else(String::new);
+        let component_part = ComponentPart::from_type(&field.ty);
+        let required: Required =
+            (!matches!(&component_part.generic_type, Some(GenericType::Option))).into();
+
+        tokens.extend(quote! { utoipa::openapi::path::ParameterBuilder::new()
+            .name(#name)
+            .required(#required)
+            .parameter_in(<Self as utoipa::ParameterIn>::parameter_in().unwrap_or_default())
+        });
+
+        if let Some(deprecated) = component::get_deprecated(&field.attrs) {
+            tokens.extend(quote! { .deprecated(Some(#deprecated)) });
+        }
+
+        if let Some(comment) = CommentAttributes::from_attributes(&field.attrs).0.first() {
+            tokens.extend(quote! {
+                .description(Some(#comment))
+            })
+        }
+
+        let param_type = ParamType {
+            ty: &component_part,
+        };
+
+        tokens.extend(quote! { .schema(Some(#param_type)).build() });
+    }
+}
+
+struct ParamType<'a> {
+    ty: &'a ComponentPart<'a>,
+}
+
+impl ToTokens for ParamType<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        match &self.ty.generic_type {
+            Some(GenericType::Vec) => {
+                let param_type = ParamType {
+                    ty: self.ty.child.as_ref().unwrap(),
+                };
+
+                tokens.extend(quote! { #param_type.to_array_builder() });
+            }
+            None => match self.ty.value_type {
+                ValueType::Primitive => {
+                    let component_type = ComponentType(self.ty.ident);
+
+                    tokens.extend(quote! {
+                        utoipa::openapi::PropertyBuilder::new().component_type(#component_type)
+                    });
+
+                    let format = ComponentFormat(self.ty.ident);
+                    if format.is_known_format() {
+                        tokens.extend(quote! {
+                            .format(Some(#format))
+                        })
+                    }
+                }
+                ValueType::Object => abort!(
+                    self.ty.ident.span(),
+                    "unsupported type, only primitive and String types are supported"
+                ),
+            },
+            Some(GenericType::Option)
+            | Some(GenericType::Cow)
+            | Some(GenericType::Box)
+            | Some(GenericType::RefCell) => {
+                let param_type = ParamType {
+                    ty: self.ty.child.as_ref().unwrap(),
+                };
+
+                tokens.extend(param_type.into_token_stream())
+            }
+            Some(GenericType::Map) => abort!(
+                self.ty.ident,
+                "maps are not supported parameter receiver types"
+            ),
+        };
+    }
+}

--- a/utoipa-gen/src/into_params.rs
+++ b/utoipa-gen/src/into_params.rs
@@ -40,12 +40,12 @@ impl ToTokens for IntoParams {
 impl IntoParams {
     fn get_struct_fields(&self) -> impl Iterator<Item = &Field> {
         let ident = &self.ident;
-        let abort = |help: &str| {
+        let abort = |note: &str| {
             abort! {
-                ident.span(),
+                ident,
                 "unsupported data type, expected struct with named fields `struct {} {{...}}`",
                 ident.to_string();
-                help = help
+                note = note
             }
         };
 
@@ -75,8 +75,8 @@ impl ToTokens for Param<'_> {
 
         tokens.extend(quote! { utoipa::openapi::path::ParameterBuilder::new()
             .name(#name)
-            .required(#required)
             .parameter_in(<Self as utoipa::ParameterIn>::parameter_in().unwrap_or_default())
+            .required(#required)
         });
 
         if let Some(deprecated) = component::get_deprecated(&field.attrs) {
@@ -127,7 +127,7 @@ impl ToTokens for ParamType<'_> {
                     }
                 }
                 ValueType::Object => abort!(
-                    self.ty.ident.span(),
+                    self.ty.ident,
                     "unsupported type, only primitive and String types are supported"
                 ),
             },

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -13,6 +13,8 @@ use component::Component;
 use doc_comment::CommentAttributes;
 
 use ext::{PathOperationResolver, PathOperations, PathResolver};
+#[cfg(feature = "actix_extras")]
+use into_params::IntoParams;
 use openapi::OpenApi;
 use proc_macro::TokenStream;
 use proc_macro_error::{proc_macro_error, OptionExt, ResultExt};
@@ -31,6 +33,8 @@ mod component;
 mod component_type;
 mod doc_comment;
 mod ext;
+#[cfg(feature = "actix_extras")]
+mod into_params;
 mod openapi;
 mod path;
 mod security_requirement;
@@ -701,6 +705,27 @@ pub fn openapi(input: TokenStream) -> TokenStream {
     let openapi = OpenApi(openapi_attributes, ident);
 
     openapi.to_token_stream().into()
+}
+
+#[cfg(feature = "actix_extras")]
+#[proc_macro_error]
+#[proc_macro_derive(IntoParams)]
+/// IntoParams derive macro
+pub fn into_params(input: TokenStream) -> TokenStream {
+    let DeriveInput {
+        ident,
+        generics,
+        data,
+        ..
+    } = syn::parse_macro_input!(input);
+
+    let into_params = IntoParams {
+        generics,
+        data,
+        ident,
+    };
+
+    into_params.to_token_stream().into()
 }
 
 /// Tokenizes slice or Vec of tokenizable items as array either with reference (`&[...]`)


### PR DESCRIPTION
* Add IntoParams trait derive implementation with tests. Previously only path parameters
  with tuple or primitive types where supported. This enhances actix-web parameter
  resolving to support structs to resolve path and query parameters making params
  declaration within utoipa::path obsolete.