### PR TITLE
Parameters as struct implementing IntoParams for warp (and other frameworks)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ utoipa-gen = { version = "1.1.0", path = "./utoipa-gen" }
 [dev-dependencies]
 assert-json-diff = "2"
 actix-web = { version = "4" }
+assert-json-diff = "2"
 paste = "1"
 chrono = { version  = "0.4", features = ["serde"] }
 rust_decimal = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ serde_yaml = { version = "0.8", optional = true }
 utoipa-gen = { version = "1.1.0", path = "./utoipa-gen" }
 
 [dev-dependencies]
-assert-json-diff = "2"
 actix-web = { version = "4" }
 assert-json-diff = "2"
 paste = "1"

--- a/examples/todo-warp/src/main.rs
+++ b/examples/todo-warp/src/main.rs
@@ -94,7 +94,7 @@ mod todo {
     };
 
     use serde::{Deserialize, Serialize};
-    use utoipa::Component;
+    use utoipa::{openapi::path::ParameterIn, Component, IntoParams};
     use warp::{hyper::StatusCode, Filter, Reply};
 
     pub type Store = Arc<Mutex<Vec<Todo>>>;
@@ -110,6 +110,19 @@ mod todo {
         value: String,
     }
 
+    #[derive(Debug, Deserialize, IntoParams)]
+    pub struct ListQueryParams {
+        /// Filters the returned `Todo` items according to whether they contain the specified string.
+        #[param(style = Form, example = json!("task"))]
+        contains: Option<String>,
+    }
+
+    impl utoipa::ParameterIn for ListQueryParams {
+        fn parameter_in() -> Option<utoipa::openapi::path::ParameterIn> {
+            Some(ParameterIn::Query)
+        }
+    }
+
     pub fn handlers() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
         let store = Store::default();
 
@@ -117,6 +130,7 @@ mod todo {
             .and(warp::get())
             .and(warp::path::end())
             .and(with_store(store.clone()))
+            .and(warp::query::<ListQueryParams>())
             .and_then(list_todos);
 
         let create = warp::path("todo")
@@ -146,14 +160,28 @@ mod todo {
     #[utoipa::path(
         get,
         path = "/todo",
+        params(ListQueryParams),
         responses(
             (status = 200, description = "List todos successfully", body = [Todo])
         )
     )]
