### PR TITLE
Refactor ComponentFormat derive

### DIFF
--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -139,7 +139,7 @@ fn derive_struct_with_custom_properties_success() {
             #[component(
                 default = "testhash",
                 example = "base64 text",
-                format = ComponentFormat::Byte,
+                format = Byte,
             )]
             hash: String,
         }
@@ -1035,7 +1035,7 @@ fn derive_struct_component_field_type_override_with_format() {
     let post = api_doc! {
         struct Post {
             id: i32,
-            #[component(value_type = String, format = ComponentFormat::Byte)]
+            #[component(value_type = String, format = Byte)]
             value: i64,
         }
     };
@@ -1053,7 +1053,7 @@ fn derive_struct_component_field_type_override_with_format_with_vec() {
     let post = api_doc! {
         struct Post {
             id: i32,
-            #[component(value_type = String, format = ComponentFormat::Binary)]
+            #[component(value_type = String, format = Binary)]
             value: Vec<u8>,
         }
     };
@@ -1082,7 +1082,7 @@ fn derive_unnamed_struct_component_type_override() {
 #[test]
 fn derive_unnamed_struct_component_type_override_with_format() {
     let value = api_doc! {
-        #[component(value_type = String, format = ComponentFormat::Byte)]
+        #[component(value_type = String, format = Byte)]
         struct Value(i64);
     };
 

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -71,7 +71,7 @@ use ext::ArgumentResolver;
 /// # Unnamed Field Struct Optional Configuration Options for `#[component(...)]`
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
 /// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
-/// * `format = ...` [`ComponentFormat`][format] to use for the property. By default the format is derived from
+/// * `format = ...` Any variant of a [`ComponentFormat`][format] to use for the property. By default the format is derived from
 ///   the type of the property according OpenApi spec.
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
 ///   This is useful in cases where the default type does not correspond to the actual type e.g. when
@@ -84,7 +84,7 @@ use ext::ArgumentResolver;
 /// # Named Fields Optional Configuration Options for `#[component(...)]`
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
 /// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
-/// * `format = ...` [`ComponentFormat`][format] to use for the property. By default the format is derived from
+/// * `format = ...` Any variant of a [`ComponentFormat`][format] to use for the property. By default the format is derived from
 ///   the type of the property according OpenApi spec.
 /// * `write_only` Defines property is only used in **write** operations *POST,PUT,PATCH* but not in *GET*
 /// * `read_only` Defines property is only used in **read** operations *GET* but not in *POST,PUT,PATCH*
@@ -302,7 +302,7 @@ use ext::ArgumentResolver;
 /// #[derive(Component)]
 /// struct Post {
 ///     id: i32,
-///     #[component(value_type = String, format = ComponentFormat::Binary)]
+///     #[component(value_type = String, format = Binary)]
 ///     value: Vec<u8>,
 /// }
 /// ```


### PR DESCRIPTION
Refactor ComponentFormat derive to behave similarly to the ParameterIn
and ParameterStyle derive allowing users to use only a variant of before
mentioned enums instead of the whole enum.