### PR TITLE
Implement serde `tag` property for simple enums

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ serde_yaml = { version = "0.8", optional = true }
 utoipa-gen = { version = "1.0.2", path = "./utoipa-gen" }
 
 [dev-dependencies]
+assert-json-diff = "2"
 actix-web = { version = "4" }
 paste = "1"
 chrono = { version  = "0.4", features = ["serde"] }

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -535,69 +535,6 @@ fn derive_complex_enum_with_named_and_unnamed_fields() {
 }
 
 #[test]
-fn derive_complex_enum_without_serde_tag() {
-    #[derive(Serialize)]
-    struct Foo(String);
-
-    let value: Value = api_doc! {
-        #[derive(Serialize)]
-        #[serde(rename_all = "snake_case")]
-        enum Bar {
-            UnitValue,
-            NamedFields {
-                id: &'static str,
-                names: Option<Vec<String>>
-            },
-            UnnamedFields(Foo),
-        }
-    };
-
-    assert_json_eq!(
-        value,
-        json!({
-            "oneOf": [
-                {
-                    "enum": [
-                        "unit_value"
-                    ],
-                    "type": "string"
-                },
-                {
-                    "properties": {
-                        "named_fields": {
-                            "properties": {
-                                "id": {
-                                    "type": "string"
-                                },
-                                "names": {
-                                    "items": {
-                                        "type": "string"
-                                    },
-                                    "type": "array"
-                                }
-                            },
-                            "required": [
-                                "id"
-                            ],
-                            "type": "object"
-                        }
-                    },
-                    "type": "object"
-                },
-                {
-                    "properties": {
-                        "unnamed_fields": {
-                            "$ref": "#/components/schemas/Foo"
-                        }
-                    },
-                    "type": "object"
-                }
-            ]
-        })
-    );
-}
-
-#[test]
 fn derive_simple_enum_without_serde_tag() {
     let value: Value = api_doc! {
         #[derive(Serialize)]
@@ -685,7 +622,69 @@ fn derive_simple_enum_with_serde_tag() {
 }
 
 #[test]
-#[ignore = "todo"]
+fn derive_complex_enum_without_serde_tag() {
+    #[derive(Serialize)]
+    struct Foo(String);
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(rename_all = "snake_case")]
+        enum Bar {
+            UnitValue,
+            NamedFields {
+                id: &'static str,
+                names: Option<Vec<String>>
+            },
+            UnnamedFields(Foo),
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "string",
+                    "enum": [
+                        "unit_value",
+                    ],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "named_fields": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                },
+                                "names": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                    },
+                                },
+                            },
+                            "required": [
+                                "id",
+                            ],
+                        },
+                    },
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "unnamed_fields": {
+                            "$ref": "#/components/schemas/Foo",
+                        },
+                    },
+                },
+            ],
+        })
+    );
+}
+
+#[test]
 fn derive_complex_enum_with_serde_tag() {
     #[derive(Serialize)]
     struct Foo(String);
@@ -711,11 +710,11 @@ fn derive_complex_enum_with_serde_tag() {
                     "type": "object",
                     "properties": {
                         "tag": {
+                            "type": "string",
                             "enum": [
-                              "unit_value"
+                                "unit_value",
                             ],
-                            "type": "string"
-                        }
+                        },
                     },
                     "required": [
                         "tag",
@@ -725,20 +724,20 @@ fn derive_complex_enum_with_serde_tag() {
                     "type": "object",
                     "properties": {
                         "id": {
-                            "type": "string"
+                            "type": "string",
                         },
                         "names": {
                             "type": "array",
                             "items": {
-                                "type": "string"
+                                "type": "string",
                             },
                         },
                         "tag": {
                             "type": "string",
                             "enum": [
-                                "named_fields"
-                            ]
-                        }
+                                "named_fields",
+                            ],
+                        },
                     },
                     "required": [
                         "id",
@@ -749,18 +748,18 @@ fn derive_complex_enum_with_serde_tag() {
                     "type": "object",
                     "properties": {
                         "tag": {
-                            "type": "string"
+                            "type": "string",
                         },
                         "unnamed_fields": {
-                            "$ref": "#/components/schemas/Foo"
-                        }
+                            "$ref": "#/components/schemas/Foo",
+                        },
                     },
                     "required": [
                         "id",
                         "unnamed_fields",
-                    ]
-                }
-            ]
+                    ],
+                },
+            ],
         })
     );
 }

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -508,33 +508,6 @@ fn derive_with_box_and_refcell() {
 }
 
 #[test]
