### PR TITLE
Into params inline

### DIFF
--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -410,6 +410,10 @@ fn derive_path_params_intoparams() {
         #[param(inline)]
         #[allow(unused)]
         foo_inline: Foo,
+        /// An optional Foo item inline.
+        #[param(inline)]
+        #[allow(unused)]
+        foo_inline_option: Option<Foo>,
     }
 
     #[utoipa::path(
@@ -482,6 +486,19 @@ fn derive_path_params_intoparams() {
                 "in": "query",
                 "name": "foo_inline",
                 "required": true,
+                "schema": {
+                    "default": "foo1",
+                    "example": "foo1",
+                    "enum": ["foo1", "foo2"],
+                    "type": "string",
+                },
+                "style": "form"
+            },
+            {
+                "description": "An optional Foo item inline.",
+                "in": "query",
+                "name": "foo_inline_option",
+                "required": false,
                 "schema": {
                     "default": "foo1",
                     "example": "foo1",

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -2,7 +2,7 @@
 use assert_json_diff::assert_json_eq;
 use paste::paste;
 use serde_json::{json, Value};
-use utoipa::IntoParams;
+use utoipa::{Component, IntoParams};
 
 mod common;
 
@@ -384,6 +384,14 @@ fn derive_path_with_parameter_inline_schema() {
 
 #[test]
 fn derive_path_params_intoparams() {
+    #[derive(serde::Deserialize, Component)]
+    #[component(default = "foo1", example = "foo1")]
+    #[serde(rename_all = "snake_case")]
+    enum Foo {
+        Foo1,
+        Foo2,
+    }
+
     #[derive(serde::Deserialize, IntoParams)]
     #[into_params(style = Form, parameter_in = Query)]
     struct MyParams {
@@ -395,6 +403,13 @@ fn derive_path_params_intoparams() {
         #[param(example = "2020-04-12T10:23:00Z")]
         #[allow(unused)]
         since: Option<String>,
+        /// A Foo item ref.
+        #[allow(unused)]
+        foo_ref: Foo,
+        /// A Foo item inline.
+        #[param(inline)]
+        #[allow(unused)]
+        foo_inline: Foo,
     }
 
     #[utoipa::path(
@@ -449,6 +464,29 @@ fn derive_path_params_intoparams() {
                 "required": false,
                 "schema": {
                     "type": "string"
+                },
+                "style": "form"
+            },
+            {
+                "description": "A Foo item ref.",
+                "in": "query",
+                "name": "foo_ref",
+                "required": true,
+                "schema": {
+                    "$ref": "#/components/schemas/Foo"
+                },
+                "style": "form"
+            },
+            {
+                "description": "A Foo item inline.",
+                "in": "query",
+                "name": "foo_inline",
+                "required": true,
+                "schema": {
+                    "default": "foo1",
+                    "example": "foo1",
+                    "enum": ["foo1", "foo2"],
+                    "type": "string",
                 },
                 "style": "form"
             },

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -414,6 +414,10 @@ fn derive_path_params_intoparams() {
         #[param(inline)]
         #[allow(unused)]
         foo_inline_option: Option<Foo>,
+        /// A vector of Foo item inline.
+        #[param(inline)]
+        #[allow(unused)]
+        foo_inline_vec: Vec<Foo>,
     }
 
     #[utoipa::path(
@@ -506,6 +510,22 @@ fn derive_path_params_intoparams() {
                     "type": "string",
                 },
                 "style": "form"
+            },
+            {
+                "description": "A vector of Foo item inline.",
+                "in": "query",
+                "name": "foo_inline_vec",
+                "required": true,
+                "schema": {
+                    "items": {
+                        "default": "foo1",
+                        "example": "foo1",
+                        "enum": ["foo1", "foo2"],
+                        "type": "string",
+                    },
+                    "type": "array",
+                },
+                "style": "form",
             },
             {
                 "deprecated": false,

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -936,6 +936,8 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// * `allow_reserved` Defines whether reserved characters _`:/?#[]@!$&'()*+,;=`_ is allowed within value.
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json] Given example
 ///   will override any example in underlying parameter type.
+/// * `inline` If set, the schema for this field's type needs to be a [`Component`][component], and
+///   the component schema definition will be inlined.
 ///
 /// **Note!** `#[into_params(...)]` is only supported on unnamed struct types to declare names for the arguments.
 ///
@@ -995,10 +997,17 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// Demonstrate [`IntoParams`][into_params] usage with the `#[param(...)]` container attribute to
-/// be used as a path query:
+/// be used as a path query, and inlining a component query field:
 /// ```rust
 /// use serde::Deserialize;
-/// use utoipa::IntoParams;
+/// use utoipa::{IntoParams, Component};
+///
+/// #[derive(Deserialize, Component)]
+/// #[serde(rename_all = "snake_case")]
+/// enum PetKind {
+///     Dog,
+///     Cat,
+/// }
 ///
 /// #[derive(Deserialize, IntoParams)]
 /// #[param(style = Form, parameter_in = Query)]
@@ -1007,6 +1016,9 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///     name: Option<String>,
 ///     /// Age of pet
 ///     age: Option<i32>,
+///     /// Kind of pet
+///     #[param(inline)]
+///     kind: PetKind
 /// }
 ///
 /// #[utoipa::path(
@@ -1021,7 +1033,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///     // ...
 /// }
 /// ```
-///
+/// [component]: trait.Component.html
 /// [into_params]: trait.IntoParams.html
 /// [path_params]: attr.path.html#params-attributes
 /// [struct]: https://doc.rust-lang.org/std/keyword.struct.html

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -313,6 +313,7 @@ pub struct ParameterExt {
     pub style: Option<ParameterStyle>,
     pub explode: Option<bool>,
     pub allow_reserved: Option<bool>,
+    pub inline: Option<bool>,
     pub(crate) example: Option<AnyValue>,
 }
 
@@ -339,11 +340,14 @@ impl ParameterExt {
         if from.example.is_some() {
             self.example = from.example
         }
+        if from.inline.is_some() {
+            self.inline = from.inline
+        }
     }
 
     fn parse_once(input: ParseStream) -> syn::Result<Self> {
         const EXPECTED_ATTRIBUTE_MESSAGE: &str =
-            "unexpected attribute, expected any of: style, explode, allow_reserved, example";
+            "unexpected attribute, expected any of: style, explode, allow_reserved, example, inline";
 
         let ident = input.parse::<Ident>().map_err(|error| {
             Error::new(
@@ -372,6 +376,10 @@ impl ParameterExt {
                 example: Some(parse_utils::parse_next(input, || {
                     AnyValue::parse_any(input)
                 })?),
+                ..Default::default()
+            },
+            "inline" => ParameterExt {
+                inline: Some(parse_utils::parse_bool_or_true(input)?),
                 ..Default::default()
             },
             _ => return Err(Error::new(ident.span(), EXPECTED_ATTRIBUTE_MESSAGE)),

--- a/utoipa-gen/src/schema/into_params.rs
+++ b/utoipa-gen/src/schema/into_params.rs
@@ -331,7 +331,11 @@ impl ToTokens for ParamType<'_> {
                     inline: self.inline,
                 };
 
-                tokens.extend(quote! { #param_type.to_array_builder() });
+                tokens.extend(quote! {
+                    utoipa::openapi::Component::Array(
+                        utoipa::openapi::ArrayBuilder::new().items(#param_type).build()
+                    )
+                });
             }
             None => match component.value_type {
                 ValueType::Primitive => {


### PR DESCRIPTION
Add inline option to params(...) struct field attribute for `#[derive(IntoParams)]`

This allows the schema for a type of a struct field to be inlined with
the `IntoParams` derive.

This work was sponsored by [Arctoris](https://www.arctoris.com/).