### PR TITLE
Fix duplicate parameter in

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,19 +535,7 @@ pub trait Modify {
 pub trait IntoParams {
     /// Provide [`Vec`] of [`openapi::path::Parameter`]s to caller. The result is used in `utoipa-gen` library to
     /// provide OpenAPI parameter information for the endpoint using the parameters.
-    fn into_params() -> Vec<openapi::path::Parameter>;
-}
-
-/// Internal trait used to provide [`ParameterIn`] definition for implementer type.
-///
-/// This is typically used in tandem with [`IntoParams`] trait and only from `utoipa-gen` library.
-/// In manual implementation there is typically never a need to implement this trait since
-/// manual implementations can directly define the [`ParameterIn`] definition they see fit to the purpose.
-#[cfg(feature = "actix_extras")]
-#[doc(hidden)]
-pub trait ParameterIn {
-    /// Provide [`ParameterIn`] declaration for caller. Default implementation returns [`None`].
-    fn parameter_in() -> Option<openapi::path::ParameterIn> {
-        None
-    }
+    fn into_params(
+        parameter_in_provider: impl Fn() -> Option<openapi::path::ParameterIn>,
+    ) -> Vec<openapi::path::Parameter>;
 }

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -65,13 +65,7 @@ impl PathOperations {
                 {
                     struct #assert_ty where #ty : utoipa::IntoParams;
 
-                    impl utoipa::ParameterIn for #ty {
-                        fn parameter_in() -> Option<utoipa::openapi::path::ParameterIn> {
-                            Some(#parameter_in)
-                        }
-                    }
-
-                    <#ty>::into_params()
+                    <#ty>::into_params(|| Some(#parameter_in))
                 }
             })
         })

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -778,7 +778,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 
 #[cfg(feature = "actix_extras")]
 #[proc_macro_error]
-#[proc_macro_derive(IntoParams, attributes(param))]
+#[proc_macro_derive(IntoParams, attributes(param, into_params))]
 /// IntoParams derive macro for **actix-web** only.
 ///
 /// This is `#[derive]` implementation for [`IntoParams`][into_params] trait.
@@ -804,6 +804,29 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json] Given example
 ///   will override any example in underlying parameter type.
 ///
+/// # IntoParams Attributes for `#[into_params(...)]`
+///
+/// * `names(...)` Define comma seprated list of names for unnamed fields of struct used as a path parameter.
+///
+/// **Note!** `#[into_params(...)]` is only supported on unnamed struct types to declare names for the arguments.
+///
+/// Use `names` to define name for single unnamed argument.
+/// ```rust
+/// # use utoipa::IntoParams;
+/// #
+/// #[derive(IntoParams)]
+/// #[into_params(names("id"))]
+/// struct Id(u64);
+/// ```
+///
+/// Use `names` to define names for multiple unnamed arguments.
+/// ```rust
+/// # use utoipa::IntoParams;
+/// #
+/// #[derive(IntoParams)]
+/// #[into_params(names("id", "name"))]
+/// struct IdAndName(u64, String);
+/// ```
 /// # Examples
 ///
 /// Demonstrate [`IntoParams`][into_params] usage with resolving `path` and `query` parameters
@@ -855,6 +878,7 @@ pub fn into_params(input: TokenStream) -> TokenStream {
         ident,
         generics,
         data,
+        attrs,
         ..
     } = syn::parse_macro_input!(input);
 
@@ -862,6 +886,7 @@ pub fn into_params(input: TokenStream) -> TokenStream {
         generics,
         data,
         ident,
+        attrs,
     };
 
     into_params.to_token_stream().into()