-    pub async fn list_todos(store: Store) -> Result<impl Reply, Infallible> {
+    pub async fn list_todos(
+        store: Store,
+        query: ListQueryParams,
+    ) -> Result<impl Reply, Infallible> {
         let todos = store.lock().unwrap();
 
-        Ok(warp::reply::json(&todos.clone()))
+        let todos: Vec<Todo> = if let Some(contains) = query.contains {
+            todos
+                .iter()
+                .filter(|todo| todo.value.contains(&contains))
+                .cloned()
+                .collect()
+        } else {
+            todos.clone()
+        };
+
+        Ok(warp::reply::json(&todos))
     }
 
     /// Create new todo item.

--- a/examples/todo-warp/src/main.rs
+++ b/examples/todo-warp/src/main.rs
@@ -63,7 +63,9 @@ async fn serve_swagger(
     config: Arc<Config<'static>>,
 ) -> Result<Box<dyn Reply + 'static>, Rejection> {
     if full_path.as_str() == "/swagger-ui" {
-        return Ok(Box::new(warp::redirect::found(Uri::from_static("/swagger-ui/"))));
+        return Ok(Box::new(warp::redirect::found(Uri::from_static(
+            "/swagger-ui/",
+        ))));
     }
 
     let path = tail.as_str();
@@ -94,7 +96,7 @@ mod todo {
     };
 
     use serde::{Deserialize, Serialize};
-    use utoipa::{openapi::path::ParameterIn, Component, IntoParams};
+    use utoipa::{Component, IntoParams};
     use warp::{hyper::StatusCode, Filter, Reply};
 
     pub type Store = Arc<Mutex<Vec<Todo>>>;
@@ -111,16 +113,11 @@ mod todo {
     }
 
     #[derive(Debug, Deserialize, IntoParams)]
+    #[into_params(parameter_in = Query)]
     pub struct ListQueryParams {
         /// Filters the returned `Todo` items according to whether they contain the specified string.
         #[param(style = Form, example = json!("task"))]
         contains: Option<String>,
-    }
-
-    impl utoipa::ParameterIn for ListQueryParams {
-        fn parameter_in() -> Option<utoipa::openapi::path::ParameterIn> {
-            Some(ParameterIn::Query)
-        }
     }
 
     pub fn handlers() -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@
 //!             (status = 404, description = "Pet was not found")
 //!         ),
 //!         params(
-//!             ("id" = u64, path, description = "Pet database id to get Pet for"),
+//!             ("id" = u64, Path, description = "Pet database id to get Pet for"),
 //!         )
 //!     )]
 //!     async fn get_pet_by_id(pet_id: u64) -> Pet {
@@ -159,7 +159,7 @@
 //! #             (status = 404, description = "Pet was not found")
 //! #         ),
 //! #         params(
-//! #             ("id" = u64, path, description = "Pet database id to get Pet for"),
+//! #             ("id" = u64, Path, description = "Pet database id to get Pet for"),
 //! #         )
 //! #     )]
 //! #     async fn get_pet_by_id(pet_id: u64) -> Pet {
@@ -344,7 +344,7 @@ pub trait Component {
 ///         (status = 404, description = "Pet was not found")
 ///     ),
 ///     params(
-///         ("id" = u64, path, description = "Pet database id to get Pet for"),
+///         ("id" = u64, Path, description = "Pet database id to get Pet for"),
 ///     )
 /// )]
 /// async fn get_pet_by_id(pet_id: u64) -> Pet {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -472,7 +472,7 @@ pub trait Modify {
     fn modify(&self, openapi: &mut openapi::OpenApi);
 }
 
-/// Trait used to convert implementing type to OpenAPI parameters for **actix-web** framework.
+/// Trait used to convert implementing type to OpenAPI parameters.
 ///
 /// This trait is [derivable][derive] for structs which are used to describe `path` or `query` parameters.
 /// For more details of `#[derive(IntoParams)]` refer to [derive documentation][derive].
@@ -531,7 +531,6 @@ pub trait Modify {
 /// }
 /// ```
 /// [derive]: derive.IntoParams.html
-#[cfg(feature = "actix_extras")]
 pub trait IntoParams {
     /// Provide [`Vec`] of [`openapi::path::Parameter`]s to caller. The result is used in `utoipa-gen` library to
     /// provide OpenAPI parameter information for the endpoint using the parameters.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,7 +482,7 @@ pub trait Modify {
 /// Derive [`IntoParams`] implementation. This example will fail to compile because [`IntoParams`] cannot
 /// be used alone and it need to be used together with endpoint using the params as well. See
 /// [derive documentation][derive] for more details.
-/// ```compile_fail
+/// ```
 /// use utoipa::{IntoParams};
 ///
 /// #[derive(IntoParams)]
@@ -503,12 +503,14 @@ pub trait Modify {
 /// #    name: String,
 /// # }
 /// impl utoipa::IntoParams for PetParams {
-///     fn into_params() -> Vec<utoipa::openapi::path::Parameter> {
+///     fn into_params(
+///         parameter_in_provider: impl Fn() -> Option<utoipa::openapi::path::ParameterIn>
+///     ) -> Vec<utoipa::openapi::path::Parameter> {
 ///         vec![
 ///             utoipa::openapi::path::ParameterBuilder::new()
 ///                 .name("id")
 ///                 .required(utoipa::openapi::Required::True)
-///                 .parameter_in(utoipa::openapi::path::ParameterIn::Path)
+///                 .parameter_in(parameter_in_provider().unwrap_or_default())
 ///                 .description(Some("Id of pet"))
 ///                 .schema(Some(
 ///                     utoipa::openapi::PropertyBuilder::new()
@@ -519,7 +521,7 @@ pub trait Modify {
 ///             utoipa::openapi::path::ParameterBuilder::new()
 ///                 .name("name")
 ///                 .required(utoipa::openapi::Required::True)
-///                 .parameter_in(utoipa::openapi::path::ParameterIn::Path)
+///                 .parameter_in(parameter_in_provider().unwrap_or_default())
 ///                 .description(Some("Name of pet"))
 ///                 .schema(Some(
 ///                     utoipa::openapi::PropertyBuilder::new()

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -237,7 +237,7 @@ fn derive_path_with_security_requirements() {
 #[test]
 fn derive_path_params_intoparams() {
     #[derive(serde::Deserialize, IntoParams)]
-    #[param(style = Form)]
+    #[param(style = Form, parameter_in = query)]
     struct MyParams {
         /// Foo database id.
         #[param(example = 1)]

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -278,46 +278,35 @@ fn derive_path_params_intoparams() {
         path: "/list"
     };
 
+    let parameters = operation.get("parameters").unwrap();
+
     assert_json_eq!(
-        operation,
-        json!({
-            "deprecated": false,
-            "description": "",
-            "operationId": "list",
-            "parameters": [
-                {
-                    "description": "Foo database id.",
-                    "example": 1,
-                    "in": "query",
-                    "name": "id",
-                    "required": true,
-                    "schema": {
-                        "format": "int64",
-                        "type": "integer"
-                    },
-                    "style": "form"
+        parameters,
+        json!([
+            {
+                "description": "Foo database id.",
+                "example": 1,
+                "in": "query",
+                "name": "id",
+                "required": true,
+                "schema": {
+                    "format": "int64",
+                    "type": "integer"
                 },
-                {
-                    "description": "Datetime since foo is updated.",
-                    "example": "2020-04-12T10:23:00Z",
-                    "in": "query",
-                    "name": "since",
-                    "required": false,
-                    "schema": {
-                        "type": "string"
-                    },
-                    "style": "form"
-                }
-            ],
-            "responses": {
-                "200": {
-                    "description": "success response"
-                }
+                "style": "form"
             },
-            "tags": [
-                "crate"
-            ]
-        })
+            {
+                "description": "Datetime since foo is updated.",
+                "example": "2020-04-12T10:23:00Z",
+                "in": "query",
+                "name": "since",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+                "style": "form"
+            }
+        ])
     )
 }
 

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -251,14 +251,17 @@ fn derive_path_params_intoparams() {
 
     #[utoipa::path(
         get,
-        path = "/list",
+        path = "/list/{id}",
         responses(
             (status = 200, description = "success response")
         ),
-        params(MyParams),
+        params(
+            MyParams,
+            ("id" = i64, path, description = "Id of some items to list")
+        )
     )]
     #[allow(unused)]
-    fn list(params: MyParams) -> String {
+    fn list(id: i64, params: MyParams) -> String {
         "".to_string()
     }
 
@@ -270,7 +273,7 @@ fn derive_path_params_intoparams() {
     let operation: Value = test_api_fn_doc! {
         list,
         operation: get,
-        path: "/list"
+        path: "/list/{id}"
     };
 
     let parameters = operation.get("parameters").unwrap();
@@ -300,6 +303,17 @@ fn derive_path_params_intoparams() {
                     "type": "string"
                 },
                 "style": "form"
+            },
+            {
+                "deprecated": false,
+                "description": "Id of some items to list",
+                "in": "path",
+                "name": "id",
+                "required": true,
+                "schema": {
+                    "format": "int64",
+                    "type": "integer"
+                }
             }
         ])
     )

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -237,7 +237,7 @@ fn derive_path_with_security_requirements() {
 #[test]
 fn derive_path_params_intoparams() {
     #[derive(serde::Deserialize, IntoParams)]
-    #[param(style = Form, parameter_in = query)]
+    #[param(style = Form, parameter_in = Query)]
     struct MyParams {
         /// Foo database id.
         #[param(example = 1)]

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -237,21 +237,16 @@ fn derive_path_with_security_requirements() {
 #[test]
 fn derive_path_params_intoparams() {
     #[derive(serde::Deserialize, IntoParams)]
+    #[param(style = Form)]
     struct MyParams {
         /// Foo database id.
-        #[param(style = Form, example = 1)]
+        #[param(example = 1)]
         #[allow(unused)]
         id: u64,
         /// Datetime since foo is updated.
-        #[param(style = Form, example = "2020-04-12T10:23:00Z")]
+        #[param(example = "2020-04-12T10:23:00Z")]
         #[allow(unused)]
         since: Option<String>,
-    }
-
-    impl utoipa::ParameterIn for MyParams {
-        fn parameter_in() -> Option<utoipa::openapi::path::ParameterIn> {
-            Some(utoipa::openapi::path::ParameterIn::Query)
-        }
     }
 
     #[utoipa::path(

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -160,7 +160,7 @@ fn derive_path_with_defaults_success() {
     ),
     params(
         ("id" = u64, description = "Foo database id"),
-        ("since" = Option<String>, query, description = "Datetime since foo is updated")
+        ("since" = Option<String>, Query, description = "Datetime since foo is updated")
     )
 )]
 #[allow(unused)]
@@ -257,7 +257,7 @@ fn derive_path_params_intoparams() {
         ),
         params(
             MyParams,
-            ("id" = i64, path, description = "Id of some items to list")
+            ("id" = i64, Path, description = "Id of some items to list")
         )
     )]
     #[allow(unused)]

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -237,7 +237,7 @@ fn derive_path_with_security_requirements() {
 #[test]
 fn derive_path_params_intoparams() {
     #[derive(serde::Deserialize, IntoParams)]
-    #[param(style = Form, parameter_in = Query)]
+    #[into_params(style = Form, parameter_in = Query)]
     struct MyParams {
         /// Foo database id.
         #[param(example = 1)]

--- a/tests/path_parameter_derive_test.rs
+++ b/tests/path_parameter_derive_test.rs
@@ -16,7 +16,7 @@ mod derive_params_all_options {
             (status = 200, description = "success"),
         ),
         params(
-            ("id" = i32, path, deprecated, description = "Search foos by ids"),
+            ("id" = i32, Path, deprecated, description = "Search foos by ids"),
         )
     )]
     #[allow(unused)]
@@ -148,11 +148,11 @@ mod mod_derive_parameters_all_types {
             (status = 200, description = "success"),
         ),
         params(
-            ("id" = i32, path, description = "Foo id"),
-            ("since" = String, deprecated, query, description = "Datetime since"),
-            ("numbers" = Option<[u64]>, query, description = "Foo numbers list"),
-            ("token" = String, header, deprecated, description = "Token of foo"),
-            ("cookieval" = String, cookie, deprecated, description = "Foo cookie"),
+            ("id" = i32, Path, description = "Foo id"),
+            ("since" = String, deprecated, Query, description = "Datetime since"),
+            ("numbers" = Option<[u64]>, Query, description = "Foo numbers list"),
+            ("token" = String, Header, deprecated, description = "Token of foo"),
+            ("cookieval" = String, Cookie, deprecated, description = "Foo cookie"),
         )
     )]
     #[allow(unused)]
@@ -224,7 +224,7 @@ mod derive_params_without_args {
             (status = 200, description = "success"),
         ),
         params(
-            ("id" = i32, path, description = "Foo id"),
+            ("id" = i32, Path, description = "Foo id"),
         )
     )]
     #[allow(unused)]
@@ -263,7 +263,7 @@ fn derive_params_with_params_ext() {
             (status = 200, description = "success"),
         ),
         params(
-            ("value" = Option<[String]>, query, description = "Foo value description", style = Form, allow_reserved, deprecated, explode)
+            ("value" = Option<[String]>, Query, description = "Foo value description", style = Form, allow_reserved, deprecated, explode)
         )
     )]
     #[allow(unused)]

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -836,9 +836,23 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// While it is totally okay to declare deprecated with reason
 /// `#[deprecated  = "There is better way to do this"]` the reason would not render in OpenAPI spec.
 ///
-/// # IntoParams Attributes for `#[param(...)]`
+/// # IntoParams Container Attributes for `#[param(...)]`
 ///
-/// * `style = ...` Defines how parameters are serialized by [`ParameterStyle`][style]. Default values are based on _`in`_ attribute.
+/// The following attributes are available for use in on the container attribute `#[param(...)]` for the struct
+/// deriving `IntoParams`:
+///
+/// * `style = ...` Defines how all parameters are serialized by [`ParameterStyle`][style]. Default
+///    values are based on _`parameter_in`_ attribute.
+/// * `parameter_in = ...` =  Defines where the parameters of this field are used by
+///    [`openapi::path::ParameterIn`][in_enum]. There is no default value, if this attribute is not
+///    supplied, then one must implement [`ParameterIn`][in_trait] trait for the struct performing
+///    this derive.
+///
+/// # IntoParams Field Attributes for `#[param(...)]`
+///
+/// The following attributes are available for use in the `#[param(...)]` on struct fields:
+///
+/// * `style = ...` Defines how the parameter is serialized by [`ParameterStyle`][style]. Default values are based on _`parameter_in`_ attribute.
 /// * `explode` Defines whether new _`parameter=value`_ is created for each parameter withing _`object`_ or _`array`_.
 /// * `allow_reserved` Defines whether reserved characters _`:/?#[]@!$&'()*+,;=`_ is allowed within value.
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json] Given example
@@ -905,10 +919,27 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
+/// Demonstrate [`IntoParams`][into_params] usage with the `#[param(...)] container attribute:`:
+/// ```rust
+/// use serde::Deserialize;
+/// use utoipa::IntoParams;
+///
+/// #[derive(Deserialize, IntoParams)]
+/// #[param(style = Form, parameter_in = query)]
+/// struct PetPathArgs {
+///     /// Id of pet
+///     id: i64,
+///     /// Name of pet
+///     name: String,
+/// }
+/// ```
+///
 /// [into_params]: trait.IntoParams.html
 /// [path_params]: attr.path.html#params-attributes
 /// [struct]: https://doc.rust-lang.org/std/keyword.struct.html
 /// [style]: openapi/path/enum.ParameterStyle.html
+/// [in_enum]: utoipa/openapi/path/enum.ParameterIn.html
+/// [in_trait]: utoipa/trait.ParameterIn.html
 ///
 /// [^actix]: Feature **actix_extras** need to be enabled
 ///

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -471,7 +471,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// that implements [`IntoParams`][into_params]. See [`IntoParams`][into_params] for an
 /// example.
 ///
-/// [into_params]: ./trait.IntoParams.html 
+/// [into_params]: ./trait.IntoParams.html
 /// **For example:**
 ///
 /// ```text
@@ -697,7 +697,9 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
         let args = resolved_path.as_mut().map(|path| mem::take(&mut path.args));
         let arguments = PathOperations::resolve_path_arguments(&ast_fn.sig.inputs, args);
 
-        path_attribute.update_parameters(arguments);
+        path_attribute
+            .update_parameters(arguments)
+            .unwrap_or_abort();
     }
 
     let path = Path::new(path_attribute, fn_name)