-fn derive_complex_enum_with_named_and_unnamed_fields() {
-    struct Foo;
-    let complex_enum = api_doc! {
-        enum Bar {
-            UnitValue,
-            NamedFields {
-                id: &'static str,
-                names: Option<Vec<String>>
-            },
-            UnnamedFields(Foo),
-        }
-    };
-
-    common::assert_json_array_len(complex_enum.get("oneOf").unwrap(), 3);
-    assert_value! {complex_enum=>
-        "oneOf.[0].type" = r###""string""###, "Complex enum unit value type"
-        "oneOf.[0].enum" = r###"["UnitValue"]"###, "Complex enum unit value enum"
-        "oneOf.[1].type" = r###""object""###, "Complex enum named fields type"
-        "oneOf.[1].properties.NamedFields.type" = r###""object""###, "Complex enum named fields object type"
-        "oneOf.[1].properties.NamedFields.properties.id.type" = r###""string""###, "Complex enum named fields id type"
-        "oneOf.[1].properties.NamedFields.properties.names.type" = r###""array""###, "Complex enum named fields names type"
-        "oneOf.[2].type" = r###""object""###, "Complex enum unnamed fields type"
-        "oneOf.[2].properties.UnnamedFields.$ref" = r###""#/components/schemas/Foo""###, "Complex enum unnamed fields type"
-    }
-}
-
-#[test]
 fn derive_simple_enum() {
     let value: Value = api_doc! {
         #[derive(Serialize)]
@@ -621,6 +594,7 @@ fn derive_simple_enum_serde_tag() {
     );
 }
 
+/// Derive a complex enum with named and unnamed fields.
 #[test]
 fn derive_complex_enum() {
     #[derive(Serialize)]
@@ -813,6 +787,8 @@ fn derive_complex_enum_serde_rename_variant() {
     );
 }
 
+/// Derive a complex enum with the serde `tag` container attribute applied for internal tagging.
+/// Note that tuple fields are not supported.
 #[test]
 fn derive_complex_enum_serde_tag() {
     #[derive(Serialize)]

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -628,6 +628,68 @@ fn derive_complex_enum() {
 
     let value: Value = api_doc! {
         #[derive(Serialize)]
+        enum Bar {
+            UnitValue,
+            NamedFields {
+                id: &'static str,
+                names: Option<Vec<String>>
+            },
+            UnnamedFields(Foo),
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "string",
+                    "enum": [
+                        "UnitValue",
+                    ],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "NamedFields": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                },
+                                "names": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string",
+                                    },
+                                },
+                            },
+                            "required": [
+                                "id",
+                            ],
+                        },
+                    },
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "UnnamedFields": {
+                            "$ref": "#/components/schemas/Foo",
+                        },
+                    },
+                },
+            ],
+        })
+    );
+}
+
+#[test]
+fn derive_complex_enum_serde_rename_all() {
+    #[derive(Serialize)]
+    struct Foo(String);
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
         #[serde(rename_all = "snake_case")]
         enum Bar {
             UnitValue,
@@ -751,7 +813,6 @@ fn derive_complex_enum_serde_rename_variant() {
     );
 }
 
-#[ignore = "todo"]
 #[test]
 fn derive_complex_enum_serde_tag() {
     #[derive(Serialize)]
@@ -766,7 +827,6 @@ fn derive_complex_enum_serde_tag() {
                 id: &'static str,
                 names: Option<Vec<String>>
             },
-            UnnamedFields(Foo),
         }
     };
 
