### PR TITLE
Add Rocket IntoParams and generalize ext args

### DIFF
--- a/tests/path_derive_rocket.rs
+++ b/tests/path_derive_rocket.rs
@@ -361,7 +361,8 @@ fn resolve_path_query_params_from_form() {
                 (status = 200, description = "Hello from server")
             ),
             params(
-                ("id", description = "Hello id")
+                ("id", description = "Hello id"),
+                QueryParams
             )
         )]
         #[get("/hello/<id>?<rest..>")]
@@ -381,7 +382,39 @@ fn resolve_path_query_params_from_form() {
         .pointer("/paths/~1hello~1{id}/get/parameters")
         .unwrap();
 
-    dbg!(&parameters);
+    assert_json_eq!(
+        parameters,
+        json!([
+            {
+                "deprecated": false,
+                "description": "Hello id",
+                "in": "path",
+                "name": "id",
+                "required": true,
+                "schema": {
+                    "format": "int32",
+                    "type": "integer"
+                }
+            },
+            {
+                "in": "query",
+                "name": "foo",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "in": "query",
+                "name": "bar",
+                "required": true,
+                "schema": {
+                    "format": "int64",
+                    "type": "integer"
+                }
+            }
+        ])
+    )
 }
 
 macro_rules! test_derive_path_operations {

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -208,7 +208,6 @@ pub mod fn_arg {
     }
 
     fn get_argument_types(path_segment: &PathSegment) -> impl Iterator<Item = &TypePath> {
-        dbg!(&path_segment);
         match &path_segment.arguments {
             PathArguments::AngleBracketed(angle_bracketed) => {
                 angle_bracketed.args.iter().flat_map(|arg| match arg {
@@ -238,7 +237,6 @@ pub mod fn_arg {
         let tt = fn_args
             .iter()
             .map(|arg| {
-                dbg!(&arg);
                 let pat_type = get_fn_arg_pat_type(arg);
 
                 let arg_name = match pat_type.pat.as_ref() {
@@ -273,7 +271,6 @@ pub mod fn_arg {
         fn_arg: &'a syn::FnArg,
         finder: &impl SegmentFinder,
     ) -> Option<&'a PathSegment> {
-        dbg!(&fn_arg);
         let pat_type = get_fn_arg_pat_type(fn_arg);
         let type_path = get_type_path(pat_type.ty.as_ref());
 
@@ -353,8 +350,12 @@ pub mod fn_arg {
         }
     }
 
-    pub(super) fn non_primitive_arg2(fn_arg: &FnArg2) -> bool {
-        matches!(fn_arg.ty.value_type, ValueType::Object)
+    pub(super) fn into_params(fn_arg: &FnArg2) -> bool {
+        matches!(fn_arg.ty.value_type, ValueType::Object) && matches!(fn_arg.ty.generic_type, None)
+    }
+
+    pub(super) fn into_params_actix(fn_arg: &FnArg2) -> bool {
+        fn_arg.ty.is("Path") || fn_arg.ty.is("Query")
     }
 
     #[inline]

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -144,8 +144,6 @@ pub mod fn_arg {
     use crate::schema::ValueType;
 
     use super::IntoParamsType;
-    #[cfg(any(feature = "actix_extras"))]
-    use super::{ArgumentIn, MacroArg, ValueArgument};
 
     /// Http operation handler functions fn argument.
     #[cfg_attr(feature = "debug", derive(Debug))]
@@ -220,7 +218,7 @@ pub mod fn_arg {
         let type_path = arg
             .ty
             .children
-            .expect("FnArg TypeTree expected must have children")
+            .expect("FnArg TypeTree generic type Path must have children")
             .into_iter()
             .next()
             .unwrap()
@@ -235,21 +233,6 @@ pub mod fn_arg {
         IntoParamsType {
             parameter_in_provider,
             type_path,
-        }
-    }
-
-    #[cfg(any(feature = "actix_extras"))]
-    pub(super) fn into_value_argument(
-        (macro_arg, primitive_arg): (MacroArg, TypeTree),
-    ) -> ValueArgument {
-        ValueArgument {
-            name: match macro_arg {
-                MacroArg::Path(path) => Some(Cow::Owned(path.name)),
-            },
-            type_path: primitive_arg.path,
-            is_array: false,
-            is_option: false,
-            argument_in: ArgumentIn::Path,
         }
     }
 

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -137,7 +137,7 @@ pub mod fn_arg {
 
     use crate::{
         component_type::ComponentType,
-        schema::{ComponentPart, GenericType, ValueType},
+        schema::{ComponentPart, GenericType, TypeTree, TypeTreeValue, ValueType},
     };
 
     use super::{ArgumentIn, IntoParamsType, MacroArg, ValueArgument};
@@ -160,12 +160,12 @@ pub mod fn_arg {
 
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct FnArg2<'a> {
-        pub(super) ty: ComponentPart<'a>,
+        pub(super) ty: TypeTreeValue<'a>,
         pub(super) name: &'a Ident,
     }
 
-    impl<'a> From<(ComponentPart<'a>, &'a Ident)> for FnArg2<'a> {
-        fn from((ty, name): (ComponentPart<'a>, &'a Ident)) -> Self {
+    impl<'a> From<(TypeTreeValue<'a>, &'a Ident)> for FnArg2<'a> {
+        fn from((ty, name): (TypeTreeValue<'a>, &'a Ident)) -> Self {
             Self { ty, name }
         }
     }
@@ -233,7 +233,7 @@ pub mod fn_arg {
     ) -> impl Iterator<Item = FnArg2<'_>> {
         let tt = fn_args
             .iter()
-            .map(|arg| {
+            .flat_map(|arg| {
                 let pat_type = get_fn_arg_pat_type(arg);
 
                 let arg_name = match pat_type.pat.as_ref() {
@@ -242,8 +242,9 @@ pub mod fn_arg {
                         "unexpected syn::Pat, expected syn::Pat::Ident,in get_fn_args, cannot get fn argument name"
                     ),
                 };
-
-                (ComponentPart::from_type(pat_type.ty.as_ref()), arg_name)
+                dbg!(&pat_type.ty);
+                TypeTree::from_type(pat_type.ty.as_ref()).into_type_tree_values()
+                    .map(move |tree_value| (tree_value, arg_name))
             })
             .map(FnArg2::from);
 

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -1,10 +1,12 @@
-#![allow(unused)]
-use std::{borrow::Cow, cmp::Ordering};
+use std::borrow::Cow;
 
-use proc_macro2::{Ident, TokenStream};
-use syn::{punctuated::Punctuated, token::Comma, Attribute, FnArg, ItemFn, TypePath};
+#[cfg(feature = "rocket_extras")]
+use std::cmp::Ordering;
 
-use crate::path::{parameter::Parameter, PathOperation};
+use proc_macro2::TokenStream;
+use syn::{punctuated::Punctuated, token::Comma, ItemFn, TypePath};
+
+use crate::path::PathOperation;
 
 #[cfg(feature = "actix_extras")]
 pub mod actix;
@@ -30,13 +32,14 @@ pub struct ValueArgument<'a> {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct IntoParamsType<'a> {
     pub parameter_in_provider: TokenStream,
-    pub type_path: Cow<'a, TypePath>,
+    pub type_path: Option<Cow<'a, TypePath>>,
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(PartialEq)]
 pub enum ArgumentIn {
     Path,
+    #[cfg(feature = "rocket_extras")]
     Query,
 }
 
@@ -46,19 +49,22 @@ pub struct MacroPath {
     pub args: Vec<MacroArg>,
 }
 
-// #[derive(PartialEq, Eq, PartialOrd, Ord)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum MacroArg {
+    #[cfg_attr(feature = "axum_extras", allow(dead_code))]
     Path(ArgValue),
+    #[cfg(feature = "rocket_extras")]
     Query(ArgValue),
 }
 
 impl MacroArg {
     /// Get ordering by name
+    #[cfg(feature = "rocket_extras")]
     fn by_name(a: &MacroArg, b: &MacroArg) -> Ordering {
         a.get_value().name.cmp(&b.get_value().name)
     }
 
+    #[cfg(feature = "rocket_extras")]
     fn get_value(&self) -> &ArgValue {
         match self {
             MacroArg::Path(path) => path,
@@ -125,239 +131,142 @@ impl PathOperationResolver for PathOperations {}
     feature = "rocket_extras"
 ))]
 pub mod fn_arg {
-    use std::{borrow::Cow, cmp::Ordering};
+    use std::borrow::Cow;
 
     use proc_macro2::{Ident, TokenStream};
-    use proc_macro_error::abort_call_site;
+    use proc_macro_error::abort;
+    #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
     use quote::quote;
-    use syn::{
-        punctuated::Punctuated, token::Comma, GenericArgument, PatType, PathArguments, PathSegment,
-        Type, TypePath,
-    };
+    use syn::{punctuated::Punctuated, token::Comma, PatType, TypePath};
 
-    use crate::{
-        component_type::ComponentType,
-        schema::{ComponentPart, GenericType, TypeTree, TypeTreeValue, ValueType},
-    };
+    use crate::schema::TypeTree;
+    #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
+    use crate::schema::ValueType;
 
-    use super::{ArgumentIn, IntoParamsType, MacroArg, ValueArgument};
+    use super::IntoParamsType;
+    #[cfg(any(feature = "actix_extras"))]
+    use super::{ArgumentIn, MacroArg, ValueArgument};
 
-    /// Http operation handler funtion's fn argument.
-    ///
-    /// [`FnArg`] is used to indicate the parameter type of handler function argument.
-    /// E.g in following case [`FnArg::Path`] would be used. This in turn will specify the
-    /// [`utoipa::openapi::path::ParameterIn`] for the parameter(s).
-    /// ```text
-    /// fn get_me(params: Path<i32>) {}
-    /// ```
-    #[cfg_attr(feature = "debug", derive(Debug, Clone))]
-    pub enum FnArg<'a> {
-        /// Path query parameters after the question mark (?).
-        Query(&'a TypePath),
-        /// Path parameters
-        Path(&'a TypePath),
-    }
-
+    /// Http operation handler functions fn argument.
     #[cfg_attr(feature = "debug", derive(Debug))]
-    pub struct FnArg2<'a> {
-        pub(super) ty: TypeTreeValue<'a>,
+    pub struct FnArg<'a> {
+        pub(super) ty: TypeTree<'a>,
         pub(super) name: &'a Ident,
     }
 
-    impl<'a> From<(TypeTreeValue<'a>, &'a Ident)> for FnArg2<'a> {
-        fn from((ty, name): (TypeTreeValue<'a>, &'a Ident)) -> Self {
+    impl<'a> From<(TypeTree<'a>, &'a Ident)> for FnArg<'a> {
+        fn from((ty, name): (TypeTree<'a>, &'a Ident)) -> Self {
             Self { ty, name }
         }
     }
 
-    impl<'a> Ord for FnArg2<'a> {
+    impl<'a> Ord for FnArg<'a> {
         fn cmp(&self, other: &Self) -> std::cmp::Ordering {
             self.name.cmp(other.name)
         }
     }
 
-    impl<'a> PartialOrd for FnArg2<'a> {
+    impl<'a> PartialOrd for FnArg<'a> {
         fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
             self.name.partial_cmp(other.name)
         }
     }
 
-    impl<'a> PartialEq for FnArg2<'a> {
+    impl<'a> PartialEq for FnArg<'a> {
         fn eq(&self, other: &Self) -> bool {
             self.ty == other.ty && self.name == other.name
         }
     }
 
-    impl<'a> Eq for FnArg2<'a> {}
+    impl<'a> Eq for FnArg<'a> {}
 
-    /// Will
-    pub trait SegmentFinder {
-        fn matches(&self, path_segment: &PathSegment) -> bool;
-        fn to_fn_arg<'a>(&self, type_path: &'a TypePath) -> FnArg<'a>;
-    }
-
-    fn get_type_path(ty: &Type) -> &TypePath {
-        match ty {
-            Type::Path(path) => path,
-            Type::Reference(reference) => get_type_path(reference.elem.as_ref()),
-            _ => abort_call_site!("unexpected type in path operations, expected Type::Path"), // should not get here by any means with current types
-        }
-    }
-
-    fn get_argument_types(path_segment: &PathSegment) -> impl Iterator<Item = &TypePath> {
-        match &path_segment.arguments {
-            PathArguments::AngleBracketed(angle_bracketed) => {
-                angle_bracketed.args.iter().flat_map(|arg| match arg {
-                    GenericArgument::Type(ty) => match ty {
-                        Type::Path(path) => vec![path],
-                        Type::Tuple(tuple) => tuple.elems.iter().map(get_type_path).collect(),
-                        _ => {
-                            abort_call_site!("unexpected type, expected Type::Path or Type::Tuple")
-                        } // should not get here by any means with current types
-                    },
-                    _ => {
-                        abort_call_site!(
-                            "unexpected generic argument, expected GenericArgument::Type"
-                        )
-                    }
-                })
-            }
-            _ => {
-                abort_call_site!("unexpected argument type, expected Path<...> with angle brakets")
-            }
-        }
-    }
-
-    pub fn get_fn_args(
-        fn_args: &Punctuated<syn::FnArg, Comma>,
-    ) -> impl Iterator<Item = FnArg2<'_>> {
-        let tt = fn_args
+    pub fn get_fn_args(fn_args: &Punctuated<syn::FnArg, Comma>) -> impl Iterator<Item = FnArg<'_>> {
+        fn_args
             .iter()
-            .flat_map(|arg| {
+            .map(|arg| {
                 let pat_type = get_fn_arg_pat_type(arg);
 
                 let arg_name = match pat_type.pat.as_ref() {
                     syn::Pat::Ident(ident) => &ident.ident,
-                    _ => abort_call_site!(
+                    _ => abort!(pat_type.pat.as_ref(),
                         "unexpected syn::Pat, expected syn::Pat::Ident,in get_fn_args, cannot get fn argument name"
                     ),
                 };
-                dbg!(&pat_type.ty);
-                TypeTree::from_type(pat_type.ty.as_ref()).into_type_tree_values()
-                    .map(move |tree_value| (tree_value, arg_name))
+                (TypeTree::form_type(&pat_type.ty), arg_name)
             })
-            .map(FnArg2::from);
-
-        tt
-
-        // let ff = fn_args
-        //     .iter()
-        //     .filter_map(|arg| get_fn_arg_segment(arg, finder))
-        //     .flat_map(|path_segment| {
-        //         // let op = if path_segment.ident == "Path" {
-        //         //     FnArg::Path
-        //         // } else {
-        //         //     FnArg::Query
-        //         // };
-        //         get_argument_types(path_segment).map(|segment| finder.to_fn_arg(segment))
-        //     });
-
-        // ff
-    }
-
-    fn get_fn_arg_segment<'a>(
-        fn_arg: &'a syn::FnArg,
-        finder: &impl SegmentFinder,
-    ) -> Option<&'a PathSegment> {
-        let pat_type = get_fn_arg_pat_type(fn_arg);
-        let type_path = get_type_path(pat_type.ty.as_ref());
-
-        type_path
-            .path
-            .segments
-            .iter()
-            .find(|segment| finder.matches(segment))
-        // .find(|segment| segment.ident == "Path" || segment.ident == "Query")
-    }
-
-    fn get_fn_arg_pat_type(fn_arg: &syn::FnArg) -> &PatType {
-        match fn_arg {
-            syn::FnArg::Typed(value) => value,
-            _ => abort_call_site!("unexpected fn argument type, expected FnArg::Typed"),
-        }
-    }
-
-    pub(super) fn to_into_params_types<'a, I: IntoIterator<Item = FnArg2<'a>>>(
-        arguments: I,
-        parameter_in_provider: impl Fn(&'_ FnArg2<'a>) -> TokenStream + 'a,
-    ) -> impl Iterator<Item = IntoParamsType<'a>> {
-        arguments.into_iter().map(move |path_arg| {
-            // let FnArg2 { ty, name } = &path_arg;
-            // let (arg, parameter_in) = match path_arg {
-            //     FnArg::Path(arg) => (arg, quote! { utoipa::openapi::path::ParameterIn::Path }),
-            //     FnArg::Query(arg) => (arg, quote! { utoipa::openapi::path::ParameterIn::Query }),
-            // };
-
-            let parameter_in = parameter_in_provider(&path_arg);
-
-            IntoParamsType {
-                parameter_in_provider: quote! {
-                    || Some(#parameter_in)
-                },
-                type_path: path_arg.ty.path,
-            }
-        })
-    }
-
-    pub(super) fn to_value_args<
-        'a,
-        R: IntoIterator<Item = MacroArg>,
-        P: IntoIterator<Item = FnArg<'a>>,
-    >(
-        macro_args: R,
-        primitive_args: P,
-    ) -> impl Iterator<Item = ValueArgument<'a>> {
-        macro_args
-            .into_iter()
-            .zip(primitive_args)
-            .map(|(macro_arg, primitive_arg)| ValueArgument {
-                name: match macro_arg {
-                    MacroArg::Path(path) => Some(Cow::Owned(path.name)),
-                    _ => {
-                        unreachable!("ResolvedArg::Query is not reachable with primitive path type")
-                    }
-                },
-                type_path: match primitive_arg {
-                    FnArg::Path(arg_type) => Some(Cow::Borrowed(arg_type)),
-                    _ => {
-                        unreachable!("FnArg::Query is not reachable with primitive type")
-                    }
-                },
-                is_array: false,
-                is_option: false,
-                argument_in: ArgumentIn::Path,
-            })
-    }
-
-    pub(super) fn non_primitive_arg(fn_arg: &FnArg) -> bool {
-        let is_primitive = |type_path| ComponentType(type_path).is_primitive();
-
-        match fn_arg {
-            FnArg::Path(path) => !is_primitive(path),
-            FnArg::Query(query) => !is_primitive(query),
-        }
-    }
-
-    pub(super) fn into_params(fn_arg: &FnArg2) -> bool {
-        matches!(fn_arg.ty.value_type, ValueType::Object) && matches!(fn_arg.ty.generic_type, None)
-    }
-
-    pub(super) fn into_params_actix(fn_arg: &FnArg2) -> bool {
-        fn_arg.ty.is("Path") || fn_arg.ty.is("Query")
+            .map(FnArg::from)
     }
 
     #[inline]
-    pub(super) fn get_last_ident(type_path: &TypePath) -> Option<&Ident> {
-        type_path.path.segments.last().map(|segment| &segment.ident)
+    fn get_fn_arg_pat_type(fn_arg: &syn::FnArg) -> &PatType {
+        match fn_arg {
+            syn::FnArg::Typed(value) => value,
+            _ => abort!(fn_arg, "unexpected fn argument type, expected FnArg::Typed"),
+        }
+    }
+
+    #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
+    pub(super) fn with_parameter_in(
+        arg: FnArg<'_>,
+    ) -> Option<(Option<Cow<'_, TypePath>>, TokenStream)> {
+        let parameter_in_provider = if arg.ty.is("Path") {
+            quote! { || Some (utoipa::openapi::path::ParameterIn::Path) }
+        } else if arg.ty.is("Query") {
+            quote! { || Some( utoipa::openapi::path::ParameterIn::Query) }
+        } else {
+            quote! { || None }
+        };
+
+        let type_path = arg
+            .ty
+            .children
+            .expect("FnArg TypeTree expected must have children")
+            .into_iter()
+            .next()
+            .unwrap()
+            .path;
+
+        Some((type_path, parameter_in_provider))
+    }
+
+    pub(super) fn into_into_params_type(
+        (type_path, parameter_in_provider): (Option<Cow<'_, TypePath>>, TokenStream),
+    ) -> IntoParamsType<'_> {
+        IntoParamsType {
+            parameter_in_provider,
+            type_path,
+        }
+    }
+
+    #[cfg(any(feature = "actix_extras"))]
+    pub(super) fn into_value_argument(
+        (macro_arg, primitive_arg): (MacroArg, TypeTree),
+    ) -> ValueArgument {
+        ValueArgument {
+            name: match macro_arg {
+                MacroArg::Path(path) => Some(Cow::Owned(path.name)),
+            },
+            type_path: primitive_arg.path,
+            is_array: false,
+            is_option: false,
+            argument_in: ArgumentIn::Path,
+        }
+    }
+
+    // if type is either Path or Query with direct children as Object types without generics
+    #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
+    pub(super) fn is_into_params(fn_arg: &FnArg) -> bool {
+        (fn_arg.ty.is("Path") || fn_arg.ty.is("Query"))
+            && fn_arg
+                .ty
+                .children
+                .as_ref()
+                .map(|children| {
+                    children.iter().all(|child| {
+                        matches!(child.value_type, ValueType::Object)
+                            && matches!(child.generic_type, None)
+                    })
+                })
+                .unwrap_or(false)
     }
 }

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -165,11 +165,8 @@ pub mod fn_arg {
     }
 
     impl<'a> From<(ComponentPart<'a>, &'a Ident)> for FnArg2<'a> {
-        fn from(tuple: (ComponentPart<'a>, &'a Ident)) -> Self {
-            Self {
-                ty: tuple.0,
-                name: tuple.1,
-            }
+        fn from((ty, name): (ComponentPart<'a>, &'a Ident)) -> Self {
+            Self { ty, name }
         }
     }
 

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use lazy_static::lazy_static;
 use proc_macro2::Ident;
 use proc_macro_error::abort;
@@ -12,8 +14,8 @@ use crate::{
 
 use super::{
     fn_arg::{self, FnArg},
-    ArgumentResolver, MacroArg, MacroPath, PathOperationResolver, PathOperations, PathResolver,
-    ResolvedOperation,
+    ArgumentIn, ArgumentResolver, MacroArg, MacroPath, PathOperationResolver, PathOperations,
+    PathResolver, ResolvedOperation, ValueArgument,
 };
 
 impl ArgumentResolver for PathOperations {
@@ -36,7 +38,7 @@ impl ArgumentResolver for PathOperations {
                     macro_args
                         .into_iter()
                         .zip(primitive_args)
-                        .map(fn_arg::into_value_argument)
+                        .map(into_value_argument)
                         .collect(),
                 ),
                 Some(
@@ -81,6 +83,18 @@ fn get_primitive_args(value_args: Vec<FnArg>) -> impl Iterator<Item = TypeTree> 
                 unreachable!("Value arguments does not have ValueType::Object arguments")
             }
         })
+}
+
+fn into_value_argument((macro_arg, primitive_arg): (MacroArg, TypeTree)) -> ValueArgument {
+    ValueArgument {
+        name: match macro_arg {
+            MacroArg::Path(path) => Some(Cow::Owned(path.name)),
+        },
+        type_path: primitive_arg.path,
+        is_array: false,
+        is_option: false,
+        argument_in: ArgumentIn::Path,
+    }
 }
 
 impl PathOperationResolver for PathOperations {

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 use super::{
-    fn_arg::{self, FnArg},
+    fn_arg::{self, FnArg, FnArg2},
     ArgumentIn, ArgumentResolver, MacroArg, MacroPath, PathOperationResolver, PathOperations,
     PathResolver, ResolvedOperation,
 };
@@ -32,21 +32,25 @@ impl ArgumentResolver for PathOperations {
         Option<Vec<super::ValueArgument<'_>>>,
         Option<Vec<super::IntoParamsType<'_>>>,
     ) {
-        let (non_primitive_args, primitive_args): (Vec<FnArg>, Vec<FnArg>) =
+        let (into_params_args, value_args): (Vec<FnArg2>, Vec<FnArg2>) =
             fn_arg::get_fn_args(fn_args)
                 .into_iter()
-                .partition(fn_arg::non_primitive_arg);
+                .partition(fn_arg::into_params_actix);
+
+        dbg!(&into_params_args, &value_args);
 
         if let Some(macro_args) = macro_args {
-            (
-                Some(fn_arg::to_value_args(macro_args, primitive_args).collect()),
-                Some(fn_arg::to_into_params_types(non_primitive_args).collect()),
-            )
+            (None, None)
+            // (
+            //     Some(fn_arg::to_value_args(macro_args, value_args).collect()),
+            //     Some(fn_arg::to_into_params_types(into_params_args).collect()),
+            // )
         } else {
-            (
-                None,
-                Some(fn_arg::to_into_params_types(non_primitive_args).collect()),
-            )
+            (None, None)
+            // (
+            //     None,
+            //     Some(fn_arg::to_into_params_types(into_params_args).collect()),
+            // )
         }
     }
 }

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -1,27 +1,19 @@
-use std::borrow::Cow;
-
 use lazy_static::lazy_static;
-use proc_macro::TokenTree;
-use proc_macro2::{Ident, Literal, Punct};
-use proc_macro_error::{abort, abort_call_site};
-use quote::{format_ident, quote, quote_spanned};
+use proc_macro2::Ident;
+use proc_macro_error::abort;
 use regex::{Captures, Regex};
-use syn::{
-    parse::Parse, punctuated::Punctuated, token::Comma, Attribute, DeriveInput, ExprPath,
-    GenericArgument, ItemFn, LitStr, Pat, PatType, PathArguments, PathSegment, Type, TypeInfer,
-    TypePath,
-};
+use syn::{parse::Parse, punctuated::Punctuated, token::Comma, ItemFn, LitStr};
 
 use crate::{
-    component_type::ComponentType,
-    ext::{ArgValue, ValueArgument},
-    path::{self, PathOperation},
+    ext::ArgValue,
+    path::PathOperation,
+    schema::{TypeTree, ValueType},
 };
 
 use super::{
-    fn_arg::{self, FnArg, FnArg2},
-    ArgumentIn, ArgumentResolver, MacroArg, MacroPath, PathOperationResolver, PathOperations,
-    PathResolver, ResolvedOperation,
+    fn_arg::{self, FnArg},
+    ArgumentResolver, MacroArg, MacroPath, PathOperationResolver, PathOperations, PathResolver,
+    ResolvedOperation,
 };
 
 impl ArgumentResolver for PathOperations {
@@ -32,27 +24,63 @@ impl ArgumentResolver for PathOperations {
         Option<Vec<super::ValueArgument<'_>>>,
         Option<Vec<super::IntoParamsType<'_>>>,
     ) {
-        let (into_params_args, value_args): (Vec<FnArg2>, Vec<FnArg2>) =
-            fn_arg::get_fn_args(fn_args)
-                .into_iter()
-                .partition(fn_arg::into_params_actix);
-
-        dbg!(&into_params_args, &value_args);
+        let (into_params_args, value_args): (Vec<FnArg>, Vec<FnArg>) = fn_arg::get_fn_args(fn_args)
+            .into_iter()
+            .partition(fn_arg::is_into_params);
 
         if let Some(macro_args) = macro_args {
-            (None, None)
-            // (
-            //     Some(fn_arg::to_value_args(macro_args, value_args).collect()),
-            //     Some(fn_arg::to_into_params_types(into_params_args).collect()),
-            // )
+            let primitive_args = get_primitive_args(value_args);
+
+            (
+                Some(
+                    macro_args
+                        .into_iter()
+                        .zip(primitive_args)
+                        .map(fn_arg::into_value_argument)
+                        .collect(),
+                ),
+                Some(
+                    into_params_args
+                        .into_iter()
+                        .flat_map(fn_arg::with_parameter_in)
+                        .map(fn_arg::into_into_params_type)
+                        .collect(),
+                ),
+            )
         } else {
-            (None, None)
-            // (
-            //     None,
-            //     Some(fn_arg::to_into_params_types(into_params_args).collect()),
-            // )
+            (
+                None,
+                Some(
+                    into_params_args
+                        .into_iter()
+                        .flat_map(fn_arg::with_parameter_in)
+                        .map(fn_arg::into_into_params_type)
+                        .collect(),
+                ),
+            )
         }
     }
+}
+
+fn get_primitive_args(value_args: Vec<FnArg>) -> impl Iterator<Item = TypeTree> {
+    value_args
+        .into_iter()
+        .filter(|arg| arg.ty.is("Path"))
+        .flat_map(|path_arg| {
+            path_arg
+                .ty
+                .children
+                .expect("Path argument must have children")
+        })
+        .flat_map(|path_arg| match path_arg.value_type {
+            ValueType::Primitive => vec![path_arg],
+            ValueType::Tuple => path_arg
+                .children
+                .expect("ValueType::Tuple will always have children"),
+            ValueType::Object => {
+                unreachable!("Value arguments does not have ValueType::Object arguments")
+            }
+        })
 }
 
 impl PathOperationResolver for PathOperations {
@@ -88,11 +116,11 @@ impl Parse for Path {
         // ignore rest of the tokens from actix-web path attribute macro
         input.step(|cursor| {
             let mut rest = *cursor;
-            while let Some((tt, next)) = rest.token_tree() {
+            while let Some((_, next)) = rest.token_tree() {
                 rest = next;
             }
             Ok(((), rest))
-        });
+        })?;
 
         Ok(Self(path))
     }
@@ -149,9 +177,4 @@ impl PathResolver for PathOperations {
 fn is_valid_request_type(ident: Option<&Ident>) -> bool {
     matches!(ident, Some(operation) if ["get", "post", "put", "delete", "head", "connect", "options", "trace", "patch"]
         .iter().any(|expected_operation| operation == expected_operation))
-}
-
-#[inline]
-fn get_last_ident(type_path: &TypePath) -> Option<&Ident> {
-    type_path.path.segments.last().map(|segment| &segment.ident)
 }

--- a/utoipa-gen/src/ext/rocket.rs
+++ b/utoipa-gen/src/ext/rocket.rs
@@ -152,6 +152,7 @@ fn get_value_type(ty: TypeTree<'_>) -> Option<Cow<TypePath>> {
     }
 }
 
+#[inline]
 fn is_into_params(fn_arg: &FnArg) -> bool {
     matches!(fn_arg.ty.value_type, ValueType::Object) && matches!(fn_arg.ty.generic_type, None)
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -581,7 +581,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///
 /// See the **actix_extras** in action in examples [todo-actix](https://github.com/juhaku/utoipa/tree/master/examples/todo-actix).
 ///
-/// With **actix_extras** feature enabled the you can leave out definitions for **path**, **operation** and **parameter types** [^actix_extras].
+/// With **actix_extras** feature enabled the you can leave out definitions for **path**, **operation**
+/// and **parameter types** [^actix_extras].
 /// ```rust
 /// use actix_web::{get, web, HttpResponse, Responder};
 /// use serde_json::json;
@@ -601,8 +602,8 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// With **actix_extras** you may also not to list any _**params**_ if you do not want to specify any description for them. Params are resolved from
-/// path and the argument types of handler. [^actix_extras]
+/// With **actix_extras** you may also not to list any _**params**_ if you do not want to specify any description for them. Params are
+/// resolved from path and the argument types of handler. [^actix_extras]
 /// ```rust
 /// use actix_web::{get, web, HttpResponse, Responder};
 /// use serde_json::json;
@@ -621,12 +622,12 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
 ///
 /// # rocket_extras support for rocket
 ///
-/// **rocket_extras** feature gives **utoipa** ability to use **rocket** path operation macros such as _`#[get(...)]`_ to
-/// resolve path for `#[utoipa::path]`.  Also it is able to parse the `path` and `query` parameters from path operation macro
-/// combined with function arguments of the operation. Allowing you leave out types from parameters in `params(...)` section
-/// or even leave out the section if description is not needed for parameters. Utoipa is only able to parse parameter types
-/// for [primitive types][primitive], [`String`], [`Vec`], [`Option`] or [`std::path::PathBuf`] type. Other function arguments are
-/// simply ignored.
+/// **rocket_extras** feature enahances path operation parameter support. It gives **utoipa** ability to parse `path`, `path parameters`
+/// and `query parameters` based on arguments given to **rocket**  proc macros such as _**`#[get(...)]`**_.  
+///
+/// 1. It is able to parse parameter types for [primitive types][primitive], [`String`], [`Vec`], [`Option`] or [`std::path::PathBuf`]
+///    type.
+/// 2. It is able to determine `parameter_in` for [`IntoParams`][into_params] trait used for `FromForm` type of query parameters.
 ///
 /// See the **rocket_extras** in action in examples [rocket-todo](https://github.com/juhaku/utoipa/tree/master/examples/rocket-todo).
 ///

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -160,10 +160,11 @@ impl<'p> PathAttr<'p> {
                     Parameter::Value(_) => None,
                     Parameter::Struct(parameter) => Some(parameter),
                 });
+                // TODO fix this by default its || None but updating paramter_in for actix does not work
                 for parameter in parameters {
                     if let Some(into_params_argument) = into_params_types
                         .iter_mut()
-                        .find(|argument| argument.type_path.path == parameter.path.path)
+                        .find(|argument| matches!(&argument.type_path, Some(path) if path.path == parameter.path.path))
                     {
                         parameter
                             .update_parameter_in(&mut into_params_argument.parameter_in_provider);

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -160,7 +160,6 @@ impl<'p> PathAttr<'p> {
                     Parameter::Value(_) => None,
                     Parameter::Struct(parameter) => Some(parameter),
                 });
-                // TODO fix this by default its || None but updating paramter_in for actix does not work
                 for parameter in parameters {
                     if let Some(into_params_argument) = into_params_types
                         .iter_mut()

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fmt::Display};
 
 use proc_macro2::{Ident, TokenStream};
-use quote::{format_ident, quote, quote_spanned, ToTokens};
+use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     parenthesized,
     parse::{Parse, ParseBuffer, ParseStream},
@@ -61,7 +61,6 @@ impl ToTokens for Parameter<'_> {
                 parameter_in_fn,
             }) => {
                 let last_ident = &path.path.segments.last().unwrap().ident;
-                let assert_into_params_ty = format_ident!("_Assert{}", last_ident);
 
                 let default_parameter_in_provider = &quote! { || None };
                 let parameter_in_provider = parameter_in_fn
@@ -69,11 +68,7 @@ impl ToTokens for Parameter<'_> {
                     .unwrap_or(default_parameter_in_provider);
                 tokens.extend(quote_spanned! {last_ident.span()=>
                     .parameters(
-                        {
-                            struct #assert_into_params_ty where #path : utoipa::IntoParams;
-
-                            Some(<#path>::into_params(#parameter_in_provider))
-                        }
+                        Some(<#path>::into_params(#parameter_in_provider))
                     )
                 })
             }

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -30,7 +30,7 @@ fn get_deprecated(attributes: &[Attribute]) -> Option<Deprecated> {
 #[derive(PartialEq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 /// Linked list of implementing types of a field in a struct.
-pub(self) struct ComponentPart<'a> {
+pub struct ComponentPart<'a> {
     pub path: Cow<'a, TypePath>,
     pub value_type: ValueType,
     pub generic_type: Option<GenericType>,
@@ -58,7 +58,8 @@ impl<'a> ComponentPart<'a> {
 
     /// Creates a [`ComponentPath`] from a [`TypePath`].
     fn from_type_path(path: &'a TypePath) -> ComponentPart<'a> {
-        let last_segment = path.path.segments.last().unwrap(); // there will always be one segment at least
+        // there will always be one segment at least
+        let last_segment = path.path.segments.last().unwrap();
         if last_segment.arguments.is_empty() {
             Self::convert(Cow::Borrowed(path))
         } else {
@@ -75,10 +76,9 @@ impl<'a> ComponentPart<'a> {
             );
         };
 
-        // TODO avoid clone
         let path = TypePath {
             qself: None,
-            path: syn::Path::from(segment.clone()),
+            path: syn::Path::from(segment.clone()), // seems like cannot avoid clone
         };
 
         let mut generic_component_type = ComponentPart::convert(Cow::Owned(path));
@@ -141,8 +141,12 @@ impl<'a> ComponentPart<'a> {
     }
 
     fn convert(path: Cow<'a, TypePath>) -> ComponentPart<'a> {
-        // TODO: handle unwrap
-        let last_segment = path.path.segments.last().unwrap();
+        let last_segment = path
+            .path
+            .segments
+            .last()
+            .expect("at least one segment within path in ComponentPart::convert");
+
         let generic_type = ComponentPart::get_generic(last_segment);
         let is_primitive = ComponentType(&*path).is_primitive();
 
@@ -212,14 +216,14 @@ impl<'a> AsMut<ComponentPart<'a>> for ComponentPart<'a> {
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Clone, Copy, PartialEq)]
-enum ValueType {
+pub enum ValueType {
     Primitive,
     Object,
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(PartialEq, Clone, Copy)]
-enum GenericType {
+pub enum GenericType {
     Vec,
     Map,
     Option,

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -79,7 +79,7 @@ impl<'a> ComponentPart<'a> {
 
         let path = TypePath {
             qself: None,
-            path: syn::Path::from(segment.clone()), // seems like cannot avoid clone
+            path: syn::Path::from(segment.clone()),
         };
 
         let mut generic_component_type = ComponentPart::convert(Cow::Owned(path));
@@ -266,7 +266,7 @@ impl<'t> TypeTree<'t> {
                 .path
                 .segments
                 .last()
-                .expect("at least one segment within path in TypeTree::from_type_path");
+                .expect("at least one segment within path in TypeTree::convert_types");
 
             if last_segment.arguments.is_empty() {
                 Self::convert(Cow::Borrowed(path), last_segment)

--- a/utoipa-gen/src/schema.rs
+++ b/utoipa-gen/src/schema.rs
@@ -206,6 +206,23 @@ impl<'a> ComponentPart<'a> {
     fn is_any(&self) -> bool {
         &*self.path.to_token_stream().to_string() == "Any"
     }
+
+    /// Check whether [`ComponentPart`]'s [`syn::TypePath`] is a given type as [`str`].
+    pub fn is(&self, s: &str) -> bool {
+        let mut is = self
+            .path
+            .path
+            .segments
+            .last()
+            .expect("at least one segment in ComponentPart path")
+            .ident
+            == s;
+        if let Some(ref child) = self.child {
+            is = is || child.is(s)
+        }
+
+        is
+    }
 }
 
 impl<'a> AsMut<ComponentPart<'a>> for ComponentPart<'a> {

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -821,6 +821,8 @@ where
                             }
                         }
                     }
+                    // TODO support for tuple types
+                    ValueType::Tuple => (),
                 }
             }
         }

--- a/utoipa-gen/src/schema/into_params.rs
+++ b/utoipa-gen/src/schema/into_params.rs
@@ -485,6 +485,8 @@ impl ToTokens for ParamType<'_> {
                             });
                         }
                     }
+                    // TODO support for tuple types
+                    ValueType::Tuple => (),
                 }
             }
         };


### PR DESCRIPTION
Add Rocket IntoParams implementation for `FromForm` trait and refactor
Rocket extensions.

Refactor all extension modules to use general `TypeTree` type for
arguments and generalize implementations. Clean up the extension
implementations and deprecate `ComponentPart` type in favor of new
`TypeTree` type which handles maps and tuples correctly. Further PR:s
should address moving to the new `TypeTree`.

Implements #222 