### PR TITLE
Add IntoParams custom module support

### DIFF
--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -489,8 +489,7 @@ impl ToTokens for Operation<'_> {
         let deprecated = self
             .deprecated
             .map(Into::<Deprecated>::into)
-            .or(Some(Deprecated::False))
-            .unwrap();
+            .unwrap_or(Deprecated::False);
         tokens.extend(quote! {
            .deprecated(Some(#deprecated))
         });


### PR DESCRIPTION
Add support for type deriving IntoParams so that it can be defined in another
module than the handler using it. Previously they needed to exists in
same module.