@@ -937,9 +939,14 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// #[utoipa::path(
-///     params(PetQuery)
+///     get,
+///     path = "/get_pet",
+///     params(PetQuery),
+///     responses(
+///         (status = 200, description = "success response")
+///     )
 /// )]
-/// async get_pet(query: PetQuery) {
+/// async fn get_pet(query: PetQuery) {
 ///     // ...
 /// }
 /// ```

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -403,20 +403,27 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///
 /// **Minimal response format:**
 /// ```text
-/// (status = 200, description = "success response")
+/// responses(
+///     (status = 200, description = "success response"),
+///     (status = 404, description = "resource missing"),
+/// )
 /// ```
 ///
 /// **Response with all possible values:**
 /// ```text
-/// (status = 200, description = "Success response", body = Pet, content_type = "application/json",
-///     headers(...),
-///     example = json!({"id": 1, "name": "bob the cat"})
+/// responses(
+///     (status = 200, description = "Success response", body = Pet, content_type = "application/json",
+///         headers(...),
+///         example = json!({"id": 1, "name": "bob the cat"})
+///     )
 /// )
 /// ```
 ///
 /// **Response with multiple response content types:**
 /// ```text
-/// (status = 200, description = "Success response", body = Pet, content_type = ["application/json", "text/xml"])
+/// responses(
+///     (status = 200, description = "Success response", body = Pet, content_type = ["application/json", "text/xml"])
+/// )
 /// ```
 ///
 /// # Response Header Attributes
