### PR TITLE
Add expr path support for components in openapi

### DIFF
--- a/tests/openapi_derive.rs
+++ b/tests/openapi_derive.rs
@@ -1,5 +1,6 @@
 #![cfg(feature = "json")]
 
+use serde_json::Value;
 use utoipa::OpenApi;
 
 mod common;
@@ -77,4 +78,30 @@ fn derive_openapi_with_external_docs_only_url() {
         "externalDocs.url" = r###""http://localhost.more.about.api""###, "External docs url"
         "externalDocs.description" = r###"null"###, "External docs description"
     }
+}
+
+#[test]
+fn derive_openapi_with_components_in_different_module() {
+    mod custom {
+        use utoipa::Component;
+
+        #[derive(Component)]
+        #[allow(unused)]
+        pub(super) struct Todo {
+            name: String,
+        }
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(components(custom::Todo))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let todo = common::get_json_path(&doc, "components.schemas.Todo");
+
+    assert_ne!(
+        todo,
+        &Value::Null,
+        "Expected components.schemas.Todo not to be null"
+    );
 }


### PR DESCRIPTION
Previously components within `#[openapi(components(...))]` needed to be declared in same module with the openapi.
This PR will add support for components so that they can be defined similarly to the handlers with expression path.

Before `#[openapi(components(Todo))]` -> now `#[openapi(components(path::to::the::Todo))]`. This allows cleaner imports leaving unnecessary imports out.