@@ -810,24 +870,6 @@ fn derive_complex_enum_serde_tag() {
                     "required": [
                         "id",
                         "tag",
-                    ],
-                },
-                {
-                    "type": "object",
-                    "properties": {
-                        "tag": {
-                            "type": "string",
-                            "enum": [
-                                "UnnamedFields",
-                            ],
-                        },
-                        "UnnamedFields": {
-                            "$ref": "#/components/schemas/Foo",
-                        },
-                    },
-                    "required": [
-                        "tag",
-                        "UnnamedFields",
                     ],
                 },
             ],

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -214,16 +214,14 @@ pub mod serde {
 
     use std::str::FromStr;
 
-    use proc_macro2::{Span, TokenTree, Ident};
+    use proc_macro2::{Ident, Span, TokenTree};
     use proc_macro_error::ResultExt;
     use syn::{buffer::Cursor, Attribute, Error};
 
     fn parse_next_lit_str(next: Cursor) -> Option<(String, Span)> {
         match next.token_tree() {
             Some((tt, next)) => match tt {
-                TokenTree::Punct(punct) if punct.as_char() == '=' => {
-                    parse_next_lit_str(next)
-                }
+                TokenTree::Punct(punct) if punct.as_char() == '=' => parse_next_lit_str(next),
                 TokenTree::Literal(literal) => {
                     Some((literal.to_string().replace('\"', ""), literal.span()))
                 }
@@ -274,7 +272,11 @@ pub mod serde {
     }
 
     impl SerdeContainer {
-        fn parse_ident(ident: Ident, next: Cursor, container: &mut SerdeContainer) -> syn::Result<()> {
+        fn parse_ident(
+            ident: Ident,
+            next: Cursor,
+            container: &mut SerdeContainer,
+        ) -> syn::Result<()> {
             match ident.to_string().as_str() {
                 "rename_all" => {
                     if let Some((literal, span)) = parse_next_lit_str(next) {
@@ -290,7 +292,7 @@ pub mod serde {
                         container.tag = Some(literal)
                     }
                 }
-                _ => {},
+                _ => {}
             }
             Ok(())
         }

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -214,62 +214,35 @@ pub mod serde {
 
     use std::str::FromStr;
 
-    use proc_macro2::{Span, TokenTree};
+    use proc_macro2::{Span, TokenTree, Ident};
     use proc_macro_error::ResultExt;
     use syn::{buffer::Cursor, Attribute, Error};
 
-    #[cfg_attr(feature = "debug", derive(Debug))]
-    pub enum Serde {
-        Container(SerdeContainer),
-        Value(SerdeValue),
+    fn parse_next_lit_str(next: Cursor) -> Option<(String, Span)> {
+        match next.token_tree() {
+            Some((tt, next)) => match tt {
+                TokenTree::Punct(punct) if punct.as_char() == '=' => {
+                    parse_next_lit_str(next)
+                }
+                TokenTree::Literal(literal) => {
+                    Some((literal.to_string().replace('\"', ""), literal.span()))
+                }
+                _ => None,
+            },
+            _ => None,
+        }
     }
 
-    impl Serde {
-        #[inline]
-        fn parse_next_lit_str(next: Cursor) -> Option<(String, Span)> {
-            match next.token_tree() {
-                Some((tt, next)) => match tt {
-                    TokenTree::Punct(punct) if punct.as_char() == '=' => {
-                        Serde::parse_next_lit_str(next)
-                    }
-                    TokenTree::Literal(literal) => {
-                        Some((literal.to_string().replace('\"', ""), literal.span()))
-                    }
-                    _ => None,
-                },
-                _ => None,
-            }
-        }
+    #[derive(Default)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct SerdeValue {
+        pub skip: Option<bool>,
+        pub rename: Option<String>,
+    }
 
-        fn parse_container(input: syn::parse::ParseStream) -> syn::Result<Self> {
-            let mut container = SerdeContainer::default();
-
-            input.step(|cursor| {
-                let mut rest = *cursor;
-                while let Some((tt, next)) = rest.token_tree() {
-                    match tt {
-                        TokenTree::Ident(ident) if ident == "rename_all" => {
-                            if let Some((literal, span)) = Serde::parse_next_lit_str(next) {
-                                container.rename_all = Some(
-                                    literal
-                                        .parse::<RenameRule>()
-                                        .map_err(|error| Error::new(span, error.to_string()))?,
-                                );
-                            };
-                        }
-                        _ => (),
-                    }
-
-                    rest = next;
-                }
-                Ok(((), rest))
-            })?;
-
-            Ok(Serde::Container(container))
-        }
-
-        fn parse_value(input: syn::parse::ParseStream) -> syn::Result<Self> {
-            let mut value = SerdeValue::default();
+    impl SerdeValue {
+        fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+            let mut value = Self::default();
 
             input.step(|cursor| {
                 let mut rest = *cursor;
@@ -277,7 +250,7 @@ pub mod serde {
                     match tt {
                         TokenTree::Ident(ident) if ident == "skip" => value.skip = Some(true),
                         TokenTree::Ident(ident) if ident == "rename" => {
-                            if let Some((literal, _)) = Serde::parse_next_lit_str(next) {
+                            if let Some((literal, _)) = parse_next_lit_str(next) {
                                 value.rename = Some(literal)
                             };
                         }
@@ -289,41 +262,77 @@ pub mod serde {
                 Ok(((), rest))
             })?;
 
-            Ok(Serde::Value(value))
+            Ok(value)
         }
-    }
-
-    #[derive(Default)]
-    #[cfg_attr(feature = "debug", derive(Debug))]
-    pub struct SerdeValue {
-        pub skip: Option<bool>,
-        pub rename: Option<String>,
     }
 
     #[derive(Default)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct SerdeContainer {
         pub rename_all: Option<RenameRule>,
+        pub tag: Option<String>,
     }
 
-    pub fn parse_value(attributes: &[Attribute]) -> Option<Serde> {
+    impl SerdeContainer {
+        fn parse_ident(ident: Ident, next: Cursor, container: &mut SerdeContainer) -> syn::Result<()> {
+            match ident.to_string().as_str() {
+                "rename_all" => {
+                    if let Some((literal, span)) = parse_next_lit_str(next) {
+                        container.rename_all = Some(
+                            literal
+                                .parse::<RenameRule>()
+                                .map_err(|error| Error::new(span, error.to_string()))?,
+                        );
+                    };
+                }
+                "tag" => {
+                    if let Some((literal, _span)) = parse_next_lit_str(next) {
+                        container.tag = Some(literal)
+                    }
+                }
+                _ => {},
+            }
+            Ok(())
+        }
+
+        fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+            let mut container = Self::default();
+
+            input.step(|cursor| {
+                let mut rest = *cursor;
+                while let Some((tt, next)) = rest.token_tree() {
+                    match tt {
+                        TokenTree::Ident(ident) => Self::parse_ident(ident, next, &mut container)?,
+                        _ => (),
+                    }
+
+                    rest = next;
+                }
+                Ok(((), rest))
+            })?;
+
+            Ok(container)
+        }
+    }
+
+    pub fn parse_value(attributes: &[Attribute]) -> Option<SerdeValue> {
         attributes
             .iter()
             .find(|attribute| attribute.path.is_ident("serde"))
             .map(|serde_attribute| {
                 serde_attribute
-                    .parse_args_with(Serde::parse_value)
+                    .parse_args_with(SerdeValue::parse)
                     .unwrap_or_abort()
             })
     }
 
-    pub fn parse_container(attributes: &[Attribute]) -> Option<Serde> {
+    pub fn parse_container(attributes: &[Attribute]) -> Option<SerdeContainer> {
         attributes
             .iter()
             .find(|attribute| attribute.path.is_ident("serde"))
             .map(|serde_attribute| {
                 serde_attribute
-                    .parse_args_with(Serde::parse_container)
+                    .parse_args_with(SerdeContainer::parse)
                     .unwrap_or_abort()
             })
     }

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -802,8 +802,8 @@ fn is_not_skipped(rule: &Option<SerdeValue>) -> bool {
 /// rules.
 #[inline]
 fn rename_field<'a>(
-    container_rule: &'a mut Option<SerdeContainer>,
-    field_rule: &'a mut Option<SerdeValue>,
+    container_rule: &'a Option<SerdeContainer>,
+    field_rule: &'a Option<SerdeValue>,
     field: &str,
 ) -> Option<String> {
     rename(container_rule, field_rule, &|rule| rule.rename(field))
@@ -815,8 +815,8 @@ fn rename_field<'a>(
 /// rules.
 #[inline]
 fn rename_variant<'a>(
-    container_rule: &'a mut Option<SerdeContainer>,
-    field_rule: &'a mut Option<SerdeValue>,
+    container_rule: &'a Option<SerdeContainer>,
+    field_rule: &'a Option<SerdeValue>,
     variant: &str,
 ) -> Option<String> {
     rename(container_rule, field_rule, &|rule| {
@@ -829,16 +829,16 @@ fn rename_variant<'a>(
 /// `Some` of the result of the `rename_op` if a rename is required by the supplied rules.
 #[inline]
 fn rename<'a>(
-    container_rule: &'a mut Option<SerdeContainer>,
-    field_rule: &'a mut Option<SerdeValue>,
+    container_rule: &'a Option<SerdeContainer>,
+    field_rule: &'a Option<SerdeValue>,
     rename_op: &impl Fn(&RenameRule) -> String,
 ) -> Option<String> {
     field_rule
-        .as_mut()
-        .and_then(|value| value.rename.take())
+        .as_ref()
+        .and_then(|value| value.rename.clone())
         .or_else(|| {
             container_rule
-                .as_mut()
+                .as_ref()
                 .and_then(|container| container.rename_all.as_ref().map(rename_op))
         })
 }

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -513,17 +513,17 @@ impl ToTokens for ComplexEnum<'_> {
         self.variants
             .iter()
             .filter_map(|variant: &Variant| {
-                let variant_rules = serde::parse_value(&variant.attrs);
-                if is_not_skipped(&variant_rules) {
-                    Some((variant, variant_rules))
+                let variant_serde_rules = serde::parse_value(&variant.attrs);
+                if is_not_skipped(&variant_serde_rules) {
+                    Some((variant, variant_serde_rules))
                 } else {
                     None
                 }
             })
-            .map(|(variant, mut variant_rule)| {
+            .map(|(variant, mut variant_serde_rules)| {
                 let variant_name = &*variant.ident.to_string();
                 let renamed_variant =
-                    rename_variant(&mut container_rule, &mut variant_rule, variant_name)
+                    rename_variant(&mut container_rule, &mut variant_serde_rules, variant_name)
                         .unwrap_or_else(|| String::from(variant_name));
 
                 match &variant.fields {

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -751,6 +751,9 @@ fn rename_variant<'a>(
     })
 }
 
+/// Resolves the appropriate [`RenameRule`] to apply during a `rename_op` given a `container_rule`
+/// (`struct` or `enum` level) and `field_rule` (`struct` field or `enum` variant level). Returns
+/// `Some` of the result of the `rename_op` if a rename is required by the supplied rules.
 #[inline]
 fn rename<'a>(
     container_rule: &'a mut Option<Serde>,

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -731,6 +731,10 @@ fn is_not_skipped(rule: &Option<Serde>) -> bool {
         .unwrap_or(true)
 }
 
+/// Resolves the appropriate [`RenameRule`] to apply to the specified `struct` `field` name given a
+/// `container_rule` (`struct` or `enum` level) and `field_rule` (`struct` field or `enum` variant
+/// level). Returns `Some` of the result of the `rename_op` if a rename is required by the supplied
+/// rules.
 #[inline]
 fn rename_field<'a>(
     container_rule: &'a mut Option<Serde>,
@@ -740,14 +744,18 @@ fn rename_field<'a>(
     rename(container_rule, field_rule, &|rule| rule.rename(field))
 }
 
+/// Resolves the appropriate [`RenameRule`] to apply to the specified `enum` `variant` name given a
+/// `container_rule` (`struct` or `enum` level) and `field_rule` (`struct` field or `enum` variant
+/// level). Returns `Some` of the result of the `rename_op` if a rename is required by the supplied
+/// rules.
 #[inline]
 fn rename_variant<'a>(
     container_rule: &'a mut Option<Serde>,
     field_rule: &'a mut Option<Serde>,
-    field: &str,
+    variant: &str,
 ) -> Option<String> {
     rename(container_rule, field_rule, &|rule| {
-        rule.rename_variant(field)
+        rule.rename_variant(variant)
     })
 }
 

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -392,6 +392,8 @@ struct SimpleEnum<'a> {
 }
 
 impl SimpleEnum<'_> {
+    /// Produce tokens that represent each variant for the situation where the serde enum tag =
+    /// "<tag>" attribute applies.
     fn tagged_variants_tokens(
         enum_values: Array<String>,
         serde_container: serde::SerdeContainer,
@@ -424,6 +426,7 @@ impl SimpleEnum<'_> {
         }
     }
 
+    /// Produce tokens that represent each variant.
     fn variants_tokens(enum_values: Array<String>) -> TokenStream2 {
         let len = enum_values.len();
         quote! {
@@ -456,7 +459,6 @@ impl ToTokens for SimpleEnum<'_> {
             .collect::<Array<String>>();
 
         tokens.extend(match container_rules {
-            // Handle the serde enum tag = "<tag>" property
             Some(Serde::Container(serde_container)) if serde_container.tag.is_some() => {
                 Self::tagged_variants_tokens(enum_values, serde_container)
             }

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -522,7 +522,7 @@ impl ToTokens for ComplexEnum<'_> {
             })
             .map(|(variant, mut variant_serde_rules)| {
                 let variant_name = &*variant.ident.to_string();
-                let renamed_variant =
+                let variant_name =
                     rename_variant(&mut container_rule, &mut variant_serde_rules, variant_name)
                         .unwrap_or_else(|| String::from(variant_name));
 
@@ -537,7 +537,7 @@ impl ToTokens for ComplexEnum<'_> {
 
                         quote! {
                             utoipa::openapi::schema::ObjectBuilder::new()
-                                .property(#renamed_variant, #named_enum)
+                                .property(#variant_name, #named_enum)
                         }
                     }
                     Fields::Unnamed(unnamed_fields) => {
@@ -548,14 +548,14 @@ impl ToTokens for ComplexEnum<'_> {
 
                         quote! {
                             utoipa::openapi::schema::ObjectBuilder::new()
-                                .property(#renamed_variant, #unnamed_enum)
+                                .property(#variant_name, #unnamed_enum)
                         }
                     }
                     Fields::Unit => {
                         quote! {
                             utoipa::openapi::PropertyBuilder::new()
                                 .component_type(utoipa::openapi::ComponentType::String)
-                                .enum_values::<[&str; 1], &str>(Some([#renamed_variant]))
+                                .enum_values::<[&str; 1], &str>(Some([#variant_name]))
                         }
                     }
                 }

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -581,7 +581,6 @@ impl ToTokens for ComplexEnum<'_> {
         let capacity = self.variants.len();
         tokens.extend(quote! {});
 
-        // TODO: refactor this to return Option<SerdeContainer>
         let mut container_rules = serde::parse_container(self.attributes);
         let tag: Option<String> =
             if let Some(Serde::Container(serde_container)) = &mut container_rules {

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -577,7 +577,6 @@ impl ToTokens for ComplexEnum<'_> {
         }
 
         let capacity = self.variants.len();
-        tokens.extend(quote! {});
 
         let mut container_rules = serde::parse_container(self.attributes);
         let tag: Option<String> = if let Some(serde_container) = &mut container_rules {


### PR DESCRIPTION
Implements #130 

- Implement serde's `tag`  property for the [Internally Tagged](https://serde.rs/enum-representations.html#internally-tagged) representation of simple and complex enums
- Add `assert-json-diff` for improved json comparison ergonimics in
  tests. Discussion here: https://github.com/juhaku/utoipa/discussions/145
- Documentation for `rename()`, `rename_variant()` and `rename_field()` functions used in the `Component` macro.
- Refactor `serde::parse_container()` to return `SerdeContainer` instead of `Serde::Container(SerdeContainer)`, same for `serde::parse_value()` removing the now unecessary `Serde` enum in the process.

This work was sponsored by [Arctoris](https://www.arctoris.com/).