@@ -435,7 +442,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///
 /// # Params Attributes
 ///
-/// The `params(...)` attribute can take two forms: [Tuples](#tuples) or [IntoParams
+/// The list of attributes inside the `params(...)` attribute can take two forms: [Tuples](#tuples) or [IntoParams
 /// Type](#intoparams-type).
 ///
 /// ## Tuples
@@ -460,9 +467,20 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// **For example:**
 ///
 /// ```text
-/// ("id" = String, path, deprecated, description = "Pet database id"),
-/// ("id", path, deprecated, description = "Pet database id"),
-/// ("value" = Option<[String]>, query, description = "Value description", style = Form, allow_reserved, deprecated, explode, example = json!(["Value"]))
+/// params(
+///     ("id" = String, path, deprecated, description = "Pet database id"),
+///     ("name", path, deprecated, description = "Pet name"),
+///     (
+///         "value" = Option<[String]>,
+///         query,
+///         description = "Value description",
+///         style = Form,
+///         allow_reserved,
+///         deprecated,
+///         explode,
+///         example = json!(["Value"]))
+///     )
+/// )
 /// ```
 ///
 /// ## IntoParams Type
@@ -475,7 +493,18 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// **For example:**
 ///
 /// ```text
-/// MyParamters
+/// params(MyParamters)
+/// ```
+///
+/// Note that `MyParameters` can also be used in combination with the [tuples
+/// representation](#tuples) or other structs. **For example:**
+///
+/// ```text
+/// params(
+///     MyParameters1,
+///     MyParameters2,
+///     ("id" = String, path, deprecated, description = "Pet database id"),
+/// )
 /// ```
 ///
 /// # Security Requirement Attributes

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -455,7 +455,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///   E.g. _`String`_ or _`[String]`_ or _`Option<String>`_. Parameter type is placed after `name` with
 ///   equals sign E.g. _`"id" = String`_
 /// * `in` _**Must be placed after name or parameter_type**_. Define the place of the parameter.