--- a/utoipa-gen/src/schema/into_params.rs
+++ b/utoipa-gen/src/schema/into_params.rs
@@ -30,7 +30,7 @@ impl ToTokens for IntoParams {
         tokens.extend(quote! {
             impl #impl_generics utoipa::IntoParams for #ident #ty_generics #where_clause {
 
-                fn into_params() -> Vec<utoipa::openapi::path::Parameter> {
+                fn into_params(parameter_in_provider: impl Fn() -> Option<utoipa::openapi::path::ParameterIn>) -> Vec<utoipa::openapi::path::Parameter> {
                     #params.to_vec()
                 }
 
@@ -77,7 +77,7 @@ impl ToTokens for Param<'_> {
 
         tokens.extend(quote! { utoipa::openapi::path::ParameterBuilder::new()
             .name(#name)
-            .parameter_in(<Self as utoipa::ParameterIn>::parameter_in().unwrap_or_default())
+            .parameter_in(parameter_in_provider().unwrap_or_default())
             .required(#required)
         });
 

--- a/utoipa-gen/src/schema/into_params.rs
+++ b/utoipa-gen/src/schema/into_params.rs
@@ -1,20 +1,55 @@
 use proc_macro_error::{abort, ResultExt};
 use quote::{quote, ToTokens};
-use syn::{Data, Field, Generics, Ident};
+use syn::{
+    parse::Parse, punctuated::Punctuated, token::Comma, Attribute, Data, Error, Field, Generics,
+    Ident, LitStr,
+};
 
 use crate::{
     component_type::{ComponentFormat, ComponentType},
     doc_comment::CommentAttributes,
+    parse_utils,
     path::parameter::ParameterExt,
     Array, Required,
 };
 
 use super::{ComponentPart, GenericType, ValueType};
 
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct IntoParamsAttr {
+    names: Vec<String>,
+}
+
+impl Parse for IntoParamsAttr {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        const EXPECTED_ATTRIBUTE: &str = "unexpected token, expected: names";
+
+        input
+            .parse::<Ident>()
+            .map_err(|error| Error::new(error.span(), format!("{EXPECTED_ATTRIBUTE}, {error}")))
+            .and_then(|ident| {
+                if ident != "names" {
+                    Err(Error::new(ident.span(), EXPECTED_ATTRIBUTE))
+                } else {
+                    Ok(ident)
+                }
+            })?;
+
+        Ok(IntoParamsAttr {
+            names: parse_utils::parse_punctuated_within_parenthesis::<LitStr>(input)?
+                .into_iter()
+                .map(|name| name.value())
+                .collect(),
+        })
+    }
+}
+
+#[cfg_attr(feature = "debug", derive(Debug))]
 pub struct IntoParams {
     pub generics: Generics,
     pub data: Data,
     pub ident: Ident,
+    pub attrs: Vec<Attribute>,
 }
 
 impl ToTokens for IntoParams {
@@ -22,9 +57,27 @@ impl ToTokens for IntoParams {
         let ident = &self.ident;
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
+        let into_params_attrs = &mut self
+            .attrs
+            .iter()
+            .find(|attr| attr.path.is_ident("into_params"))
+            .map(|attribute| attribute.parse_args::<IntoParamsAttr>().unwrap_or_abort());
+
         let params = self
-            .get_struct_fields()
-            .map(Param)
+            .get_struct_fields(
+                &into_params_attrs
+                    .as_mut()
+                    .map(|params| params.names.as_ref()),
+            )
+            .enumerate()
+            .map(|(index, field)| {
+                Param(
+                    field,
+                    into_params_attrs
+                        .as_ref()
+                        .and_then(|param| param.names.get(index)),
+                )
+            })
             .collect::<Array<Param>>();
 
         tokens.extend(quote! {
@@ -40,12 +93,16 @@ impl ToTokens for IntoParams {
 }
 
 impl IntoParams {
-    fn get_struct_fields(&self) -> impl Iterator<Item = &Field> {
+    fn get_struct_fields(
+        &self,
+        field_names: &Option<&Vec<String>>,
+    ) -> impl Iterator<Item = &Field> {
         let ident = &self.ident;
         let abort = |note: &str| {
             abort! {
                 ident,
-                "unsupported data type, expected struct with named fields `struct {} {{...}}`",
+                "unsupported data type, expected struct with named fields `struct {} {{...}}` or unnamed fields `struct {}(...)`",
+                ident.to_string(),
                 ident.to_string();
                 note = note
             }
@@ -53,24 +110,63 @@ impl IntoParams {
 
         match &self.data {
             Data::Struct(data_struct) => match &data_struct.fields {
-                syn::Fields::Named(named_fields) => named_fields.named.iter(),
-                _ => abort("Only struct with named fields is supported"),
+                syn::Fields::Named(named_fields) => {
+                    if field_names.is_some() {
+                        abort! {ident, "`#[into_params(names(...))]` is not supported attribute on a struct with named fields"}
+                    }
+                    named_fields.named.iter()
+                }
+                syn::Fields::Unnamed(unnamed_fields) => {
+                    self.validate_unnamed_field_names(&unnamed_fields.unnamed, field_names);
+                    unnamed_fields.unnamed.iter()
+                }
+                _ => abort("Unit type struct is not supported"),
             },
             _ => abort("Only struct type is supported"),
         }
     }
+
+    fn validate_unnamed_field_names(
+        &self,
+        unnamed_fields: &Punctuated<Field, Comma>,
+        field_names: &Option<&Vec<String>>,
+    ) {
+        let ident = &self.ident;
+        match field_names {
+            Some(names) => {
+                if names.len() != unnamed_fields.len() {
+                    abort! {
+                        ident,
+                        "declared names amount '{}' does not match to the unnamed fields amount '{}' in type: {}",
+                            names.len(), unnamed_fields.len(), ident;
+                        help = r#"Did you forget to add a field name to `#[into_params(names(... , "field_name"))]`"#;
+                        help = "Or have you added extra name but haven't defined a type?"
+                    }
+                }
+            }
+            None => {
+                abort! {
+                    ident,
+                    "struct with unnamed fields must have explisit name declarations.";
+                    help = "Try defining `#[into_params(names(...))]` over your type: {}", ident,
+                }
+            }
+        }
+    }
 }
 
-struct Param<'a>(&'a Field);
+struct Param<'a>(&'a Field, Option<&'a String>);
 
 impl ToTokens for Param<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let unnamed_field_name = self.1;
         let field = self.0;
         let ident = &field.ident;
         let name = ident
             .as_ref()
             .map(|ident| ident.to_string())
-            .unwrap_or_else(String::new);
+            .or_else(|| unnamed_field_name.map(ToString::to_string))
+            .unwrap_or_default();
         let component_part = ComponentPart::from_type(&field.ty);
         let required: Required =
             (!matches!(&component_part.generic_type, Some(GenericType::Option))).into();
@@ -159,7 +255,10 @@ impl ToTokens for ParamType<'_> {
                 tokens.extend(param_type.into_token_stream())
             }
             Some(GenericType::Map) => {
-                abort!(ty.ident, "maps are not supported parameter receiver types")
+                // Maps are treated just as generic objects without types. There is no Map type in OpenAPI spec.
+                tokens.extend(quote! {
+                    utoipa::openapi::ObjectBuilder::new()
+                });
             }
         };
     }


### PR DESCRIPTION
* Delete ParameterIn trait -> obsolete since using another mechanish to pass the ParameterIn type
* Add support for unnamed field structs to be derived with IntoParmas
* Update docs & and add tests
* Allow maps as parameter types similar to the components -> Maps render as objects in OpenAPI