### PR TITLE
Added redirects in the warp servers from `/swagger-ui` to `/swagger-ui/`

### DIFF
--- a/examples/todo-warp/src/main.rs
+++ b/examples/todo-warp/src/main.rs
@@ -6,8 +6,9 @@ use utoipa::{
 };
 use utoipa_swagger_ui::Config;
 use warp::{
+    http::Uri,
     hyper::{Response, StatusCode},
-    path::Tail,
+    path::{FullPath, Tail},
     Filter, Rejection, Reply,
 };
 
@@ -46,6 +47,7 @@ async fn main() {
 
     let swagger_ui = warp::path("swagger-ui")
         .and(warp::get())
+        .and(warp::path::full())
         .and(warp::path::tail())
         .and(warp::any().map(move || config.clone()))
         .and_then(serve_swagger);
@@ -56,9 +58,14 @@ async fn main() {
 }
 
 async fn serve_swagger(
+    full_path: FullPath,
     tail: Tail,
     config: Arc<Config<'static>>,
 ) -> Result<Box<dyn Reply + 'static>, Rejection> {
+    if full_path.as_str() == "/swagger-ui" {
+        return Ok(Box::new(warp::redirect::found(Uri::from_static("/swagger-ui/"))));
+    }
+
     let path = tail.as_str();
     match utoipa_swagger_ui::serve(path, config) {
         Ok(file) => {


### PR DESCRIPTION
Extra info:
in the warp examples, http://localhost:8080/swagger-ui doesn't work, but http://localhost:8080/swagger-ui/ does. Unfortunately, there doesn't seem to be a simple way to enforce that in `warp` (see https://github.com/seanmonstar/warp/issues/584), so I added a manual redirect. This way, future `warp` users will be aware of this pitfall.

Commit message follows:
The ui only works if you go to `/swagger-ui/` with a tailing `/`.
If you browse to `/swagger-ui`, you get an unhelpful blank page,
due to the relative links for JS, CSS, et al files.
My investigation indicates that the best way to fix this in `warp`
is to manually create a redirect.
So I updated the `warp` examples to have this
(I am unsure if the other servers have the same problem)

I considered using a regex on the full path
instead of passing in both the path and tail,
but I decided passing along two strings was more efficient than
running a full regex every time