-///   E.g. _`path, query, header, cookie`_
+///   This must be one of the variants of [`openapi::path::ParameterIn`][in_enum].
+///   E.g. _`Path, Query, Header, Cookie`_
 /// * `deprecated` Define whether the parameter is deprecated or not.
 /// * `description = "..."` Define possible description for the parameter as str.
 /// * `style = ...` Defines how parameters are serialized by [`ParameterStyle`][style]. Default values are based on _`in`_ attribute.
@@ -609,7 +610,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///         ),
 ///    ),
 ///    params(
-///      ("x-csrf-token" = String, header, deprecated, description = "Current csrf token of user"),
+///      ("x-csrf-token" = String, Header, deprecated, description = "Current csrf token of user"),
 ///    ),
 ///    security(
 ///        (),
@@ -644,7 +645,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///         ),
 ///    ),
 ///    params(
-///      ("x-csrf-token", header, description = "Current csrf token of user"),
+///      ("x-csrf-token", Header, description = "Current csrf token of user"),
 ///    )
 /// )]
 /// fn post_pet(pet: Pet) -> Pet {
@@ -689,6 +690,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///     HttpResponse::Ok().json(json!({ "pet": format!("{:?}", &id.into_inner()) }))
 /// }
 /// ```
+///
+/// [in_enum]: utoipa/openapi/path/enum.ParameterIn.html
 /// [path]: trait.Path.html
 /// [openapi]: derive.OpenApi.html
 /// [security]: openapi/security/struct.SecurityRequirement.html
@@ -914,7 +917,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// ```
 /// # Examples
 ///
-/// Demonstrate [`IntoParams`][into_params] usage with resolving `path` and `query` parameters
+/// Demonstrate [`IntoParams`][into_params] usage with resolving `Path` and `Query` parameters
 /// for `get_pet` endpoint. [^actix]
 /// ```rust
 /// use actix_web::{get, HttpResponse, Responder};

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -447,7 +447,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///
 /// ## Tuples
 ///
-/// In the tuples format, paramters are specified using the following attributes inside a list of
+/// In the tuples format, parameters are specified using the following attributes inside a list of
 /// tuples seperated by commas:
 ///
 /// * `name` _**Must be the first argument**_. Define the name for parameter.

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -493,7 +493,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// **For example:**
 ///
 /// ```text
-/// params(MyParamters)
+/// params(MyParameters)
 /// ```
 ///
 /// Note that `MyParameters` can also be used in combination with the [tuples

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -468,8 +468,10 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// ## IntoParams Type
 ///
 /// In the IntoParams paramters format, the paramters are specified using an identifier for a type
-/// that implements [`IntoParams`](./trait.IntoParams.html).
+/// that implements [`IntoParams`][into_params]. See [`IntoParams`][into_params] for an
+/// example.
 ///
+/// [into_params]: ./trait.IntoParams.html 
 /// **For example:**
 ///
 /// ```text
