### PR TITLE
Only enable the "deflate" feature of the zip crate

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -32,6 +32,6 @@ similar = "2.1"
 features = ["actix-web", "rocket"]
 
 [build-dependencies]
-zip = "0.6"
+zip = { version = "0.6", default-features = false, features = ["deflate"] }
 regex = "1.5"  
 lazy_static = "1.4"


### PR DESCRIPTION
This saves ~3-4 seconds on release builds on my local machine per `cargo build --timings`