### PR TITLE
Update todo-actix example and docs

### DIFF
--- a/examples/todo-actix/src/main.rs
+++ b/examples/todo-actix/src/main.rs
@@ -1,6 +1,16 @@
-use std::{error::Error, net::Ipv4Addr};
+use std::{
+    error::Error,
+    future::{self, Ready},
+    net::Ipv4Addr,
+};
 
-use actix_web::{middleware::Logger, web::Data, App, HttpServer};
+use actix_web::{
+    dev::{Service, ServiceRequest, ServiceResponse, Transform},
+    middleware::Logger,
+    web::Data,
+    App, HttpResponse, HttpServer,
+};
+use futures::future::LocalBoxFuture;
 use utoipa::{
     openapi::security::{ApiKey, ApiKeyValue, SecurityScheme},
     Modify, OpenApi,
@@ -10,6 +20,9 @@ use utoipa_swagger_ui::SwaggerUi;
 use crate::todo::{ErrorResponse, Todo, TodoStore, TodoUpdateRequest};
 
 mod todo;
+
+const API_KEY_NAME: &str = "todo_apikey";
+const API_KEY: &str = "utoipa-rocks";
 
 #[actix_web::main]
 async fn main() -> Result<(), impl Error> {
@@ -46,17 +59,142 @@ async fn main() -> Result<(), impl Error> {
     }
 
     let store = Data::new(TodoStore::default());
+    // Make instance variable of ApiDoc so all worker threads gets the same instance.
+    let openapi = ApiDoc::openapi();
 
     HttpServer::new(move || {
+        // This factory closure is called on each worker thread independently.
         App::new()
             .wrap(Logger::default())
             .configure(todo::configure(store.clone()))
             .service(
-                SwaggerUi::new("/swagger-ui/{_:.*}")
-                    .url("/api-doc/openapi.json", ApiDoc::openapi()),
+                SwaggerUi::new("/swagger-ui/{_:.*}").url("/api-doc/openapi.json", openapi.clone()),
             )
     })
     .bind((Ipv4Addr::UNSPECIFIED, 8080))?
     .run()
     .await
+}
+
+/// Require api key middlware will actually require valid api key
+struct RequireApiKey;
+
+impl<S> Transform<S, ServiceRequest> for RequireApiKey
+where
+    S: Service<
+        ServiceRequest,
+        Response = ServiceResponse<actix_web::body::BoxBody>,
+        Error = actix_web::Error,
+    >,
+    S::Future: 'static,
+{
+    type Response = ServiceResponse<actix_web::body::BoxBody>;
+    type Error = actix_web::Error;
+    type Transform = ApiKeyMiddleware<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        future::ready(Ok(ApiKeyMiddleware {
+            service,
+            log_only: false,
+        }))
+    }
+}
+
+/// Log api key midleware only logs about missing or invalid api keys
+struct LogApiKey;
+
+impl<S> Transform<S, ServiceRequest> for LogApiKey
+where
+    S: Service<
+        ServiceRequest,
+        Response = ServiceResponse<actix_web::body::BoxBody>,
+        Error = actix_web::Error,
+    >,
+    S::Future: 'static,
+{
+    type Response = ServiceResponse<actix_web::body::BoxBody>;
+    type Error = actix_web::Error;
+    type Transform = ApiKeyMiddleware<S>;
+    type InitError = ();
+    type Future = Ready<Result<Self::Transform, Self::InitError>>;
+
+    fn new_transform(&self, service: S) -> Self::Future {
+        future::ready(Ok(ApiKeyMiddleware {
+            service,
+            log_only: true,
+        }))
+    }
+}
+
+struct ApiKeyMiddleware<S> {
+    service: S,
+    log_only: bool,
+}
+
+impl<S> Service<ServiceRequest> for ApiKeyMiddleware<S>
+where
+    S: Service<
+        ServiceRequest,
+        Response = ServiceResponse<actix_web::body::BoxBody>,
+        Error = actix_web::Error,
+    >,
+    S::Future: 'static,
+{
+    type Response = ServiceResponse<actix_web::body::BoxBody>;
+    type Error = actix_web::Error;
+    type Future = LocalBoxFuture<'static, Result<Self::Response, actix_web::Error>>;
+
+    fn poll_ready(
+        &self,
+        ctx: &mut core::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.service.poll_ready(ctx)
+    }
+
+    fn call(&self, req: ServiceRequest) -> Self::Future {
+        let response = |req: ServiceRequest, response: HttpResponse| -> Self::Future {
+            Box::pin(async { Ok(req.into_response(response)) })
+        };
+
+        match req.headers().get(API_KEY_NAME) {
+            Some(key) if key != API_KEY => {
+                if self.log_only {
+                    log::debug!("Incorrect api api provided!!!")
+                } else {
+                    return response(
+                        req,
+                        HttpResponse::Unauthorized().json(ErrorResponse::Unauthorized(
+                            String::from("incorrect api key"),
+                        )),
+                    );
+                }
+            }
+            None => {
+                if self.log_only {
+                    log::debug!("Missing api key!!!")
+                } else {
+                    return response(
+                        req,
+                        HttpResponse::Unauthorized()
+                            .json(ErrorResponse::Unauthorized(String::from("missing api key"))),
+                    );
+                }
+            }
+            _ => (), // just passthrough
+        }
+
+        if self.log_only {
+            log::debug!("Performing operation")
+        }
+
+        let future = self.service.call(req);
+
+        Box::pin(async move {
+            let response = future.await?;
+
+            Ok(response)
+        })
+    }
 }

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -4,7 +4,7 @@ use lazy_static::lazy_static;
 use proc_macro::TokenTree;
 use proc_macro2::{Ident, Literal, Punct};
 use proc_macro_error::{abort, abort_call_site};