@@ -919,18 +921,26 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Demonstrate [`IntoParams`][into_params] usage with the `#[param(...)] container attribute:`:
+/// Demonstrate [`IntoParams`][into_params] usage with the `#[param(...)]` container attribute to
+/// be used as a path query:
 /// ```rust
 /// use serde::Deserialize;
 /// use utoipa::IntoParams;
 ///
 /// #[derive(Deserialize, IntoParams)]
 /// #[param(style = Form, parameter_in = Query)]
-/// struct PetPathArgs {
-///     /// Id of pet
-///     id: i64,
+/// struct PetQuery {
 ///     /// Name of pet
-///     name: String,
+///     name: Option<String>,
+///     /// Age of pet
+///     age: Option<i32>,
+/// }
+///
+/// #[utoipa::path(
+///     params(PetQuery)
+/// )]
+/// async get_pet(query: PetQuery) {
+///     // ...
 /// }
 /// ```
 ///

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -874,10 +874,10 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///
 /// * `style = ...` Defines how all parameters are serialized by [`ParameterStyle`][style]. Default
 ///    values are based on _`parameter_in`_ attribute.
-/// * `parameter_in = ...` =  Defines where the parameters of this field are used by
+/// * `parameter_in = ...` =  Defines where the parameters of this field are used with a value from
 ///    [`openapi::path::ParameterIn`][in_enum]. There is no default value, if this attribute is not
-///    supplied, then one must implement [`ParameterIn`][in_trait] trait for the struct performing
-///    this derive.
+///    supplied, then the value is determined by the `parameter_in_provider` in
+///    [`IntoParams::into_params()`](trait.IntoParams.html#tymethod.into_params).
 ///
 /// # IntoParams Field Attributes for `#[param(...)]`
 ///
@@ -983,7 +983,6 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// [struct]: https://doc.rust-lang.org/std/keyword.struct.html
 /// [style]: openapi/path/enum.ParameterStyle.html
 /// [in_enum]: utoipa/openapi/path/enum.ParameterIn.html
-/// [in_trait]: utoipa/trait.ParameterIn.html
 ///
 /// [^actix]: Feature **actix_extras** need to be enabled
 ///

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -726,9 +726,7 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
         let args = resolved_path.as_mut().map(|path| mem::take(&mut path.args));
         let arguments = PathOperations::resolve_path_arguments(&ast_fn.sig.inputs, args);
 
-        path_attribute
-            .update_parameters(arguments)
-            .unwrap_or_abort();
+        path_attribute.update_parameters(arguments)
     }
 
     let path = Path::new(path_attribute, fn_name)

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -915,18 +915,18 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// [^json]: **json** feature need to be enabled for `json!(...)` type to work.
 pub fn into_params(input: TokenStream) -> TokenStream {
     let DeriveInput {
+        attrs,
         ident,
         generics,
         data,
-        attrs,
         ..
     } = syn::parse_macro_input!(input);
 
     let into_params = IntoParams {
+        attrs,
         generics,
         data,
         ident,
-        attrs,
     };
 
     into_params.to_token_stream().into()

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -870,11 +870,12 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// While it is totally okay to declare deprecated with reason
 /// `#[deprecated  = "There is better way to do this"]` the reason would not render in OpenAPI spec.
 ///
-/// # IntoParams Container Attributes for `#[param(...)]`
+/// # IntoParams Container Attributes for `#[into_params(...)]`
 ///
-/// The following attributes are available for use in on the container attribute `#[param(...)]` for the struct
+/// The following attributes are available for use in on the container attribute `#[into_params(...)]` for the struct
 /// deriving `IntoParams`:
 ///
+/// * `names(...)` Define comma seprated list of names for unnamed fields of struct used as a path parameter.
 /// * `style = ...` Defines how all parameters are serialized by [`ParameterStyle`][style]. Default
 ///    values are based on _`parameter_in`_ attribute.
 /// * `parameter_in = ...` =  Defines where the parameters of this field are used with a value from
@@ -891,10 +892,6 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// * `allow_reserved` Defines whether reserved characters _`:/?#[]@!$&'()*+,;=`_ is allowed within value.
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json] Given example
 ///   will override any example in underlying parameter type.
-///
-/// # IntoParams Attributes for `#[into_params(...)]`
-///
-/// * `names(...)` Define comma seprated list of names for unnamed fields of struct used as a path parameter.
 ///
 /// **Note!** `#[into_params(...)]` is only supported on unnamed struct types to declare names for the arguments.
 ///

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -925,7 +925,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// use utoipa::IntoParams;
 ///
 /// #[derive(Deserialize, IntoParams)]
-/// #[param(style = Form, parameter_in = query)]
+/// #[param(style = Form, parameter_in = Query)]
 /// struct PetPathArgs {
 ///     /// Id of pet
 ///     id: i64,

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -485,7 +485,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///
 /// ## IntoParams Type
 ///
