### PR TITLE
Add axum Swagger UI integration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,5 +71,5 @@ jobs:
         elif [[ "${{ matrix.testset }}" == "utoipa-gen" ]] && [[ ${{ steps.changes.outputs.gen_changed }} == true ]]; then
           cargo test -p utoipa-gen --features utoipa/actix_extras
         elif [[ "${{ matrix.testset }}" == "utoipa-swagger-ui" ]] && [[ ${{ steps.changes.outputs.swagger_changed }} == true ]]; then
-          cargo test -p utoipa-swagger-ui --features actix-web,rocket
+          cargo test -p utoipa-swagger-ui --features actix-web,rocket,axum
         fi

--- a/examples/todo-axum/Cargo.toml
+++ b/examples/todo-axum/Cargo.toml
@@ -16,7 +16,7 @@ hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1.17", features = ["full"] }
 tower = "0.4"
 utoipa = { path = "../.." }
-utoipa-swagger-ui = { path = "../../utoipa-swagger-ui" }
+utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["axum"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 env_logger = "0.9.0"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -15,5 +15,5 @@ if [[ "$crate" == "utoipa" ]]; then
   elif [[ "$crate" == "utoipa-gen" ]]; then
   cargo test -p utoipa-gen --features utoipa/actix_extras
   elif [[ "$crate" == "utoipa-swagger-ui" ]]; then
-  cargo test -p utoipa-swagger-ui --features actix-web,rocket
+  cargo test -p utoipa-swagger-ui --features actix-web,rocket,axum
 fi

--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -20,6 +20,7 @@ rust-embed = { version = "6.3", features = ["interpolate-folder-path"] }
 mime_guess = { version = "2.0" }
 actix-web =  { version = "4", optional = true }
 rocket = { version = "0.5.0-rc.1", features = ["json"], optional = true }
+axum = { version = "0.5", optional = true }
 utoipa = { version = "1", path = "..", default-features = false, features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/utoipa-swagger-ui/README.md
+++ b/utoipa-swagger-ui/README.md
@@ -13,6 +13,7 @@ works as a bridge for serving the OpenAPI documetation created with
 
 * **actix-web** `version >= 4`
 * **rocket** `version >=0.5.0-rc.1`
+* **axum** `version >=0.5`
 
 Serving Swagger UI is framework independant thus this crate also supports serving the Swagger UI with
 other frameworks as well. With other frameworks there is bit more manual implementation to be done. See
@@ -25,6 +26,8 @@ more details at [serve](https://docs.rs/utoipa-swagger-ui/1.1.0/utoipa_swagger_u
   users to use the Swagger UI without a hazzle.
 * **rocket** Enables rocket integration with with pre-configured routes for serving the Swagger UI 
   and api doc without a hazzle.
+* **axum** Enables `axum` integration with pre-configured Router serving Swagger UI and OpenAPI specs
+  hazzle free.
 
 # Install
 
@@ -44,7 +47,7 @@ utoipa-swagger-ui = { version = "1", features = ["actix-web"] }
 
 # Examples
 
-Serve Swagger UI with api doc via actix-web. 
+Serve Swagger UI with api doc via **`actix-web`**. See full example from [exmaples](https://github.com/juhaku/utoipa/tree/master/examples/todo-actix).
 ```rust
 HttpServer::new(move || {
     App::new()
@@ -56,9 +59,8 @@ HttpServer::new(move || {
   .bind((Ipv4Addr::UNSPECIFIED, 8989)).unwrap()
   .run();
 ```
-**actix-web** feature need to be enabled.
 
-Serve Swagger UI with api doc via rocket.
+Serve Swagger UI with api doc via **`rocket`**. See full example from [examples](https://github.com/juhaku/utoipa/tree/master/examples/rocket-todo).
 ```rust
 #[rocket::launch]
 fn rocket() -> Rocket<Build> {
@@ -70,7 +72,14 @@ fn rocket() -> Rocket<Build> {
         )
 }
 ```
-**rocket** feature need to be enabled.
+
+Setup Router to serve Swagger UI with **`axum`** framework. See full implementation of how to serve
+Swagger UI with axum from [examples](https://github.com/juhaku/utoipa/tree/master/examples/todo-axum).
+```rust
+let app = Router::new()
+    .merge(SwaggerUi::new("/swagger-ui/*tail")
+        .url("/api-doc/openapi.json", ApiDoc::openapi()));
+```
 
 # License
 

--- a/utoipa-swagger-ui/src/axum.rs
+++ b/utoipa-swagger-ui/src/axum.rs
@@ -1,0 +1,66 @@
+#![cfg(feature = "axum")]
+
+use std::sync::Arc;
+
+use axum::{
+    body::HttpBody, extract::Path, http::StatusCode, response::IntoResponse, routing, Extension,
+    Json, Router,
+};
+
+use crate::{Config, SwaggerUi, Url};
+
+impl<B> From<SwaggerUi> for Router<B>
+where
+    B: HttpBody + Send + 'static,
+{
+    fn from(swagger_ui: SwaggerUi) -> Self {
+        let urls_capacity = swagger_ui.urls.len();
+
+        let (router, urls) = swagger_ui.urls.into_iter().fold(
+            (Router::<B>::new(), Vec::<Url>::with_capacity(urls_capacity)),
+            |(router, mut urls), url| {
+                let (url, openapi) = url;
+                (
+                    router.route(
+                        url.url.as_ref(),
+                        routing::get(move || async { Json(openapi) }),
+                    ),
+                    {
+                        urls.push(url);
+                        urls
+                    },
+                )
+            },
+        );
+
+        let config = if let Some(config) = swagger_ui.config {
+            config.configure_defaults(urls)
+        } else {
+            Config::new(urls)
+        };
+
+        router.route(
+            swagger_ui.path.as_ref(),
+            routing::get(serve_swagger_ui).layer(Extension(Arc::new(config))),
+        )
+    }
+}
+
+async fn serve_swagger_ui(
+    Path(tail): Path<String>,
+    Extension(state): Extension<Arc<Config<'static>>>,
+) -> impl IntoResponse {
+    match super::serve(&tail[1..], state) {
+        Ok(file) => file
+            .map(|file| {
+                (
+                    StatusCode::OK,
+                    [("Content-Type", file.content_type)],
+                    file.bytes,
+                )
+                    .into_response()
+            })
+            .unwrap_or_else(|| StatusCode::NOT_FOUND.into_response()),
+        Err(error) => (StatusCode::INTERNAL_SERVER_ERROR, error.to_string()).into_response(),
+    }
+}


### PR DESCRIPTION
Add `SwaggerUi` integration for axum to allow axum users to serve
Swagger UI with ease just by creating an instance of a `SwaggerUi` type
similar fashion to `actix-web` and `rocket` frameworks.

This commit will make it possible to merge SwaggerUi with existing axum
Router.
```rust
let app = Router::new()
    .merge(SwaggerUi::new("/swagger-ui/*tail")
        .url("/api-doc/openapi.json", ApiDoc::openapi()));
```

Also this commit will update the existing axum-todo example with the
new functionality and update the docs.

Implements partly #123 