### PR TITLE
Add support for title

### DIFF
--- a/src/openapi/schema.rs
+++ b/src/openapi/schema.rs
@@ -287,6 +287,10 @@ pub struct Property {
     #[serde(rename = "type")]
     pub component_type: ComponentType,
 
+    /// Changes the [`Property`] title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+
     /// Additional format for detailing the component type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub format: Option<ComponentFormat>,
@@ -358,6 +362,8 @@ impl ToArray for Property {}
 pub struct PropertyBuilder {
     component_type: ComponentType,
 
+    title: Option<String>,
+
     format: Option<ComponentFormat>,
 
     description: Option<String>,
@@ -386,7 +392,7 @@ pub struct PropertyBuilder {
 }
 
 from!(Property PropertyBuilder
-    component_type, format, description, default, enum_values, example, deprecated, write_only, read_only, xml);
+    component_type, title, format, description, default, enum_values, example, deprecated, write_only, read_only, xml);
 
 impl PropertyBuilder {
     new!(pub PropertyBuilder);
@@ -394,6 +400,11 @@ impl PropertyBuilder {
     /// Add or change type of the property e.g [`ComponentType::String`].
     pub fn component_type(mut self, component_type: ComponentType) -> Self {
         set_value!(self component_type component_type)
+    }
+
+    /// Add or change the title of the [`Property`].
+    pub fn title<I: Into<String>>(mut self, title: Option<I>) -> Self {
+        set_value!(self title title.map(|title| title.into()))
     }
 
     /// Add or change additional format for detailing the component type.
@@ -462,7 +473,7 @@ impl PropertyBuilder {
     to_array_builder!();
 
     build_fn!(pub Property
-        component_type, format, description, default, enum_values, example, deprecated, write_only, read_only, xml);
+        component_type, title, format, description, default, enum_values, example, deprecated, write_only, read_only, xml);
 }
 
 component_from_builder!(PropertyBuilder);
@@ -479,6 +490,10 @@ pub struct Object {
     /// Data type of [`Object`]. Will always be [`ComponentType::Object`]
     #[serde(rename = "type")]
     component_type: ComponentType,
+
+    /// Changes the [`Object`] title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
 
     /// Vector of required field names.
     #[serde(skip_serializing_if = "Vec::is_empty")]
@@ -539,6 +554,8 @@ impl ToArray for Object {}
 pub struct ObjectBuilder {
     component_type: ComponentType,
 
+    title: Option<String>,
+
     required: Vec<String>,
 
     properties: BTreeMap<String, Component>,
@@ -589,6 +606,11 @@ impl ObjectBuilder {
         self
     }
 
+    /// Add or change the title of the [`Object`].
+    pub fn title<I: Into<String>>(mut self, title: Option<I>) -> Self {
+        set_value!(self title title.map(|title| title.into()))
+    }
+
     /// Add or change description of the property. Markdown syntax is supported.
     pub fn description<I: Into<String>>(mut self, description: Option<I>) -> Self {
         set_value!(self description description.map(|description| description.into()))
@@ -618,10 +640,10 @@ impl ObjectBuilder {
 
     to_array_builder!();
 
-    build_fn!(pub Object component_type, required, properties, description, deprecated, example, xml, additional_properties);
+    build_fn!(pub Object component_type, title, required, properties, description, deprecated, example, xml, additional_properties);
 }
 
-from!(Object ObjectBuilder component_type, required, properties, description, deprecated, example, xml, additional_properties);
+from!(Object ObjectBuilder component_type, title, required, properties, description, deprecated, example, xml, additional_properties);
 component_from_builder!(ObjectBuilder);
 
 /// Implements [OpenAPI Reference Object][reference] that can be used to reference
@@ -984,6 +1006,18 @@ mod tests {
                 }
             })
         )
+    }
+
+    #[test]
+    fn test_object_with_title() {
+        let json_value = ObjectBuilder::new().title(Some("SomeName")).build();
+        assert_json_eq!(
+            json_value,
+            json!({
+                "type": "object",
+                "title": "SomeName"
+            })
+        );
     }
 
     #[test]

--- a/tests/component_derive_test.rs
+++ b/tests/component_derive_test.rs
@@ -800,6 +800,67 @@ fn derive_complex_enum() {
 }
 
 #[test]
+fn derive_complex_enum_title() {
+    #[derive(Serialize)]
+    struct Foo(String);
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Bar {
+            #[component(title = "Unit")]
+            UnitValue,
+            #[component(title = "Named")]
+            NamedFields {
+                id: &'static str,
+            },
+            #[component(title = "Unnamed")]
+            UnnamedFields(Foo),
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "string",
+                    "title": "Unit",
+                    "enum": [
+                        "UnitValue",
+                    ],
+                },
+                {
+                    "type": "object",
+                    "title": "Named",
+                    "properties": {
+                        "NamedFields": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                },
+                            },
+                            "required": [
+                                "id",
+                            ],
+                        },
+                    },
+                },
+                {
+                    "type": "object",
+                    "title": "Unnamed",
+                    "properties": {
+                        "UnnamedFields": {
+                            "$ref": "#/components/schemas/Foo",
+                        },
+                    },
+                },
+            ],
+        })
+    );
+}
+
+#[test]
 fn derive_complex_enum_serde_rename_all() {
     #[derive(Serialize)]
     struct Foo(String);
@@ -977,6 +1038,67 @@ fn derive_complex_enum_serde_tag() {
                             "items": {
                                 "type": "string",
                             },
+                        },
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "NamedFields",
+                            ],
+                        },
+                    },
+                    "required": [
+                        "id",
+                        "tag",
+                    ],
+                },
+            ],
+        })
+    );
+}
+
+#[test]
+fn derive_complex_enum_serde_tag_title() {
+    #[derive(Serialize)]
+    struct Foo(String);
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "tag")]
+        enum Bar {
+            #[component(title = "Unit")]
+            UnitValue,
+            #[component(title = "Named")]
+            NamedFields {
+                id: &'static str,
+            },
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "title": "Unit",
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "UnitValue",
+                            ],
+                        },
+                    },
+                    "required": [
+                        "tag",
+                    ],
+                },
+                {
+                    "type": "object",
+                    "title": "Named",
+                    "properties": {
+                        "id": {
+                            "type": "string",
                         },
                         "tag": {
                             "type": "string",

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1674,7 +1674,7 @@ impl ToTokens for AnyValue {
 
 /// Parsing utils
 mod parse_utils {
-    use proc_macro2::{Group, Ident, TokenStream};
+    use proc_macro2::{Group, Ident, TokenStream, TokenTree};
     use proc_macro_error::ResultExt;
     use syn::{
         parenthesized,
@@ -1683,6 +1683,21 @@ mod parse_utils {
         token::Comma,
         Error, LitBool, LitStr, Token,
     };
+
+    pub fn skip_past_next_comma(input: ParseStream) -> syn::Result<()> {
+        input.step(|cursor| {
+            let mut rest = *cursor;
+            while let Some((tt, next)) = rest.token_tree() {
+                match &tt {
+                    TokenTree::Punct(punct) if punct.as_char() == ',' => {
+                        return Ok(((), next));
+                    }
+                    _ => rest = next,
+                }
+            }
+            Ok(((), rest))
+        })
+    }
 
     pub fn parse_next<T: Sized>(input: ParseStream, next: impl FnOnce() -> T) -> T {
         input

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -264,6 +264,18 @@ use ext::ArgumentResolver;
 /// }
 /// ```
 ///
+/// It is possible to specify the title of each variant to help generators create named structures.
+/// ```rust
+/// # use utoipa::Component;
+/// #[derive(Component)]
+/// enum ErrorResponse {
+///     #[component(title = "InvalidCredentials")]
+///     InvalidCredentials,
+///     #[component(title = "NotFound")]
+///     NotFound(String),
+/// }
+/// ```
+///
 /// Use `xml` attribute to manipulate xml output.
 /// ```rust
 /// # use utoipa::Component;

--- a/utoipa-gen/src/schema/component/attr.rs
+++ b/utoipa-gen/src/schema/component/attr.rs
@@ -137,7 +137,7 @@ impl Parse for ComponentAttr<Title> {
             }
 
             if !input.is_empty() {
-                input.parse::<Token![,]>()?;
+                parse_utils::skip_past_next_comma(input)?;
             }
         }
         Ok(Self { inner: title_attr })

--- a/utoipa-gen/src/schema/component/attr.rs
+++ b/utoipa-gen/src/schema/component/attr.rs
@@ -48,6 +48,16 @@ where
 
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
+pub struct Title(Option<String>);
+
+impl IsInline for Title {
+    fn is_inline(&self) -> bool {
+        false
+    }
+}
+
+#[derive(Default)]
+#[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Enum {
     default: Option<AnyValue>,
     example: Option<AnyValue>,
@@ -104,6 +114,33 @@ pub struct NamedField<'c> {
 impl IsInline for NamedField<'_> {
     fn is_inline(&self) -> bool {
         self.inline
+    }
+}
+
+impl Parse for ComponentAttr<Title> {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        const EXPECTED_ATTRIBUTE_MESSAGE: &str = "unexpected attribute, expected any of: title";
+        let mut title_attr = Title::default();
+
+        while !input.is_empty() {
+            let ident = input.parse::<Ident>().map_err(|error| {
+                Error::new(
+                    error.span(),
+                    format!("{}, {}", EXPECTED_ATTRIBUTE_MESSAGE, error),
+                )
+            })?;
+            let name = &*ident.to_string();
+
+            match name {
+                "title" => title_attr = Title(Some(parse_utils::parse_next_literal_str(input)?)),
+                _ => (),
+            }
+
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
+        }
+        Ok(Self { inner: title_attr })
     }
 }
 
@@ -166,7 +203,7 @@ impl ComponentAttr<Struct> {
 impl Parse for ComponentAttr<Struct> {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         const EXPECTED_ATTRIBUTE_MESSAGE: &str =
-            "unexpected attribute, expected any of: example, xml";
+            "unexpected attribute, expected any of: title, example, xml";
         let mut struct_ = Struct::default();
 
         while !input.is_empty() {
@@ -179,6 +216,9 @@ impl Parse for ComponentAttr<Struct> {
             let name = &*ident.to_string();
 
             match name {
+                "title" => {
+                    parse_utils::parse_next_literal_str(input)?; // Handled by ComponentAttr<Title>
+                }
                 "example" => {
                     struct_.example = Some(parse_utils::parse_next(input, || {
                         AnyValue::parse_lit_str_or_json(input)
@@ -204,7 +244,7 @@ impl Parse for ComponentAttr<Struct> {
 impl<'c> Parse for ComponentAttr<UnnamedFieldStruct<'c>> {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         const EXPECTED_ATTRIBUTE_MESSAGE: &str =
-            "unexpected attribute, expected any of: default, example, format, value_type";
+            "unexpected attribute, expected any of: title, default, example, format, value_type";
         let mut unnamed_struct = UnnamedFieldStruct::default();
 
         while !input.is_empty() {
@@ -217,6 +257,9 @@ impl<'c> Parse for ComponentAttr<UnnamedFieldStruct<'c>> {
             let name = &*attribute.to_string();
 
             match name {
+                "title" => {
+                    parse_utils::parse_next_literal_str(input)?; // Handled by ComponentAttr<Title>
+                }
                 "default" => {
                     unnamed_struct.default = Some(parse_utils::parse_next(input, || {
                         AnyValue::parse_any(input)
@@ -372,6 +415,16 @@ where
 {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.inner.to_tokens(tokens)
+    }
+}
+
+impl ToTokens for Title {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        if let Some(ref title) = self.0 {
+            tokens.extend(quote! {
+                .title(Some(#title))
+            })
+        }
     }
 }
 


### PR DESCRIPTION
This adds support for `title`.
It's my first time working with functional macros and this is not a simple use-case so let me know if this can be improved.
The title is useful for enums because currently the generator for rust clients created a struct for each variant and name them like:
- my_enum_one_of_1
- my_enum_one_of_2
- etc

So with the title you can at least control the name of each variant structure. There is an open issue to actually produce an enum but it's not been worked on for a while https://github.com/OpenAPITools/openapi-generator/issues/9497.