### PR TITLE
Add enhanced value_type for Components

### DIFF
--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -1092,6 +1092,57 @@ fn derive_unnamed_struct_component_type_override_with_format() {
     }
 }
 
+#[test]
+fn derive_struct_override_type_with_any_type() {
+    let value = api_doc! {
+        struct Value {
+            #[component(value_type = Any)]
+            field: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "type": "object",
+            "properties": {
+                "field": {
+                    "type": "object"
+                }
+            },
+            "required": ["field"]
+        })
+    )
+}
+
+#[test]
+fn derive_struct_override_type_with_a_reference() {
+    mod custom {
+        #[allow(dead_code)]
+        struct NewBar;
+    }
+
+    let value = api_doc! {
+        struct Value {
+            #[component(value_type = custom::NewBar)]
+            field: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "type": "object",
+            "properties": {
+                "field": {
+                    "$ref": "#/components/schemas/NewBar"
+                }
+            },
+            "required": ["field"]
+        })
+    )
+}
+
 #[cfg(feature = "decimal")]
 #[test]
 fn derive_struct_with_rust_decimal() {

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -182,6 +182,12 @@ impl<'a> ComponentPart<'a> {
     fn update_ident(&mut self, ident: &'a Ident) {
         self.ident = ident
     }
+
+    /// `Any` virtual type is used when generic object is required in OpenAPI spec. Typically used
+    /// with `value_override` attribute to hinder the actual type.
+    fn is_any(&self) -> bool {
+        &*self.ident == "Any"
+    }
 }
 
 impl<'a> AsMut<ComponentPart<'a>> for ComponentPart<'a> {

--- a/utoipa-gen/src/schema/component/attr.rs
+++ b/utoipa-gen/src/schema/component/attr.rs
@@ -12,7 +12,7 @@ use syn::{
 use crate::{
     parse_utils,
     schema::{ComponentPart, GenericType},
-    AnyValue,
+    AnyValue, ValueType,
 };
 
 use super::xml::{Xml, XmlAttr};
@@ -51,7 +51,7 @@ pub struct Struct {
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct UnnamedFieldStruct {
-    pub(super) ty: Option<Ident>,
+    pub(super) value_type: Option<ValueType>,
     format: Option<ExprPath>,
     default: Option<AnyValue>,
     example: Option<AnyValue>,
@@ -61,7 +61,7 @@ pub struct UnnamedFieldStruct {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct NamedField {
     example: Option<AnyValue>,
-    pub(super) ty: Option<Ident>,
+    pub(super) value_type: Option<ValueType>,
     format: Option<ExprPath>,
     default: Option<AnyValue>,
     write_only: Option<bool>,
@@ -192,8 +192,9 @@ impl Parse for ComponentAttr<UnnamedFieldStruct> {
                 }
                 "format" => unnamed_struct.format = Some(parse_format(input)?),
                 "value_type" => {
-                    unnamed_struct.ty =
-                        Some(parse_utils::parse_next(input, || input.parse::<Ident>())?)
+                    unnamed_struct.value_type = Some(parse_utils::parse_next(input, || {
+                        input.parse::<ValueType>()
+                    })?)
                 }
                 _ => return Err(Error::new(attribute.span(), EXPECTED_ATTRIBUTE_MESSAGE)),
             }
@@ -296,7 +297,9 @@ impl Parse for ComponentAttr<NamedField> {
                     field.xml_attr = Some(xml.parse()?)
                 }
                 "value_type" => {
-                    field.ty = Some(parse_utils::parse_next(input, || input.parse::<Ident>())?)
+                    field.value_type = Some(parse_utils::parse_next(input, || {
+                        input.parse::<ValueType>()
+                    })?)
                 }
                 _ => return Err(Error::new(ident.span(), EXPECTED_ATTRIBUTE_MESSAGE)),
             }


### PR DESCRIPTION
Fixes #180 #162 

Add enhanced `value_type` for Components. Now `value_type` can be used
to alter a reference of a field of the component or `Any` type can be
used to define field type as a generic `object`.