### PR TITLE
Add value_type for IntoParams

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,6 +1,10 @@
 #![cfg(feature = "serde_json")]
 use serde_json::Value;
 
+#[deprecated(
+    since = "2.0.0",
+    note = "Favor serde native `.pointer(...)` function over custom json path function"
+)]
 pub fn get_json_path<'a>(value: &'a Value, path: &str) -> &'a Value {
     path.split('.').into_iter().fold(value, |acc, fragment| {
         let value = if fragment.starts_with('[') && fragment.ends_with(']') {

--- a/utoipa-gen/src/schema/component/attr.rs
+++ b/utoipa-gen/src/schema/component/attr.rs
@@ -7,8 +7,8 @@ use syn::{parenthesized, parse::Parse, Attribute, Error, Token};
 
 use crate::{
     parse_utils,
-    schema::{ComponentPart, GenericType},
-    AnyValue, ValueType,
+    schema::{ComponentPart, GenericType, TypeToken},
+    AnyValue,
 };
 
 use super::xml::{Xml, XmlAttr};
@@ -74,7 +74,7 @@ impl IsInline for Struct {
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct UnnamedFieldStruct {
-    pub(super) value_type: Option<ValueType>,
+    pub(super) value_type: Option<TypeToken>,
     format: Option<ComponentFormat>,
     default: Option<AnyValue>,
     example: Option<AnyValue>,
@@ -90,7 +90,7 @@ impl IsInline for UnnamedFieldStruct {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct NamedField {
     example: Option<AnyValue>,
-    pub(super) value_type: Option<ValueType>,
+    pub(super) value_type: Option<TypeToken>,
     format: Option<ComponentFormat>,
     default: Option<AnyValue>,
     write_only: Option<bool>,
@@ -233,7 +233,7 @@ impl Parse for ComponentAttr<UnnamedFieldStruct> {
                 }
                 "value_type" => {
                     unnamed_struct.value_type = Some(parse_utils::parse_next(input, || {
-                        input.parse::<ValueType>()
+                        input.parse::<TypeToken>()
                     })?)
                 }
                 _ => return Err(Error::new(attribute.span(), EXPECTED_ATTRIBUTE_MESSAGE)),
@@ -343,7 +343,7 @@ impl Parse for ComponentAttr<NamedField> {
                 }
                 "value_type" => {
                     field.value_type = Some(parse_utils::parse_next(input, || {
-                        input.parse::<ValueType>()
+                        input.parse::<TypeToken>()
                     })?)
                 }
                 _ => return Err(Error::new(ident.span(), EXPECTED_ATTRIBUTE_MESSAGE)),


### PR DESCRIPTION
Add `value_type` attribute to `IntoParams` to allow users to override
parameter type with a custom type. Implements #165 and partly #191.

Implements #191 only for `IntoParams` type. Another PR is needed implement similar support for `Component`.