-/// In the IntoParams paramters format, the paramters are specified using an identifier for a type
+/// In the IntoParams parameters format, the parameters are specified using an identifier for a type
 /// that implements [`IntoParams`][into_params]. See [`IntoParams`][into_params] for an
 /// example.
 ///

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -98,7 +98,7 @@ impl ToTokens for Params<'_> {
 
 impl<'p> PathAttr<'p> {
     #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]
-    pub fn update_parameters(&mut self, arguments: Option<Vec<Argument<'p>>>) -> syn::Result<()> {
+    pub fn update_parameters(&mut self, arguments: Option<Vec<Argument<'p>>>) {
         if let Some(arguments) = arguments {
             if let Some(ref mut parameters) = self.params {
                 let parameters = &mut parameters.parameters;
@@ -119,8 +119,6 @@ impl<'p> PathAttr<'p> {
                 });
             }
         }
-
-        Ok(())
     }
 
     #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]
@@ -147,8 +145,8 @@ impl<'p> PathAttr<'p> {
                             argument.is_option,
                         )
                     }
-                },
-                Parameter::Struct(_) | Parameter::TokenStream(_) => {},
+                }
+                Parameter::Struct(_) | Parameter::TokenStream(_) => {}
             });
     }
 

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -70,7 +70,8 @@ pub struct PathAttr<'p> {
     context_path: Option<String>,
 }
 
-/// The [`PathAttr::params`] field definition.
+/// The [`PathAttr::params`] field definition. This is parsed from the
+/// `#[utoipa::path(params(...))]` attribute.
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Default)]
 struct Params<'p> {

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -4,8 +4,6 @@ use std::{io::Error, str::FromStr};
 use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use proc_macro_error::abort;
 use quote::{format_ident, quote, ToTokens};
-use syn::buffer::TokenBuffer;
-use syn::parse::ParseBuffer;
 use syn::punctuated::Punctuated;
 use syn::{parenthesized, parse::Parse, Token};
 

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -71,6 +71,7 @@ pub struct PathAttr<'p> {
 }
 
 /// The [`PathAttr::params`] field definition.
+#[cfg_attr(feature = "debug", derive(Debug))]
 enum Params<'p> {
     /// A list of tuples of attributes that defines a parameter.
     List(Vec<Parameter<'p>>),
@@ -541,6 +542,7 @@ impl ToTokens for Operation<'_> {
                     }
                 });
             }
