### PR TITLE
Fix macro_rules generated components

### DIFF
--- a/tests/utoipa_gen_test.rs
+++ b/tests/utoipa_gen_test.rs
@@ -49,7 +49,7 @@ mod pet_api {
 
     /// Get pet by id
     ///
-    /// Get pet from database by pet database id  
+    /// Get pet from database by pet database id
     #[utoipa::path(
         get,
         path = "/pets/{id}",
@@ -78,9 +78,9 @@ mod pet_api {
 
 #[derive(Default, OpenApi)]
 #[openapi(
-    handlers(pet_api::get_pet_by_id), 
-    components(Pet), 
-    modifiers(&Foo), 
+    handlers(pet_api::get_pet_by_id),
+    components(Pet),
+    modifiers(&Foo),
     security(
         (),
         ("my_auth" = ["read:items", "edit:items"]),
@@ -88,6 +88,16 @@ mod pet_api {
     )
 )]
 struct ApiDoc;
+
+macro_rules! build_foo {
+    ($typ: ident, $d: ty, $r: ty) => {
+        #[derive(Debug, Serialize, Component)]
+        struct $typ {
+            data: $d,
+            resources: $r,
+        }
+    };
+}
 
 #[test]
 #[ignore = "this is just a test bed to run macros"]
@@ -97,6 +107,8 @@ fn derive_openapi() {
         utoipa::openapi::Paths::new(),
     );
     println!("{}", ApiDoc::openapi().to_pretty_json().unwrap());
+
+    build_foo!(GetFooBody, Foo, FooResources);
 }
 
 impl Modify for Foo {
@@ -126,4 +138,8 @@ impl Modify for Foo {
     }
 }
 
+#[derive(Debug, Serialize)]
 struct Foo;
+
+#[derive(Debug, Serialize)]
+struct FooResources;

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -108,7 +108,7 @@ impl PathOperations {
     fn get_type_path(ty: &Type) -> &TypePath {
         match ty {
             Type::Path(path) => path,
-            _ => abort_call_site!("unexpected type, expected Type::Path"), // should not get here by any means with current types
+            _ => abort_call_site!("unexpected type in actix path operations, expected Type::Path"), // should not get here by any means with current types
         }
     }
 


### PR DESCRIPTION
macro_rules generates bit different TokenStream which need to be taken account in Component derive implementation. This allows using macro_rules to generate components.