### PR TITLE
fix: escape raw identifier

### DIFF
--- a/src/openapi/path.rs
+++ b/src/openapi/path.rs
@@ -527,7 +527,7 @@ impl ParameterBuilder {
     new!(pub ParameterBuilder);
     /// Add name of the [`Parameter`].
     pub fn name<I: Into<String>>(mut self, name: I) -> Self {
-        set_value!(self name name.into())
+        set_value!(self name name.into().replace("r#", ""))
     }
 
     /// Add in of the [`Parameter`].

--- a/src/openapi/schema.rs
+++ b/src/openapi/schema.rs
@@ -561,14 +561,14 @@ impl ObjectBuilder {
         component: I,
     ) -> Self {
         self.properties
-            .insert(property_name.into(), component.into());
+            .insert(property_name.into().replace("r#", ""), component.into());
 
         self
     }
 
     /// Add field to the required fields of [`Object`].
     pub fn required<I: Into<String>>(mut self, required_field: I) -> Self {
-        self.required.push(required_field.into());
+        self.required.push(required_field.into().replace("r#", ""));
 
         self
     }
@@ -931,6 +931,24 @@ mod tests {
         let expected = r#"{"type":"object","example":{"age":20,"name":"bob the cat"}}"#;
         let json_value = ObjectBuilder::new()
             .example(Some(json!({"age": 20, "name": "bob the cat"})))
+            .build();
+
+        let value_string = serde_json::to_string(&json_value).unwrap();
+        assert_eq!(
+            value_string, expected,
+            "value string != expected string, {} != {}",
+            value_string, expected
+        );
+    }
+
+    #[test]
+    fn escape_raw_identifier() {
+        let expected = r#"{"type":"object","properties":{"type":{"type":"string"}}}"#;
+        let json_value = ObjectBuilder::new()
+            .property(
+                "r#type",
+                PropertyBuilder::new().component_type(ComponentType::String),
+            )
             .build();
 
         let value_string = serde_json::to_string(&json_value).unwrap();


### PR DESCRIPTION
### fix a unexpected behavior when we use [`r#x`](https://doc.rust-lang.org/rust-by-example/compatibility/raw_identifiers.html)

#### Example:
```rs
#[derive(Serialize, Deserialize, Component)]
struct Test {
  r#type: String
}
```
#### The result without this PR:
```json
{"type":"object","properties":{"type":{"r#type":"string"}}}
```