### PR TITLE
Add partial serde attribute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also awesome type of beer :be
 * **decimal** Add support for [rust_decimal](https://crates.io/crates/rust_decimal) `Decimal` type. **By default** 
   it is interpreted as `String`. If you wish to change the format you need to override the type. 
   See the `value_type` in [component derive docs](https://docs.rs/utoipa/0.2.0/utoipa/derive.Component.html).
-* **uuid** Add support for [UUID](https://github.com/uuid-rs/uuid). `Uuid` type will be presented as `String` with
+* **uuid** Add support for [uuid](https://github.com/uuid-rs/uuid). `Uuid` type will be presented as `String` with
   format `uuid` in OpenAPI spec.
+
+Utoipa implicitly has partial support for `serde` attributes. See [docs](https://docs.rs/utoipa/0.2.0/utoipa/derive.Component.html#partial-serde-attributes-support) for more details.
 
 ## Install
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,10 @@
 //! * **decimal** Add support for [rust_decimal](https://crates.io/crates/rust_decimal) `Decimal` type. **By default**
 //!   it is interpreted as `String`. If you wish to change the format you need to override the type.
 //!   See the `value_type` in [component derive docs][component_derive].
-//! * **uuid** Add support for [UUID](https://github.com/uuid-rs/uuid). `Uuid` type will be presented as `String` with
+//! * **uuid** Add support for [uuid](https://github.com/uuid-rs/uuid). `Uuid` type will be presented as `String` with
 //!   format `uuid` in OpenAPI spec.
+//!
+//! Utoipa implicitly has partial support for `serde` attributes. See [component derive][serde] for more details.
 //!
 //! # Install
 //!
@@ -192,6 +194,7 @@
 //! [path]: attr.path.html
 //! [rocket_path]: attr.path.html#rocket_extras-support-for-rocket
 //! [actix_path]: attr.path.html#actix_extras-support-for-actix-web
+//! [serde]: derive.Component.html#partial-serde-attributes-support
 //!
 //! [security]: openapi/security/index.html
 //! [component_derive]: derive.Component.html

--- a/utoipa-gen/src/doc_comment.rs
+++ b/utoipa-gen/src/doc_comment.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use proc_macro2::{Ident, Span};
 use proc_macro_error::{abort_call_site, emit_warning, ResultExt};
 use syn::{Attribute, Lit, Meta};
@@ -52,5 +54,13 @@ impl CommentAttributes {
             }
             _ => abort_call_site!("Exected only Meta::NameValue type"),
         }
+    }
+}
+
+impl Deref for CommentAttributes {
+    type Target = Vec<String>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -119,8 +119,9 @@ use ext::ArgumentResolver;
 ///
 /// ```rust
 /// # use serde::Serialize;
+/// # use utoipa::Component;
 /// #[derive(Serialize, Component)]
-/// struct Foo;
+/// struct Foo(String);
 ///
 /// #[derive(Serialize, Component)]
 /// #[serde(rename_all = "camelCase")]

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -7,7 +7,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 
-use std::{borrow::Cow, mem};
+use std::{borrow::Cow, mem, ops::Deref};
 
 use doc_comment::CommentAttributes;
 use schema::component::Component;
@@ -104,6 +104,39 @@ use ext::ArgumentResolver;
 /// * `xml(wrapped(name = "wrap_name"))` Will override the wrapper elements name.
 ///
 /// See [`Xml`][xml] for more details.
+///
+/// # Partial `#[serde(...)]` attributes support
+///
+/// Component derive has partial support for [serde attributes](https://serde.rs/attributes.html). These supported attributes will reflect to the
+/// generated OpenAPI doc. For example if _`#[serde(skip)]`_ is defined the attribute will not show up in the OpenAPI spec at all since it will not never
+/// be serialized anyway. Similarly the _`rename`_ and _`rename_all`_ will reflect to the generated OpenAPI doc.
+///
+/// * `rename_all = "..."` Supported in container level.
+/// * `rename = "..."` Supported **only** in field or variant level.
+/// * `skip = "..."` Supported  **only** in field or variant level.
+///
+/// Other _`serde`_ attributes works as is but does not have any effect on the generated OpenAPI doc.
+///
+/// ```rust
+/// # use serde::Serialize;
+/// #[derive(Serialize, Component)]
+/// struct Foo;
+///
+/// #[derive(Serialize, Component)]
+/// #[serde(rename_all = "camelCase")]
+/// enum Bar {
+///     UnitValue,
+///     #[serde(rename_all = "camelCase")]
+///     NamedFields {
+///         #[serde(rename = "id")]
+///         named_id: &'static str,
+///         name_list: Option<Vec<String>>
+///     },
+///     UnnamedFields(Foo),
+///     #[serde(skip)]
+///     SkipMe,
+/// }
+/// ```
 ///
 /// # Examples
 ///
@@ -822,6 +855,19 @@ where
 {
     fn from_iter<T: IntoIterator<Item = V>>(iter: T) -> Self {
         Self::Owned(iter.into_iter().collect())
+    }
+}
+
+impl<T> Deref for Array<T>
+where
+    T: Sized + ToTokens,
+{
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Owned(vec) => vec,
+        }
     }
 }
 

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -165,3 +165,301 @@ enum GenericType {
     Box,
     RefCell,
 }
+
+pub mod serde {
+    //! Provides serde related features parsing serde attributes from types.
+
+    use std::str::FromStr;
+
+    use proc_macro2::{Span, TokenTree};
+    use proc_macro_error::ResultExt;
+    use syn::{buffer::Cursor, Attribute, Error};
+
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub enum Serde {
+        Container(SerdeContainer),
+        Value(SerdeValue),
+    }
+
+    impl Serde {
+        #[inline]
+        fn parse_next_lit_str(next: Cursor) -> Option<(String, Span)> {
+            match next.token_tree() {
+                Some((tt, next)) => match tt {
+                    TokenTree::Punct(punct) if punct.as_char() == '=' => {
+                        Serde::parse_next_lit_str(next)
+                    }
+                    TokenTree::Literal(literal) => {
+                        Some((literal.to_string().replace('\"', ""), literal.span()))
+                    }
+                    _ => None,
+                },
+                _ => None,
+            }
+        }
+
+        fn parse_container(input: syn::parse::ParseStream) -> syn::Result<Self> {
+            let mut container = SerdeContainer::default();
+
+            input.step(|cursor| {
+                let mut rest = *cursor;
+                while let Some((tt, next)) = rest.token_tree() {
+                    match tt {
+                        TokenTree::Ident(ident) if ident == "rename_all" => {
+                            if let Some((literal, span)) = Serde::parse_next_lit_str(next) {
+                                container.rename_all = Some(
+                                    literal
+                                        .parse::<RenameRule>()
+                                        .map_err(|error| Error::new(span, error.to_string()))?,
+                                );
+                            };
+                        }
+                        _ => (),
+                    }
+
+                    rest = next;
+                }
+                Ok(((), rest))
+            })?;
+
+            Ok(Serde::Container(container))
+        }
+
+        fn parse_value(input: syn::parse::ParseStream) -> syn::Result<Self> {
+            let mut value = SerdeValue::default();
+
+            input.step(|cursor| {
+                let mut rest = *cursor;
+                while let Some((tt, next)) = rest.token_tree() {
+                    match tt {
+                        TokenTree::Ident(ident) if ident == "skip" => value.skip = Some(true),
+                        TokenTree::Ident(ident) if ident == "rename" => {
+                            if let Some((literal, _)) = Serde::parse_next_lit_str(next) {
+                                value.rename = Some(literal)
+                            };
+                        }
+                        _ => (),
+                    }
+
+                    rest = next;
+                }
+                Ok(((), rest))
+            })?;
+
+            Ok(Serde::Value(value))
+        }
+    }
+
+    #[derive(Default)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct SerdeValue {
+        pub skip: Option<bool>,
+        pub rename: Option<String>,
+    }
+
+    #[derive(Default)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct SerdeContainer {
+        pub rename_all: Option<RenameRule>,
+    }
+
+    pub fn parse_value(attributes: &[Attribute]) -> Option<Serde> {
+        attributes
+            .iter()
+            .find(|attribute| attribute.path.is_ident("serde"))
+            .map(|serde_attribute| {
+                serde_attribute
+                    .parse_args_with(Serde::parse_value)
+                    .unwrap_or_abort()
+            })
+    }
+
+    pub fn parse_container(attributes: &[Attribute]) -> Option<Serde> {
+        attributes
+            .iter()
+            .find(|attribute| attribute.path.is_ident("serde"))
+            .map(|serde_attribute| {
+                serde_attribute
+                    .parse_args_with(Serde::parse_container)
+                    .unwrap_or_abort()
+            })
+    }
+
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub enum RenameRule {
+        Lower,
+        Upper,
+        Camel,
+        Snake,
+        ScreamingSnake,
+        Pascal,
+        Kebab,
+        ScreamingKebab,
+    }
+
+    impl RenameRule {
+        pub fn rename(&self, value: &str) -> String {
+            match self {
+                RenameRule::Lower => value.to_ascii_lowercase(),
+                RenameRule::Upper => value.to_ascii_uppercase(),
+                RenameRule::Camel => {
+                    let mut camel_case = String::new();
+
+                    let mut upper = false;
+                    for letter in value.chars() {
+                        if letter == '_' {
+                            upper = true;
+                            continue;
+                        }
+
+                        if upper {
+                            camel_case.push(letter.to_ascii_uppercase());
+                            upper = false;
+                        } else {
+                            camel_case.push(letter)
+                        }
+                    }
+
+                    camel_case
+                }
+                RenameRule::Snake => value.to_string(),
+                RenameRule::ScreamingSnake => Self::Snake.rename(value).to_ascii_uppercase(),
+                RenameRule::Pascal => {
+                    let mut pascal_case = String::from(&value[..1].to_ascii_uppercase());
+                    pascal_case.push_str(&Self::Camel.rename(&value[1..]));
+
+                    pascal_case
+                }
+                RenameRule::Kebab => Self::Snake.rename(value).replace('_', "-"),
+                RenameRule::ScreamingKebab => Self::Kebab.rename(value).to_ascii_uppercase(),
+            }
+        }
+
+        pub fn rename_variant(&self, variant: &str) -> String {
+            match self {
+                RenameRule::Lower => variant.to_ascii_lowercase(),
+                RenameRule::Upper => variant.to_ascii_uppercase(),
+                RenameRule::Camel => {
+                    let mut snake_case = String::from(&variant[..1].to_ascii_lowercase());
+                    snake_case.push_str(&variant[1..]);
+
+                    snake_case
+                }
+                RenameRule::Snake => {
+                    let mut snake_case = String::new();
+
+                    for (index, letter) in variant.char_indices() {
+                        if index > 0 && letter.is_uppercase() {
+                            snake_case.push('_');
+                        }
+                        snake_case.push(letter);
+                    }
+
+                    snake_case.to_ascii_lowercase()
+                }
+                RenameRule::ScreamingSnake => {
+                    Self::Snake.rename_variant(variant).to_ascii_uppercase()
+                }
+                RenameRule::Pascal => variant.to_string(),
+                RenameRule::Kebab => Self::Snake.rename_variant(variant).replace('_', "-"),
+                RenameRule::ScreamingKebab => {
+                    Self::Kebab.rename_variant(variant).to_ascii_uppercase()
+                }
+            }
+        }
+    }
+
+    impl FromStr for RenameRule {
+        type Err = Error;
+
+        fn from_str(s: &str) -> Result<Self, Self::Err> {
+            [
+                ("lowecase", RenameRule::Lower),
+                ("UPPERCASE", RenameRule::Upper),
+                ("Pascal", RenameRule::Pascal),
+                ("camelCase", RenameRule::Camel),
+                ("snake_case", RenameRule::Snake),
+                ("SCREAMING_SNAKE_CASE", RenameRule::ScreamingSnake),
+                ("kebab-case", RenameRule::Kebab),
+                ("SCREAMING-KEBAB-CASE", RenameRule::ScreamingKebab),
+            ]
+            .into_iter()
+            .find_map(|(case, rule)| if case == s { Some(rule) } else { None })
+            .ok_or_else(|| {
+                Error::new(
+                    Span::call_site(),
+                    r#"unexpected rename rule, expected one of: "lowercase", "UPPERCASE", "Pascal", "camelCase", "snake_case", "SCREAMING_SNAKE_CASE", "kebab-case", "SCREAMING-KEBAB-CASE""#,
+                )
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::serde::RenameRule;
+
+    macro_rules! test_rename_rule {
+        ( $($case:expr=> $value:literal = $expected:literal)* ) => {
+            #[test]
+            fn rename_all_rename_rules() {
+                $(
+                    let value = $case.rename($value);
+                    assert_eq!(value, $expected, "expected case: {} => {} != {}", stringify!($case), $value, $expected);
+                )*
+            }
+        };
+    }
+
+    macro_rules! test_rename_variant_rule {
+        ( $($case:expr=> $value:literal = $expected:literal)* ) => {
+            #[test]
+            fn rename_all_rename_variant_rules() {
+                $(
+                    let value = $case.rename_variant($value);
+                    assert_eq!(value, $expected, "expected case: {} => {} != {}", stringify!($case), $value, $expected);
+                )*
+            }
+        };
+    }
+
+    test_rename_rule! {
+        RenameRule::Lower=> "single" = "single"
+        RenameRule::Upper=> "single" = "SINGLE"
+        RenameRule::Pascal=> "single" = "Single"
+        RenameRule::Camel=> "single" = "single"
+        RenameRule::Snake=> "single" = "single"
+        RenameRule::ScreamingSnake=> "single" = "SINGLE"
+        RenameRule::Kebab=> "single" = "single"
+        RenameRule::ScreamingKebab=> "single" = "SINGLE"
+
+        RenameRule::Lower=> "multi_value" = "multi_value"
+        RenameRule::Upper=> "multi_value" = "MULTI_VALUE"
+        RenameRule::Pascal=> "multi_value" = "MultiValue"
+        RenameRule::Camel=> "multi_value" = "multiValue"
+        RenameRule::Snake=> "multi_value" = "multi_value"
+        RenameRule::ScreamingSnake=> "multi_value" = "MULTI_VALUE"
+        RenameRule::Kebab=> "multi_value" = "multi-value"
+        RenameRule::ScreamingKebab=> "multi_value" = "MULTI-VALUE"
+    }
+
+    test_rename_variant_rule! {
+        RenameRule::Lower=> "Single" = "single"
+        RenameRule::Upper=> "Single" = "SINGLE"
+        RenameRule::Pascal=> "Single" = "Single"
+        RenameRule::Camel=> "Single" = "single"
+        RenameRule::Snake=> "Single" = "single"
+        RenameRule::ScreamingSnake=> "Single" = "SINGLE"
+        RenameRule::Kebab=> "Single" = "single"
+        RenameRule::ScreamingKebab=> "Single" = "SINGLE"
+
+        RenameRule::Lower=> "MultiValue" = "multivalue"
+        RenameRule::Upper=> "MultiValue" = "MULTIVALUE"
+        RenameRule::Pascal=> "MultiValue" = "MultiValue"
+        RenameRule::Camel=> "MultiValue" = "multiValue"
+        RenameRule::Snake=> "MultiValue" = "multi_value"
+        RenameRule::ScreamingSnake=> "MultiValue" = "MULTI_VALUE"
+        RenameRule::Kebab=> "MultiValue" = "multi-value"
+        RenameRule::ScreamingKebab=> "MultiValue" = "MULTI-VALUE"
+    }
+}

--- a/utoipa-gen/src/schema/into_params.rs
+++ b/utoipa-gen/src/schema/into_params.rs
@@ -85,7 +85,7 @@ impl ToTokens for Param<'_> {
             tokens.extend(quote! { .deprecated(Some(#deprecated)) });
         }
 
-        if let Some(comment) = CommentAttributes::from_attributes(&field.attrs).0.first() {
+        if let Some(comment) = CommentAttributes::from_attributes(&field.attrs).first() {
             tokens.extend(quote! {
                 .description(Some(#comment))
             })


### PR DESCRIPTION
* Add partial serde attribute support for Components. This allows use of serde's skip and rename on fields and variants and rename_all on container level.