### PR TITLE
Add enhanced value_type for Component

### DIFF
--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,4 +1,4 @@
-//! Rust implementation of Openapi Spec V3
+//! Rust implementation of Openapi Spec V3.
 
 use serde::{de::Visitor, Deserialize, Serialize, Serializer};
 

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,26 +1,6 @@
 #![cfg(feature = "serde_json")]
 use serde_json::Value;
 
-#[deprecated(
-    since = "2.0.0",
-    note = "Favor serde native `.pointer(...)` function over custom json path function"
-)]
-pub fn get_json_path<'a>(value: &'a Value, path: &str) -> &'a Value {
-    path.split('.').into_iter().fold(value, |acc, fragment| {
-        let value = if fragment.starts_with('[') && fragment.ends_with(']') {
-            let index = fragment
-                .replace('[', "")
-                .replace(']', "")
-                .parse::<usize>()
-                .unwrap();
-            acc.get(index)
-        } else {
-            acc.get(fragment)
-        };
-        value.unwrap_or(&serde_json::value::Value::Null)
-    })
-}
-
 pub fn value_as_string(value: Option<&'_ Value>) -> String {
     value.unwrap_or(&Value::Null).to_string()
 }
@@ -43,7 +23,8 @@ pub fn assert_json_array_len(value: &Value, len: usize) {
 macro_rules! assert_value {
     ($value:expr=> $( $path:literal = $expected:literal, $error:literal)* ) => {{
         $(
-            let actual = crate::common::value_as_string(Some(crate::common::get_json_path(&$value, $path)));
+            let p = &*format!("/{}", $path.replace(".", "/").replace("[", "").replace("]", ""));
+            let actual = crate::common::value_as_string(Some($value.pointer(p).unwrap_or(&serde_json::Value::Null)));
             assert_eq!(actual, $expected, "{}: {} expected to be: {} but was: {}", $error, $path, $expected, actual);
          )*
     }};
@@ -51,7 +32,8 @@ macro_rules! assert_value {
     ($value:expr=> $( $path:literal = $expected:expr, $error:literal)*) => {
         {
             $(
-                let actual = crate::common::get_json_path(&$value, $path);
+                let p = &*format!("/{}", $path.replace(".", "/").replace("[", "").replace("]", ""));
+                let actual = $value.pointer(p).unwrap_or(&serde_json::Value::Null);
                 assert!(actual == &$expected, "{}: {} expected to be: {:?} but was: {:?}", $error, $path, $expected, actual);
              )*
         }

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -9,8 +9,6 @@ use serde::Serialize;
 use serde_json::{json, Value};
 use utoipa::{Component, OpenApi};
 
-use crate::common::get_json_path;
-
 mod common;
 
 macro_rules! api_doc {
@@ -47,7 +45,8 @@ macro_rules! api_doc {
         struct ApiDoc;
 
         let json = serde_json::to_value(ApiDoc::openapi()).unwrap();
-        let component = get_json_path(&json, &format!("components.schemas.{}", stringify!($name)));
+
+        let component = json.pointer(&format!("/components/schemas/{}", stringify!($name))).unwrap_or(&serde_json::Value::Null);
 
         component.clone()
     }};
@@ -502,8 +501,8 @@ fn derive_with_box_and_refcell() {
     assert_value! {greeting=>
         "properties.foo.$ref" = r###""#/components/schemas/Foo""###, "Greeting foo field"
         "properties.ref_cell_foo.$ref" = r###""#/components/schemas/Foo""###, "Greeting ref_cell_foo field"
-        "required.[0]" = r###""foo""###, "Greeting required 0"
-        "required.[1]" = r###""ref_cell_foo""###, "Greeting required 1"
+        "required.0" = r###""foo""###, "Greeting required 0"
+        "required.1" = r###""ref_cell_foo""###, "Greeting required 1"
     };
 }
 
@@ -1390,8 +1389,96 @@ fn derive_component_with_aliases() {
     let doc = ApiDoc::openapi();
     let doc_value = &serde_json::to_value(doc).unwrap();
 
-    let value = common::get_json_path(doc_value, "components.schemas");
+    let value = doc_value.pointer("/components/schemas").unwrap();
     assert_value! {value=>
         "MyAlias.properties.bar.$ref" = r###""#/components/schemas/A""###, "MyAlias aliased property"
     }
+}
+
+#[test]
+fn derive_component_with_into_params_value_type() {
+    #[derive(Component)]
+    struct Foo {
+        #[allow(unused)]
+        value: String,
+    }
+
+    let doc = api_doc! {
+        #[allow(unused)]
+        struct Random {
+            #[component(value_type = i64)]
+            id: String,
+            #[component(value_type = Any)]
+            another_id: String,
+            #[component(value_type = Vec<Vec<String>>)]
+            value1: Vec<i64>,
+            #[component(value_type = Vec<String>)]
+            value2: Vec<i64>,
+            #[component(value_type = Option<String>)]
+            value3: i64,
+            #[component(value_type = Option<Any>)]
+            value4: i64,
+            #[component(value_type = Vec<Any>)]
+            value5: i64,
+            #[component(value_type = Vec<Foo>)]
+            value6: i64,
+        }
+    };
+
+    assert_json_eq!(
+        doc,
+        json!({
+            "properties": {
+                "another_id": {
+                    "type": "object"
+                },
+                "id": {
+                    "type": "integer",
+                    "format": "int64"
+                },
+                "value1": {
+                    "items": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "type": "array"
+                },
+                "value2": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "value3": {
+                    "type": "string"
+                },
+                "value4": {
+                    "type": "object"
+                },
+                "value5": {
+                    "items": {
+                        "type": "object"
+                    },
+                    "type": "array"
+                },
+                "value6": {
+                    "items": {
+                        "$ref": "#/components/schemas/Foo"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "id",
+                "another_id",
+                "value1",
+                "value2",
+                "value5",
+                "value6",
+            ],
+            "type": "object"
+        })
+    )
 }

--- a/tests/openapi_derive.rs
+++ b/tests/openapi_derive.rs
@@ -97,7 +97,7 @@ fn derive_openapi_with_components_in_different_module() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
-    let todo = common::get_json_path(&doc, "components.schemas.Todo");
+    let todo = doc.pointer("/components/schemas/Todo").unwrap();
 
     assert_ne!(
         todo,

--- a/tests/path_derive_actix.rs
+++ b/tests/path_derive_actix.rs
@@ -43,7 +43,7 @@ fn derive_path_one_value_actix_success() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}.get.parameters");
+    let parameters = doc.pointer("/paths/~1foo~1{id}/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_value! {parameters=>
@@ -86,7 +86,7 @@ fn derive_path_with_unnamed_regex_actix_success() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{arg0}.get.parameters");
+    let parameters = doc.pointer("/paths/~1foo~1{arg0}/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_value! {parameters=>
@@ -130,7 +130,7 @@ fn derive_path_with_named_regex_actix_success() {
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
-    let parameters = common::get_json_path(&doc, "paths./foo/{tail}.get.parameters");
+    let parameters = doc.pointer("/paths/~1foo~1{tail}/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_value! {parameters=>
@@ -168,7 +168,9 @@ fn derive_path_with_multiple_args() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/bar/{digest}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1bar~1{digest}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 2);
     assert_value! {parameters=>
@@ -214,7 +216,7 @@ fn derive_complex_actix_web_path() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}.get.parameters");
+    let parameters = doc.pointer("/paths/~1foo~1{id}/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_value! {parameters=>
@@ -256,7 +258,9 @@ fn derive_path_with_multiple_args_with_descriptions() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/bar/{digest}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1bar~1{digest}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 2);
     assert_value! {parameters=>
@@ -300,7 +304,7 @@ fn derive_path_with_context_path() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let path = common::get_json_path(&doc, "paths./api/foo.get");
+    let path = doc.pointer("/paths/~1api~1foo/get").unwrap();
 
     assert_ne!(path, &Value::Null, "expected path with context path /api");
 }
@@ -379,7 +383,9 @@ fn path_with_struct_variables_with_into_params() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/{name}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1{name}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 3);
     assert_value! {parameters=>
@@ -441,7 +447,9 @@ fn derive_path_with_struct_variables_with_into_params() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/{name}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1{name}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 3);
     assert_value! {parameters=>
@@ -509,8 +517,9 @@ fn derive_path_with_multiple_instances_same_path_params() {
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     for operation in ["get", "delete"] {
-        let parameters =
-            common::get_json_path(&doc, &format!("paths./foo/{{id}}.{operation}.parameters"));
+        let parameters = doc
+            .pointer(&*format!("/paths/~1foo~1{{id}}/{operation}/parameters"))
+            .unwrap();
 
         common::assert_json_array_len(parameters, 1);
         assert_value! {parameters=>
@@ -549,7 +558,9 @@ fn derive_path_with_multiple_into_params_names() {
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/{name}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1{name}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 2);
     assert_value! {parameters=>
@@ -615,7 +626,9 @@ fn derive_into_params_with_custom_attributes() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/{name}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1{name}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 4);
     assert_value! {parameters=>
@@ -694,7 +707,9 @@ fn derive_into_params_in_another_module() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./todo/foo/{id}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1todo~1foo~1{id}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_value! {parameters=>
@@ -731,8 +746,8 @@ macro_rules! test_derive_path_operations {
             let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
             let op_str = stringify!($operation);
-            let path = format!("paths./foo.{}", op_str);
-            let value = common::get_json_path(&doc, &path);
+            let path = format!("/paths/~1foo/{}", op_str);
+            let value = doc.pointer(&path).unwrap_or(&serde_json::Value::Null);
             assert!(value != &Value::Null, "expected to find operation with: {}", path);
         }
         )*

--- a/tests/path_derive_rocket.rs
+++ b/tests/path_derive_rocket.rs
@@ -26,7 +26,7 @@ fn resolve_route_with_simple_url() {
 
     let openapi = ApiDoc::openapi();
     let value = &serde_json::to_value(&openapi).unwrap();
-    let operation = common::get_json_path(value, "paths./hello.get");
+    let operation = value.pointer("/paths/~1hello/get").unwrap();
 
     assert_ne!(operation, &Value::Null, "expected paths.hello.get not null");
 }
@@ -52,7 +52,9 @@ fn resolve_get_with_multiple_args() {
 
     let openapi = ApiDoc::openapi();
     let value = &serde_json::to_value(&openapi).unwrap();
-    let parameters = common::get_json_path(value, r#"paths./hello/{id}/{name}.get.parameters"#);
+    let parameters = value
+        .pointer("/paths/~1hello~1{id}~1{name}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 3);
     assert_ne!(
@@ -107,7 +109,7 @@ fn resolve_get_with_optinal_query_args() {
 
     let openapi = ApiDoc::openapi();
     let value = &serde_json::to_value(&openapi).unwrap();
-    let parameters = common::get_json_path(value, r#"paths./hello.get.parameters"#);
+    let parameters = value.pointer("/paths/~1hello/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_ne!(
@@ -149,7 +151,9 @@ fn resolve_path_arguments_not_same_order() {
 
     let openapi = ApiDoc::openapi();
     let value = &serde_json::to_value(&openapi).unwrap();
-    let parameters = common::get_json_path(value, r#"paths./hello/{id}/{name}.get.parameters"#);
+    let parameters = value
+        .pointer("/paths/~1hello~1{id}~1{name}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 2);
     assert_ne!(
@@ -196,8 +200,9 @@ fn resolve_get_path_with_anonymous_parts() {
 
     let openapi = ApiDoc::openapi();
     let value = &serde_json::to_value(&openapi).unwrap();
-    let parameters =
-        common::get_json_path(value, r#"paths./hello/{arg0}/{arg1}/{id}.get.parameters"#);
+    let parameters = value
+        .pointer("/paths/~1hello~1{arg0}~1{arg1}~1{id}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 3);
     assert_ne!(
@@ -253,7 +258,9 @@ fn resolve_get_path_with_tail() {
 
     let openapi = ApiDoc::openapi();
     let value = &serde_json::to_value(&openapi).unwrap();
-    let parameters = common::get_json_path(value, r#"paths./hello/{tail}.get.parameters"#);
+    let parameters = value
+        .pointer("/paths/~1hello~1{tail}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_ne!(
@@ -298,7 +305,9 @@ fn resolve_get_path_and_update_params() {
 
     let openapi = ApiDoc::openapi();
     let value = &serde_json::to_value(&openapi).unwrap();
-    let parameters = common::get_json_path(value, r#"paths./hello/{id}/{name}.get.parameters"#);
+    let parameters = value
+        .pointer("/paths/~1hello~1{id}~1{name}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 2);
     assert_ne!(
@@ -352,8 +361,9 @@ macro_rules! test_derive_path_operations {
 
                 let openapi = ApiDoc::openapi();
                 let value = &serde_json::to_value(&openapi).unwrap();
-                let op =
-                    common::get_json_path(value, &format!("paths./hello.{}", stringify!($operation)));
+                let op = value
+                    .pointer(&*format!("/paths/~1hello/{}", stringify!($operation)))
+                    .unwrap();
 
                 assert_ne!(
                     op,

--- a/tests/path_parameter_derive_actix.rs
+++ b/tests/path_parameter_derive_actix.rs
@@ -37,7 +37,9 @@ fn derive_path_parameter_multiple_with_matching_names_and_types_actix_success() 
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/{digest}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1{digest}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 2);
     assert_value! {parameters=>
@@ -91,7 +93,9 @@ fn derive_path_parameter_multiple_no_matching_names_acitx_success() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/{digest}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1{digest}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 2);
     assert_value! {parameters=>
@@ -138,7 +142,9 @@ fn derive_params_from_method_args_actix_success() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/{digest}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1{digest}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 2);
     assert_value! {parameters=>

--- a/tests/path_parameter_derive_test.rs
+++ b/tests/path_parameter_derive_test.rs
@@ -32,7 +32,7 @@ fn derive_path_parameters_with_all_options_success() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}.get.parameters");
+    let parameters = doc.pointer("/paths/~1foo~1{id}/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_value! {parameters=>
@@ -73,7 +73,7 @@ fn derive_path_parameters_minimal_success() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}.get.parameters");
+    let parameters = doc.pointer("/paths/~1foo~1{id}/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_value! {parameters=>
@@ -115,7 +115,9 @@ fn derive_path_parameter_multiple_success() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}/{digest}.get.parameters");
+    let parameters = doc
+        .pointer("/paths/~1foo~1{id}~1{digest}/get/parameters")
+        .unwrap();
 
     common::assert_json_array_len(parameters, 2);
     assert_value! {parameters=>
@@ -168,7 +170,7 @@ fn derive_parameters_with_all_types() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}.get.parameters");
+    let parameters = doc.pointer("/paths/~1foo~1{id}/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 5);
     assert_value! {parameters=>
@@ -240,7 +242,7 @@ fn derive_params_without_fn_args() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo/{id}.get.parameters");
+    let parameters = doc.pointer("/paths/~1foo~1{id}/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_value! {parameters=>
@@ -276,7 +278,7 @@ fn derive_params_with_params_ext() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let parameters = common::get_json_path(&doc, "paths./foo.get.parameters");
+    let parameters = doc.pointer("/paths/~1foo/get/parameters").unwrap();
 
     common::assert_json_array_len(parameters, 1);
     assert_value! {parameters=>

--- a/tests/path_response_derive_test.rs
+++ b/tests/path_response_derive_test.rs
@@ -28,7 +28,9 @@ macro_rules! api_doc {
         struct ApiDoc;
 
         let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
-        common::get_json_path(&doc, "paths./foo.get").clone()
+        doc.pointer("/paths/~1foo/get")
+            .unwrap_or(&serde_json::Value::Null)
+            .clone()
     }};
 }
 
@@ -114,50 +116,50 @@ macro_rules! test_response_types {
 
 test_response_types! {
 primitive_string_body => body: String, assert:
-    "responses.200.content.text/plain.schema.type" = r#""string""#, "Response content type"
+    "responses.200.content.text~1plain.schema.type" = r#""string""#, "Response content type"
     "responses.200.headers" = r###"null"###, "Response headers"
 primitive_string_sclice_body => body: [String], assert:
-    "responses.200.content.text/plain.schema.items.type" = r#""string""#, "Response content items type"
-    "responses.200.content.text/plain.schema.type" = r#""array""#, "Response content type"
+    "responses.200.content.text~1plain.schema.items.type" = r#""string""#, "Response content items type"
+    "responses.200.content.text~1plain.schema.type" = r#""array""#, "Response content type"
     "responses.200.headers" = r###"null"###, "Response headers"
 primitive_integer_slice_body => body: [i32], assert:
-    "responses.200.content.text/plain.schema.items.type" = r#""integer""#, "Response content items type"
-    "responses.200.content.text/plain.schema.items.format" = r#""int32""#, "Response content items format"
-    "responses.200.content.text/plain.schema.type" = r#""array""#, "Response content type"
+    "responses.200.content.text~1plain.schema.items.type" = r#""integer""#, "Response content items type"
+    "responses.200.content.text~1plain.schema.items.format" = r#""int32""#, "Response content items format"
+    "responses.200.content.text~1plain.schema.type" = r#""array""#, "Response content type"
     "responses.200.headers" = r###"null"###, "Response headers"
 primitive_integer_body => body: i64, assert:
-    "responses.200.content.text/plain.schema.type" = r#""integer""#, "Response content type"
-    "responses.200.content.text/plain.schema.format" = r#""int64""#, "Response content format"
+    "responses.200.content.text~1plain.schema.type" = r#""integer""#, "Response content type"
+    "responses.200.content.text~1plain.schema.format" = r#""int64""#, "Response content format"
     "responses.200.headers" = r###"null"###, "Response headers"
 primitive_big_integer_body => body: u128, assert:
-    "responses.200.content.text/plain.schema.type" = r#""integer""#, "Response content type"
-    "responses.200.content.text/plain.schema.format" = r#"null"#, "Response content format"
+    "responses.200.content.text~1plain.schema.type" = r#""integer""#, "Response content type"
+    "responses.200.content.text~1plain.schema.format" = r#"null"#, "Response content format"
     "responses.200.headers" = r###"null"###, "Response headers"
 primitive_bool_body => body: bool, assert:
-    "responses.200.content.text/plain.schema.type" = r#""boolean""#, "Response content type"
+    "responses.200.content.text~1plain.schema.type" = r#""boolean""#, "Response content type"
     "responses.200.headers" = r###"null"###, "Response headers"
 object_body => body: Foo, assert:
-    "responses.200.content.application/json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
+    "responses.200.content.application~1json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
     "responses.200.headers" = r###"null"###, "Response headers"
 object_slice_body => body: [Foo], assert:
-    "responses.200.content.application/json.schema.type" = r###""array""###, "Response content type"
-    "responses.200.content.application/json.schema.items.$ref" = r###""#/components/schemas/Foo""###, "Response content items type"
+    "responses.200.content.application~1json.schema.type" = r###""array""###, "Response content type"
+    "responses.200.content.application~1json.schema.items.$ref" = r###""#/components/schemas/Foo""###, "Response content items type"
     "responses.200.headers" = r###"null"###, "Response headers"
 object_body_override_content_type_to_xml => body: Foo, "text/xml", assert:
-    "responses.200.content.application/json.schema.$ref" = r###"null"###, "Response content type"
-    "responses.200.content.text/xml.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
+    "responses.200.content.application~1json.schema.$ref" = r###"null"###, "Response content type"
+    "responses.200.content.text~1xml.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
     "responses.200.headers" = r###"null"###, "Response headers"
 object_body_with_simple_header => body: Foo, headers: (
     ("xsrf-token")
 ), assert:
-    "responses.200.content.application/json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
+    "responses.200.content.application~1json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
     "responses.200.headers.xsrf-token.schema.type" = r###""string""###, "xsrf-token header type"
     "responses.200.headers.xsrf-token.description" = r###"null"###, "xsrf-token header description"
 object_body_with_multiple_headers => body: Foo, headers: (
     ("xsrf-token"),
     ("another-header")
 ), assert:
-    "responses.200.content.application/json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
+    "responses.200.content.application~1json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
     "responses.200.headers.xsrf-token.schema.type" = r###""string""###, "xsrf-token header type"
     "responses.200.headers.xsrf-token.description" = r###"null"###, "xsrf-token header description"
     "responses.200.headers.another-header.schema.type" = r###""string""###, "another-header header type"
@@ -165,7 +167,7 @@ object_body_with_multiple_headers => body: Foo, headers: (
 object_body_with_header_with_type => body: Foo, headers: (
     ("random-digits" = [u64]),
 ), assert:
-    "responses.200.content.application/json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
+    "responses.200.content.application~1json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content type"
     "responses.200.headers.random-digits.schema.type" = r###""array""###, "random-digits header type"
     "responses.200.headers.random-digits.description" = r###"null"###, "random-digits header description"
     "responses.200.headers.random-digits.schema.items.type" = r###""integer""###, "random-digits header items type"
@@ -193,8 +195,8 @@ fn derive_response_with_json_example_success() {
 
     assert_value! {doc=>
         "responses.200.description" = r#""success""#, "Response description"
-        "responses.200.content.application/json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content ref"
-        "responses.200.content.application/json.example" = r###"{"foo":"bar"}"###, "Response content example"
+        "responses.200.content.application~1json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content ref"
+        "responses.200.content.application~1json.example" = r###"{"foo":"bar"}"###, "Response content example"
         "responses.200.headers" = r#"null"#, "Response headers"
     }
 }
@@ -212,10 +214,10 @@ fn derive_reponse_multiple_content_types() {
 
     assert_value! {doc=>
         "responses.200.description" = r#""success""#, "Response description"
-        "responses.200.content.application/json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content ref"
-        "responses.200.content.text/xml.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content ref"
-        "responses.200.content.application/json.example" = r###"null"###, "Response content example"
-        "responses.200.content.text/xml.example" = r###"null"###, "Response content example"
+        "responses.200.content.application~1json.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content ref"
+        "responses.200.content.text~1xml.schema.$ref" = r###""#/components/schemas/Foo""###, "Response content ref"
+        "responses.200.content.application~1json.example" = r###"null"###, "Response content example"
+        "responses.200.content.text~1xml.example" = r###"null"###, "Response content example"
         "responses.200.headers" = r#"null"#, "Response headers"
     }
 }

--- a/tests/request_body_derive_test.rs
+++ b/tests/request_body_derive_test.rs
@@ -42,10 +42,10 @@ fn derive_path_request_body_simple_success() {
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
-        "paths./foo.post.requestBody.content.application/json.schema.$ref" = r###""#/components/schemas/Foo""###, "Request body content object type"
-        "paths./foo.post.requestBody.content.text/plain" = r###"null"###, "Request body content object type not text/plain"
-        "paths./foo.post.requestBody.required" = r###"true"###, "Request body required"
-        "paths./foo.post.requestBody.description" = r###"null"###, "Request body description"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.$ref" = r###""#/components/schemas/Foo""###, "Request body content object type"
+        "paths.~1foo.post.requestBody.content.text~1plain" = r###"null"###, "Request body content object type not text/plain"
+        "paths.~1foo.post.requestBody.required" = r###"true"###, "Request body required"
+        "paths.~1foo.post.requestBody.description" = r###"null"###, "Request body description"
     }
 }
 
@@ -63,12 +63,12 @@ fn derive_path_request_body_simple_array_success() {
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
-        "paths./foo.post.requestBody.content.application/json.schema.$ref" = r###"null"###, "Request body content object type"
-        "paths./foo.post.requestBody.content.application/json.schema.items.$ref" = r###""#/components/schemas/Foo""###, "Request body content items object type"
-        "paths./foo.post.requestBody.content.application/json.schema.type" = r###""array""###, "Request body content items type"
-        "paths./foo.post.requestBody.content.text/plain" = r###"null"###, "Request body content object type not text/plain"
-        "paths./foo.post.requestBody.required" = r###"true"###, "Request body required"
-        "paths./foo.post.requestBody.description" = r###"null"###, "Request body description"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.$ref" = r###"null"###, "Request body content object type"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.items.$ref" = r###""#/components/schemas/Foo""###, "Request body content items object type"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.type" = r###""array""###, "Request body content items type"
+        "paths.~1foo.post.requestBody.content.text~1plain" = r###"null"###, "Request body content object type not text/plain"
+        "paths.~1foo.post.requestBody.required" = r###"true"###, "Request body required"
+        "paths.~1foo.post.requestBody.description" = r###"null"###, "Request body description"
     }
 }
 
@@ -86,12 +86,12 @@ fn derive_request_body_option_array_success() {
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
-        "paths./foo.post.requestBody.content.application/json.schema.$ref" = r###"null"###, "Request body content object type"
-        "paths./foo.post.requestBody.content.application/json.schema.items.$ref" = r###""#/components/schemas/Foo""###, "Request body content items object type"
-        "paths./foo.post.requestBody.content.application/json.schema.type" = r###""array""###, "Request body content items type"
-        "paths./foo.post.requestBody.content.text/plain" = r###"null"###, "Request body content object type not text/plain"
-        "paths./foo.post.requestBody.required" = r###"false"###, "Request body required"
-        "paths./foo.post.requestBody.description" = r###"null"###, "Request body description"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.$ref" = r###"null"###, "Request body content object type"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.items.$ref" = r###""#/components/schemas/Foo""###, "Request body content items object type"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.type" = r###""array""###, "Request body content items type"
+        "paths.~1foo.post.requestBody.content.text~1plain" = r###"null"###, "Request body content object type not text/plain"
+        "paths.~1foo.post.requestBody.required" = r###"false"###, "Request body required"
+        "paths.~1foo.post.requestBody.description" = r###"null"###, "Request body description"
     }
 }
 test_fn! {
@@ -108,12 +108,12 @@ fn derive_request_body_primitive_simple_success() {
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
-        "paths./foo.post.requestBody.content.application/json.schema.$ref" = r###"null"###, "Request body content object type not application/json"
-        "paths./foo.post.requestBody.content.application/json.schema.items.$ref" = r###"null"###, "Request body content items object type"
-        "paths./foo.post.requestBody.content.application/json.schema.type" = r###"null"###, "Request body content items type"
-        "paths./foo.post.requestBody.content.text/plain.schema.type" = r###""string""###, "Request body content object type"
-        "paths./foo.post.requestBody.required" = r###"true"###, "Request body required"
-        "paths./foo.post.requestBody.description" = r###"null"###, "Request body description"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.$ref" = r###"null"###, "Request body content object type not application/json"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.items.$ref" = r###"null"###, "Request body content items object type"
+        "paths.~1foo.post.requestBody.content.application~1json.schema.type" = r###"null"###, "Request body content items type"
+        "paths.~1foo.post.requestBody.content.text~1plain.schema.type" = r###""string""###, "Request body content object type"
+        "paths.~1foo.post.requestBody.required" = r###"true"###, "Request body required"
+        "paths.~1foo.post.requestBody.description" = r###"null"###, "Request body description"
     }
 }
 
@@ -131,12 +131,12 @@ fn derive_request_body_primitive_array_success() {
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
-        "paths./foo.post.requestBody.content.application/json" = r###"null"###, "Request body content object type not application/json"
-        "paths./foo.post.requestBody.content.text/plain.schema.type" = r###""array""###, "Request body content object item type"
-        "paths./foo.post.requestBody.content.text/plain.schema.items.type" = r###""integer""###, "Request body content items object type"
-        "paths./foo.post.requestBody.content.text/plain.schema.items.format" = r###""int64""###, "Request body content items object format"
-        "paths./foo.post.requestBody.required" = r###"true"###, "Request body required"
-        "paths./foo.post.requestBody.description" = r###"null"###, "Request body description"
+        "paths.~1foo.post.requestBody.content.application~1json" = r###"null"###, "Request body content object type not application/json"
+        "paths.~1foo.post.requestBody.content.text~1plain.schema.type" = r###""array""###, "Request body content object item type"
+        "paths.~1foo.post.requestBody.content.text~1plain.schema.items.type" = r###""integer""###, "Request body content items object type"
+        "paths.~1foo.post.requestBody.content.text~1plain.schema.items.format" = r###""int64""###, "Request body content items object format"
+        "paths.~1foo.post.requestBody.required" = r###"true"###, "Request body required"
+        "paths.~1foo.post.requestBody.description" = r###"null"###, "Request body description"
     }
 }
 
@@ -343,12 +343,12 @@ fn derive_request_body_complex_required_explisit_false_success() {
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
-        "paths./foo.post.requestBody.content.application/json" = r###"null"###, "Request body content object type not application/json"
-        "paths./foo.post.requestBody.content.text/xml.schema.$ref" = r###""#/components/schemas/Foo""###, "Request body content object type"
-        "paths./foo.post.requestBody.content.text/plain.schema.type" = r###"null"###, "Request body content object item type"
-        "paths./foo.post.requestBody.content.text/plain.schema.items.type" = r###"null"###, "Request body content items object type"
-        "paths./foo.post.requestBody.required" = r###"false"###, "Request body required"
-        "paths./foo.post.requestBody.description" = r###""Create new Foo""###, "Request body description"
+        "paths.~1foo.post.requestBody.content.application~1json" = r###"null"###, "Request body content object type not application/json"
+        "paths.~1foo.post.requestBody.content.text~1xml.schema.$ref" = r###""#/components/schemas/Foo""###, "Request body content object type"
+        "paths.~1foo.post.requestBody.content.text~1plain.schema.type" = r###"null"###, "Request body content object item type"
+        "paths.~1foo.post.requestBody.content.text~1plain.schema.items.type" = r###"null"###, "Request body content items object type"
+        "paths.~1foo.post.requestBody.required" = r###"false"###, "Request body required"
+        "paths.~1foo.post.requestBody.description" = r###""Create new Foo""###, "Request body description"
     }
 }
 
@@ -366,11 +366,11 @@ fn derive_request_body_complex_primitive_array_success() {
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
-        "paths./foo.post.requestBody.content.application/json" = r###"null"###, "Request body content object type not application/json"
-        "paths./foo.post.requestBody.content.text/plain.schema.type" = r###""array""###, "Request body content object item type"
-        "paths./foo.post.requestBody.content.text/plain.schema.items.type" = r###""integer""###, "Request body content items object type"
-        "paths./foo.post.requestBody.content.text/plain.schema.items.format" = r###""int32""###, "Request body content items object format"
-        "paths./foo.post.requestBody.required" = r###"true"###, "Request body required"
-        "paths./foo.post.requestBody.description" = r###""Create new foo references""###, "Request body description"
+        "paths.~1foo.post.requestBody.content.application~1json" = r###"null"###, "Request body content object type not application/json"
+        "paths.~1foo.post.requestBody.content.text~1plain.schema.type" = r###""array""###, "Request body content object item type"
+        "paths.~1foo.post.requestBody.content.text~1plain.schema.items.type" = r###""integer""###, "Request body content items object type"
+        "paths.~1foo.post.requestBody.content.text~1plain.schema.items.format" = r###""int32""###, "Request body content items object format"
+        "paths.~1foo.post.requestBody.required" = r###"true"###, "Request body required"
+        "paths.~1foo.post.requestBody.description" = r###""Create new foo references""###, "Request body description"
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -43,7 +43,7 @@ use ext::ArgumentResolver;
 
 #[proc_macro_error]
 #[proc_macro_derive(Component, attributes(component, aliases))]
-/// Component derive macro
+/// Component derive macro.
 ///
 /// This is `#[derive]` implementation for [`Component`][c] trait. The macro accepts one `component`
 /// attribute optionally which can be used to enhance generated documentation. The attribute can be placed
@@ -75,11 +75,8 @@ use ext::ArgumentResolver;
 ///   the type of the property according OpenApi spec.
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
 ///   This is useful in cases where the default type does not correspond to the actual type e.g. when
-///   any third-party types are used which are not components nor primitive types.
-///   Allowed one of a [`primitive`][primitive], [`std::string::String`], `Any`, or another [`Component`][c].
-///   Using type which is a [`Component`][c] will create a OpenAPI reference (_`$ref`_) to the `value_type` instead of the
-///   actual type of the field. `Any` type will render as a generic `object` type in OpenAPI spec.
-///   Types with generics are not allowed.
+///   any third-party types are used which are not [`Component`][c]s nor [`primitive` types][primitive].
+///    Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Any`_.
 ///
 /// # Named Fields Optional Configuration Options for `#[component(...)]`
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
@@ -90,12 +87,9 @@ use ext::ArgumentResolver;
 /// * `read_only` Defines property is only used in **read** operations *GET* but not in *POST,PUT,PATCH*
 /// * `xml(...)` Can be used to define [`Xml`][xml] object properties applicable to named fields.
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
-///   This is useful in cases the where default type does not correspond to the actual type e.g. when
-///   any third-party types are used which are not components nor primitive types.
-///   Allowed one of a [`primitive`][primitive], [`std::string::String`], `Any`, or another [`Component`][c].
-///   Using type which is a [`Component`][c] will create a OpenAPI reference (_`$ref`_) to the `value_type` instead of the
-///   actual type of the field. `Any` type will render as a generic `object` type in OpenAPI spec.
-///   Types with generics are not allowed.
+///   This is useful in cases where the default type does not correspond to the actual type e.g. when
+///   any third-party types are used which are not [`Component`][c]s nor [`primitive` types][primitive].
+///    Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Any`_.
 /// * `inline` If the type of this field implements [`Component`][c], then the schema definition
 ///   will be inlined. **warning:** Don't use this for recursive data types!
 ///
@@ -347,10 +341,13 @@ use ext::ArgumentResolver;
 /// };
 /// ```
 ///
+/// More examples for _`value_type`_ in [`IntoParams` derive docs][into_params].
+///
 /// [c]: trait.Component.html
 /// [format]: openapi/schema/enum.ComponentFormat.html
 /// [binary]: openapi/schema/enum.ComponentFormat.html#variant.Binary
 /// [xml]: openapi/xml/struct.Xml.html
+/// [into_params]: derive.IntoParams.html
 /// [primitive]: https://doc.rust-lang.org/std/primitive/index.html
 pub fn derive_component(input: TokenStream) -> TokenStream {
     let DeriveInput {
@@ -368,7 +365,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 
 #[proc_macro_error]
 #[proc_macro_attribute]
-/// Path attribute macro
+/// Path attribute macro.
 ///
 /// This is a `#[derive]` implementation for [`Path`][path] trait. Macro accepts set of attributes that can
 /// be used to configure and override default values what are resolved automatically.
@@ -798,7 +795,7 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 #[proc_macro_error]
 #[proc_macro_derive(OpenApi, attributes(openapi))]
-/// OpenApi derive macro
+/// OpenApi derive macro.
 ///
 /// This is `#[derive]` implementation for [`OpenApi`][openapi] trait. The macro accepts one `openapi` argument.
 ///
@@ -897,7 +894,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 
 #[proc_macro_error]
 #[proc_macro_derive(IntoParams, attributes(param, into_params))]
-/// IntoParams derive macro for **actix-web** only.
+/// IntoParams derive macro.
 ///
 /// This is `#[derive]` implementation for [`IntoParams`][into_params] trait.
 ///

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -58,19 +58,6 @@ impl<'a> ComponentPart<'a> {
         }
     }
 
-    fn from_ident(ty: &'a Ident) -> ComponentPart<'a> {
-        ComponentPart {
-            child: None,
-            generic_type: None,
-            ident: ty,
-            value_type: if ComponentType(ty).is_primitive() {
-                ValueType::Primitive
-            } else {
-                ValueType::Object
-            },
-        }
-    }
-
     fn from_type_path(
         type_path: &'a TypePath,
         op: impl Fn(&'a Ident, &'a PathSegment) -> ComponentPart<'a>,
@@ -222,12 +209,6 @@ enum GenericType {
 struct TypeToken(Type);
 
 impl TypeToken {
-    /// Get the `Ident` of last segment of the [`syn::TypePath`].
-    #[deprecated = "For removal after refactoring value type logic for component"]
-    fn get_ident(&self) -> Option<&Ident> {
-        Some(self.get_component_part().ident)
-    }
-
     /// Get the [`ComponentPart`] of the [`syn::Type`].
     fn get_component_part(&self) -> ComponentPart<'_> {
         ComponentPart::from_type(&self.0)

--- a/utoipa-gen/src/schema/into_params.rs
+++ b/utoipa-gen/src/schema/into_params.rs
@@ -445,13 +445,8 @@ impl ToTokens for ParamType<'_> {
                                 utoipa::openapi::ObjectBuilder::new()
                             });
                         } else {
-                            let assert_component = format_ident!("_Assert{}", name);
-                            tokens.extend(quote_spanned! {type_ident.span()=>
-                                {
-                                    struct #assert_component where #type_ident : utoipa::Component;
-
-                                    utoipa::openapi::Ref::from_component_name(#name)
-                                }
+                            tokens.extend(quote! {
+                                utoipa::openapi::Ref::from_component_name(#name)
                             });
                         }
                     }


### PR DESCRIPTION
Allow similar `value_type` for Component as IntoParams. Preivously
value_type was limited to certain types (namely primitive types, String,
Any or another Component).

From now onwards the type can be any Rust type which can be serialized
as JSON including previously supported types.

Also this commit adds refactoring to some tests and will remove `get_json_path`
function from tests in favor of serde `pointer()` method.

Implements #191 