-use quote::{format_ident, quote};
+use quote::{format_ident, quote, quote_spanned};
 use regex::{Captures, Regex};
 use syn::{
     parse::Parse, punctuated::Punctuated, token::Comma, Attribute, DeriveInput, FnArg,
@@ -61,7 +61,7 @@ impl PathOperations {
             };
 
             let assert_ty = format_ident!("_Assert{}", &ty);
-            Argument::TokenStream(quote! {
+            Argument::TokenStream(quote_spanned! {ty.span()=>
                 {
                     struct #assert_ty where #ty : utoipa::IntoParams;
 

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -278,10 +278,6 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// * `params(...)` Slice of params that the endpoint accepts.
 /// * `security(...)` List of [`SecurityRequirement`][security]s local to the path operation.
 ///
-/// > **Note!** when **actix_extras** feature is enabled the **operation**, **path** and **params** declaration
-/// > may be omitted since they are resolved from **actix-web** attributes namely **path** and function arguments.
-/// > To define description or other parameter info then **params** still need to be defined manually. See the example
-/// > in [examples section](#examples).
 ///
 /// # Request Body Attributes
 ///
@@ -392,11 +388,12 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///
 /// # actix_extras support for actix-web
 ///
-/// **actix_extas** feature gives **utoipa** ability to use **actix-web** path operation macros such as `#[get(...)]` to
-/// resolve path for `#[utoipa::path]`. Also it is able to parse the the `path` parameters with types from function arguments
-/// of operation which are defined within type `web::Path<...>`. Allowing you leave out types of parameters in `params(...)`
-/// section of even leave out the section if description is not needed for parameters. Utoipa is only able to resolve
-/// [primitive types][primitive] and [`String`] type. Using other types is undefined behaviour.
+/// **actix_extras** featue gives **utoipa** ability to parse path operation information from **actix-web** types and macros.
+///
+/// 1. Ability to parse `path` from **actix-web** path attribute macros e.g. _`#[get(...)]`_.
+/// 2. Ability to parse [`std::primitive`]  or [`String`] or [`tuple`] typed `path` parameters from **actix-web** _`web::Path<...>`_.
+/// 3. Ability to parse `path` and `query` parameters form **actix-web** _`web::Path<...>`_, _`web::Query<...>`_ types
+///    with [`IntoParams`][into_params] trait.
 ///
 /// See the **actix_extras** in action in examples [todo-actix](https://github.com/juhaku/utoipa/tree/master/examples/todo-actix).
 ///
@@ -440,7 +437,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///
 /// # rocket_extras support for rocket
 ///
-/// **rocket_extras** feature give **utoipa** ability to use **rocket** path operation macros such as `#[get(...)]` to
+/// **rocket_extras** feature gives **utoipa** ability to use **rocket** path operation macros such as _`#[get(...)]`_ to
 /// resolve path for `#[utoipa::path]`.  Also it is able to parse the `path` and `query` parameters from path operation macro
 /// combined with function arguments of the operation. Allowing you leave out types from parameters in `params(...)` section
 /// or even leave out the section if description is not needed for parameters. Utoipa is only able to parse parameter types
@@ -558,6 +555,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// [security]: openapi/security/struct.SecurityRequirement.html
 /// [security_schema]: openapi/security/struct.SecuritySchema.html
 /// [primitive]: https://doc.rust-lang.org/std/primitive/index.html
+/// [into_params]: trait.IntoParams.html
 ///
 /// [^json]: **json** feature need to be enabled for `json!(...)` type to work.
 ///


### PR DESCRIPTION
* Update todo-actix example to use new IntoParams trait in search todos.
* Update docs recarding utoipa::path attribute macro
* Make IntoParmas to quote_spanned! to pin point the error if IntoParams is not implemented for type.