+            // TODO: adjust this for the new into_params() signature. 
             Some(Params::Struct(parameters)) => tokens.extend(quote! {
                 .parameters(Some(<#parameters as utoipa::IntoParams>::into_params()))
             }),

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -560,9 +560,8 @@ impl ToTokens for Operation<'_> {
                     });
 
                 if let Some(struct_ident) = &parameters.struct_ident {
-                    // TODO: adjust this for new params signature
                     tokens.extend(quote! {
-                        .parameters(Some(<#struct_ident as utoipa::IntoParams>::into_params()))
+                        .parameters(Some(<#struct_ident as utoipa::IntoParams>::into_params(|| None)))
                     })
                 }
             }

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -155,7 +155,7 @@ impl Parse for Parameter<'_> {
 
 impl ToTokens for Parameter<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let mut handle_single_parameter = |parameter: &ParameterValue| {
+        fn handle_single_parameter(tokens: &mut TokenStream, parameter: &ParameterValue) {
             let name = &*parameter.name;
             tokens.extend(quote! {
                 utoipa::openapi::path::ParameterBuilder::from(utoipa::openapi::path::Parameter::new(#name))
@@ -191,10 +191,10 @@ impl ToTokens for Parameter<'_> {
 
                 tokens.extend(quote! { .schema(Some(#property)).required(#required) });
             }
-        };
+        }
 
         match self {
-            Parameter::Value(parameter) => handle_single_parameter(parameter),
+            Parameter::Value(parameter) => handle_single_parameter(tokens, parameter),
             #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]
             Parameter::TokenStream(stream) => {
                 tokens.extend(quote! { #stream });

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -243,14 +243,14 @@ impl FromStr for ParameterIn {
 
 impl Parse for ParameterIn {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        const EXPECTED_STYLE: &str = "unexpected in, expected one of: path, query, header, cookie";
+        const EXPECTED_STYLE: &str = "unexpected in, expected one of: Path, Query, Header, Cookie";
         let style = input.parse::<Ident>()?;
 
         match &*style.to_string() {
-            "path" => Ok(Self::Path),
-            "query" => Ok(Self::Query),
-            "header" => Ok(Self::Header),
-            "cookie" => Ok(Self::Cookie),
+            "Path" => Ok(Self::Path),
+            "Query" => Ok(Self::Query),
+            "Header" => Ok(Self::Header),
+            "Cookie" => Ok(Self::Cookie),
             _ => Err(Error::new(style.span(), EXPECTED_STYLE)),
         }
     }

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -9,7 +9,10 @@ use syn::{
 
 #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]
 use crate::ext::{Argument, ArgumentIn};
-use crate::{parse_utils, AnyValue, Deprecated, Required, Type};
+use crate::{
+    parse_utils, schema::into_params::{IntoParamsAttr, FieldParamContainerAttributes}, AnyValue, Deprecated, Required,
+    Type,
+};
 
 use super::property::Property;
 
@@ -260,8 +263,17 @@ pub struct ParameterExt {
     pub(crate) example: Option<AnyValue>,
 }
 
+impl From<&'_ FieldParamContainerAttributes<'_>> for ParameterExt {
+    fn from(attributes: &FieldParamContainerAttributes) -> Self {
+        Self {
+            style: attributes.style,
+            ..ParameterExt::default()
+        }
+    }
+}
+
 impl ParameterExt {
-    fn merge(&mut self, from: ParameterExt) {
+    pub fn merge(&mut self, from: ParameterExt) {
         if from.style.is_some() {
             self.style = from.style
         }
@@ -334,6 +346,7 @@ impl Parse for ParameterExt {
 }
 
 /// See definitions from `utoipa` crate path.rs
+#[derive(Copy, Clone)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum ParameterStyle {
     Matrix,

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -10,8 +10,8 @@ use syn::{
 #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]
 use crate::ext::{Argument, ArgumentIn};
 use crate::{
-    parse_utils, schema::into_params::{IntoParamsAttr, FieldParamContainerAttributes}, AnyValue, Deprecated, Required,
-    Type,
+    parse_utils, schema::into_params::FieldParamContainerAttributes, AnyValue, Deprecated,
+    Required, Type,
 };
 
 use super::property::Property;
@@ -207,7 +207,7 @@ impl ToTokens for Parameter<'_> {
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
-#[derive(PartialEq)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum ParameterIn {
     Query,
     Path,
@@ -281,7 +281,7 @@ pub struct ParameterExt {
 impl From<&'_ FieldParamContainerAttributes<'_>> for ParameterExt {
     fn from(attributes: &FieldParamContainerAttributes) -> Self {
         Self {
-            style: attributes.parameter_style,
+            style: attributes.style,
             ..ParameterExt::default()
         }
     }

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -241,6 +241,21 @@ impl FromStr for ParameterIn {
     }
 }
 
+impl Parse for ParameterIn {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        const EXPECTED_STYLE: &str = "unexpected in, expected one of: path, query, header, cookie";
+        let style = input.parse::<Ident>()?;
+
+        match &*style.to_string() {
+            "path" => Ok(Self::Path),
+            "query" => Ok(Self::Query),
+            "header" => Ok(Self::Header),
+            "cookie" => Ok(Self::Cookie),
+            _ => Err(Error::new(style.span(), EXPECTED_STYLE)),
+        }
+    }
+}
+
 impl ToTokens for ParameterIn {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(match self {
@@ -266,7 +281,7 @@ pub struct ParameterExt {
 impl From<&'_ FieldParamContainerAttributes<'_>> for ParameterExt {
     fn from(attributes: &FieldParamContainerAttributes) -> Self {
         Self {
-            style: attributes.style,
+            style: attributes.parameter_style,
             ..ParameterExt::default()
         }
     }

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -5,7 +5,7 @@ use quote::{quote, ToTokens};
 use syn::{
     parenthesized,
     parse::{Parse, ParseBuffer, ParseStream},
-    Error, LitStr, Token,
+    Error, LitStr, Token, ExprPath,
 };
 
 #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]
@@ -32,7 +32,7 @@ use super::property::Property;
 pub enum Parameter<'a> {
     Value(ParameterValue<'a>),
     /// Identifier for a struct that implements `IntoParams` trait.
-    Struct(Ident),
+    Struct(ExprPath),
     #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]
     TokenStream(TokenStream),
 }

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -5,7 +5,7 @@ use quote::{quote, ToTokens};
 use syn::{
     parenthesized,
     parse::{Parse, ParseBuffer, ParseStream},
-    Error, LitStr, Token, ExprPath,
+    Error, ExprPath, LitStr, Token,
 };
 
 #[cfg(any(feature = "actix_extras", feature = "rocket_extras"))]

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -7,7 +7,6 @@ use syn::{
 
 use crate::{component_type::ComponentType, Deprecated};
 
-#[cfg(feature = "actix_extras")]
 pub mod into_params;
 
 pub mod component;

--- a/utoipa-gen/src/schema/into_params.rs
+++ b/utoipa-gen/src/schema/into_params.rs
@@ -33,7 +33,7 @@ impl IntoParamsAttr {
             self.style = other.style;
         }
 
-        if !other.names.is_some() {
+        if other.names.is_some() {
             self.names = other.names;
         }
 
@@ -214,7 +214,7 @@ impl IntoParams {
             None => {
                 abort! {
                     ident,
-                    "struct with unnamed fields must have explisit name declarations.";
+                    "struct with unnamed fields must have explicit name declarations.";
                     help = "Try defining `#[into_params(names(...))]` over your type: {}", ident,
                 }
             }


### PR DESCRIPTION
+ Support accepting `params(Type)` for `path` where `Type` implements `IntoParams`, closing #129.
+ Modified `todo-warp` to show this feature in use.
+ Implement https://github.com/juhaku/utoipa/issues/151 container attributes for `IntoParams` including `style` and `parameter_in`. For example: `#[param(style = Form, parameter_in = Query)]`.

TODO:
- [x] Some unit tests with this feature.
- [x] Figure out what to do about `ParameterIn` which is currently documented as an "internal trait". Perhaps this trait could also be derived?
- [x] Support paths like in https://github.com/juhaku/utoipa/pull/161
- [x] ~Fix todo-warp project~ edit: looks like this is a regression on `master` https://github.com/juhaku/utoipa/issues/173

This work was sponsored by [Arctoris](https://www.arctoris.com/).