### PR TITLE
Chore refactor ComponentPart to TypeTree

### DIFF
--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -190,7 +190,7 @@ pub mod fn_arg {
                         "unexpected syn::Pat, expected syn::Pat::Ident,in get_fn_args, cannot get fn argument name"
                     ),
                 };
-                (TypeTree::form_type(&pat_type.ty), arg_name)
+                (TypeTree::from_type(&pat_type.ty), arg_name)
             })
             .map(FnArg::from)
     }

--- a/utoipa-gen/src/schema/component.rs
+++ b/utoipa-gen/src/schema/component.rs
@@ -20,7 +20,7 @@ use self::{
 
 use super::{
     serde::{self, RenameRule, SerdeContainer, SerdeValue},
-    ComponentPart, GenericType, ValueType,
+    GenericType, TypeTree, ValueType,
 };
 
 mod attr;
@@ -218,15 +218,14 @@ impl ToTokens for NamedStructComponent<'_> {
                 let name = &rename_field(&container_rules, &mut field_rule, field_name)
                     .unwrap_or_else(|| String::from(field_name));
 
-                let component_part = &mut ComponentPart::from_type(&field.ty);
+                let type_tree = &mut TypeTree::from_type(&field.ty);
 
                 if let Some((generic_types, alias)) = self.generics.zip(self.alias) {
                     generic_types
                         .type_params()
                         .enumerate()
                         .for_each(|(index, generic)| {
-                            if let Some(generic_type) =
-                                component_part.find_mut_by_ident(&generic.ident)
+                            if let Some(generic_type) = type_tree.find_mut_by_ident(&generic.ident)
                             {
                                 generic_type.update_path(
                                     &alias.generics.type_params().nth(index).unwrap().ident,
@@ -236,18 +235,12 @@ impl ToTokens for NamedStructComponent<'_> {
                 }
 
                 let deprecated = super::get_deprecated(&field.attrs);
-                let attrs = ComponentAttr::<NamedField>::from_attributes_validated(
-                    &field.attrs,
-                    component_part,
-                );
+                let attrs =
+                    ComponentAttr::<NamedField>::from_attributes_validated(&field.attrs, type_tree);
 
-                let override_component_part = attrs.as_ref().and_then(|field| {
-                    field
-                        .as_ref()
-                        .value_type
-                        .as_ref()
-                        .map(ComponentPart::from_type_path)
-                });
+                let override_type_tree = attrs
+                    .as_ref()
+                    .and_then(|field| field.as_ref().value_type.as_ref().map(TypeTree::from_type));
 
                 let xml_value = attrs
                     .as_ref()
@@ -255,7 +248,7 @@ impl ToTokens for NamedStructComponent<'_> {
                 let comments = CommentAttributes::from_attributes(&field.attrs);
 
                 let component = ComponentProperty::new(
-                    override_component_part.as_ref().unwrap_or(component_part),
+                    override_type_tree.as_ref().unwrap_or(type_tree),
                     Some(&comments),
                     attrs.as_ref(),
                     deprecated.as_ref(),
@@ -300,13 +293,13 @@ impl ToTokens for UnnamedStructComponent<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let fields_len = self.fields.len();
         let first_field = self.fields.first().unwrap();
-        let first_part = &ComponentPart::from_type(&first_field.ty);
+        let first_part = &TypeTree::from_type(&first_field.ty);
 
         let mut is_object = matches!(first_part.value_type, ValueType::Object);
 
         let all_fields_are_same = fields_len == 1
             || self.fields.iter().skip(1).all(|field| {
-                let component_part = &ComponentPart::from_type(&field.ty);
+                let component_part = &TypeTree::from_type(&field.ty);
 
                 first_part == component_part
             });
@@ -320,7 +313,7 @@ impl ToTokens for UnnamedStructComponent<'_> {
                     .as_ref()
                     .value_type
                     .as_ref()
-                    .map(ComponentPart::from_type_path)
+                    .map(TypeTree::from_type)
             });
 
             if override_component.is_some() {
@@ -660,7 +653,7 @@ struct TypeTuple<'a, T>(T, &'a Ident);
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 struct ComponentProperty<'a, T> {
-    component_part: &'a ComponentPart<'a>,
+    component_part: &'a TypeTree<'a>,
     comments: Option<&'a CommentAttributes>,
     attrs: Option<&'a ComponentAttr<T>>,
     deprecated: Option<&'a Deprecated>,
@@ -669,7 +662,7 @@ struct ComponentProperty<'a, T> {
 
 impl<'a, T: Sized + ToTokens> ComponentProperty<'a, T> {
     fn new(
-        component_part: &'a ComponentPart<'a>,
+        component_part: &'a TypeTree<'a>,
         comments: Option<&'a CommentAttributes>,
         attrs: Option<&'a ComponentAttr<T>>,
         deprecated: Option<&'a Deprecated>,
@@ -699,8 +692,16 @@ where
             Some(GenericType::Map) => {
                 // Maps are treated as generic objects with no named properties and
                 // additionalProperties denoting the type
+                // maps have 2 child components and we are interested the second one of them
+                // which is used to determine the additional properties
                 let component_property = ComponentProperty::new(
-                    self.component_part.child.as_ref().unwrap().as_ref(),
+                    self.component_part
+                        .children
+                        .as_ref()
+                        .expect("ComponentProperty Map type should have children")
+                        .iter()
+                        .nth(1)
+                        .expect("ComponentProperty Map type should have 2 child"),
                     self.comments,
                     self.attrs,
                     self.deprecated,
@@ -720,7 +721,13 @@ where
             }
             Some(GenericType::Vec) => {
                 let component_property = ComponentProperty::new(
-                    self.component_part.child.as_ref().unwrap().as_ref(),
+                    self.component_part
+                        .children
+                        .as_ref()
+                        .expect("ComponentProperty Vec should have children")
+                        .iter()
+                        .next()
+                        .expect("ComponentProperty Vec should have 1 child"),
                     self.comments,
                     self.attrs,
                     self.deprecated,
@@ -746,7 +753,13 @@ where
             | Some(GenericType::Box)
             | Some(GenericType::RefCell) => {
                 let component_property = ComponentProperty::new(
-                    self.component_part.child.as_ref().unwrap().as_ref(),
+                    self.component_part
+                        .children
+                        .as_ref()
+                        .expect("ComponentProperty generic container type should have children")
+                        .iter()
+                        .next()
+                        .expect("ComponentProperty generic container type should have 1 child"),
                     self.comments,
                     self.attrs,
                     self.deprecated,
@@ -756,17 +769,18 @@ where
                 tokens.extend(component_property.into_token_stream())
             }
             None => {
-                let component_part = self.component_part;
+                let type_tree = self.component_part;
 
-                match component_part.value_type {
+                match type_tree.value_type {
                     ValueType::Primitive => {
-                        let component_type = ComponentType(&*component_part.path);
+                        let type_path = &**type_tree.path.as_ref().unwrap();
+                        let component_type = ComponentType(type_path);
 
                         tokens.extend(quote! {
                             utoipa::openapi::PropertyBuilder::new().component_type(#component_type)
                         });
 
-                        let format: ComponentFormat = (&*component_part.path).into();
+                        let format: ComponentFormat = (type_path).into();
                         if format.is_known_format() {
                             tokens.extend(quote! {
                                 .format(Some(#format))
@@ -805,16 +819,16 @@ where
                             .attrs
                             .map(|attributes| attributes.is_inline())
                             .unwrap_or(false);
-                        if component_part.is_any() {
+                        if type_tree.is_any() {
                             tokens.extend(quote! { utoipa::openapi::ObjectBuilder::new() })
                         } else {
-                            let component_path = &*component_part.path;
+                            let type_path = &**type_tree.path.as_ref().unwrap();
                             if is_inline {
-                                tokens.extend(quote_spanned! {component_path.span() =>
-                                    <#component_path as utoipa::Component>::component()
+                                tokens.extend(quote_spanned! {type_path.span() =>
+                                    <#type_path as utoipa::Component>::component()
                                 });
                             } else {
-                                let name = format_path_ref(component_path);
+                                let name = format_path_ref(type_path);
                                 tokens.extend(quote! {
                                     utoipa::openapi::Ref::from_component_name(#name)
                                 })


### PR DESCRIPTION
Refactor ComponentPart references to TypeTree which is improved version
of ComponentPart handling correctly Maps and tuple types.