### PR TITLE
Feature `openapi_extensions` with helper functions for JSON responses and requestBodies

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@ jobs:
   test:
     strategy:
       matrix:
-        testset: 
+        testset:
           - utoipa
           - utoipa-gen
           - utoipa-swagger-ui
@@ -38,7 +38,7 @@ jobs:
           ~/.cargo/git/db/
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-    
+
     - name: Resolve changed paths
       id: changes
       run: |
@@ -61,7 +61,7 @@ jobs:
     - name: Run tests
       run: |
         if [[ "${{ matrix.testset }}" == "utoipa" ]] && [[ ${{ steps.changes.outputs.root_changed }} == true ]]; then
-          cargo test --features uuid
+          cargo test --features uuid,openapi_extensions
           cargo test --test path_response_derive_test_no_serde_json --no-default-features
           cargo test --test component_derive_no_serde_json --no-default-features
           cargo test --test path_derive_actix --test path_parameter_derive_actix --features actix_extras

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ yaml = ["serde_yaml"]
 uuid = ["utoipa-gen/uuid"]
 time = ["utoipa-gen/time"]
 smallvec = ["utoipa-gen/smallvec"]
+openapi_extensions = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@ Rust if auto generation is not your flavor or does not fit your purpose.
 Long term goal of the library is to be the place to go when OpenAPI documentation is needed in Rust
 codebase.
 
-Utoipa is framework agnostic and could be used together with any web framework or even without one. While 
-being portable and standalone one of it's key aspects is simple integration with web frameworks. 
+Utoipa is framework agnostic and could be used together with any web framework or even without one. While
+being portable and standalone one of it's key aspects is simple integration with web frameworks.
 
 ## Choose your flavor and document your API with ice cold IPA
 
 Existing [examples](./examples) for following frameworks:
 
-* **[actix-web](https://github.com/actix/actix-web)** 
+* **[actix-web](https://github.com/actix/actix-web)**
 * **[axum](https://github.com/tokio-rs/axum)**
 * **[warp](https://github.com/seanmonstar/warp)**
 * **[tide](https://github.com/http-rs/tide)**
 * **[rocket](https://github.com/SergioBenitez/Rocket)**
 
-Even if there is no example for your favourite framework `utoipa` can be used with any 
+Even if there is no example for your favourite framework `utoipa` can be used with any
 web framework which supports decorating functions with macros similarly to **warp** and **tide** examples.
 
 ## What's up with the word play?
@@ -49,34 +49,36 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also awesome type of beer :be
 * **json** Enables **serde_json** serialization of OpenAPI objects which also allows usage of JSON within
   OpenAPI values e.g. within `example` value. This is enabled by default.
 * **yaml** Enables **serde_yaml** serialization of OpenAPI objects.
-* **actix_extras** Enhances [actix-web](https://github.com/actix/actix-web/) integration with being able to 
-  parse `path` and `path and query parameters` from actix web path attribute macros. See 
+* **actix_extras** Enhances [actix-web](https://github.com/actix/actix-web/) integration with being able to
+  parse `path` and `path and query parameters` from actix web path attribute macros. See
   [docs](https://docs.rs/utoipa/1.1.0/utoipa/attr.path.html#actix_extras-support-for-actix-web) or [examples](./examples) for more details.
 * **rocket_extras** Enhances [rocket](https://github.com/SergioBenitez/Rocket) framework integration with being
   able to parse `path`, `path and query parameters` from rocket path attribute macros. See [docs](https://docs.rs/utoipa/1.1.0/utoipa/attr.path.html#rocket_extras-support-for-rocket)
   or [examples](./examples) for more details.
-* **axum_extras** Enhances [axum](https://github.com/tokio-rs/axum) framework integration allowing users to use `IntoParams` without defining the `parameter_in` attribute. See 
+* **axum_extras** Enhances [axum](https://github.com/tokio-rs/axum) framework integration allowing users to use `IntoParams` without defining the `parameter_in` attribute. See
   [docs](https://docs.rs/utoipa/1.1.0/utoipa/attr.path.html#axum_extras-suppport-for-axum) or [examples](./examples) for more details.
 * **debug** Add extra traits such as debug traits to openapi definitions and elsewhere.
 * **chrono** Add support for [chrono](https://crates.io/crates/chrono) `DateTime`, `Date` and `Duration`
-  types. By default these types are parsed to `string` types without additional format. If you want to have 
-  formats added to the types use *chrono_with_format* feature. This is useful because OpenAPI 3.1 spec 
-  does not have date-time formats. To override default `string` representation 
+  types. By default these types are parsed to `string` types without additional format. If you want to have
+  formats added to the types use *chrono_with_format* feature. This is useful because OpenAPI 3.1 spec
+  does not have date-time formats. To override default `string` representation
   users have to use `value_type` attribute to override the type. See [docs](https://docs.rs/utoipa/1.1.0/utoipa/derive.Component.html) for more details.
-* **chrono_with_format** Add support to [chrono](https://crates.io/crates/chrono) types described above 
+* **chrono_with_format** Add support to [chrono](https://crates.io/crates/chrono) types described above
   with additional `format` information type. `date-time` for `DateTime` and `date` for `Date` according
-  [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14) as `ISO-8601`. To override default `string` representation 
+  [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14) as `ISO-8601`. To override default `string` representation
   users have to use `value_type` attribute to override the type. See [docs](https://docs.rs/utoipa/1.1.0/utoipa/derive.Component.html) for more details.
 * **time** Add support for [time](https://crates.io/crates/time) `OffsetDateTime`, `PrimitiveDateTime`, `Date`, and `Duration` types.
   By default these types are parsed as `string`. `OffsetDateTime` and `PrimitiveDateTime` will use `date-time` format. `Date` will use
   `date` format and `Duration` will not have any format. To override default `string` representation users have to use `value_type` attribute
   to override the type. See [docs](https://docs.rs/utoipa/1.1.0/utoipa/derive.Component.html) for more details.
-* **decimal** Add support for [rust_decimal](https://crates.io/crates/rust_decimal) `Decimal` type. **By default** 
-  it is interpreted as `String`. If you wish to change the format you need to override the type. 
+* **decimal** Add support for [rust_decimal](https://crates.io/crates/rust_decimal) `Decimal` type. **By default**
+  it is interpreted as `String`. If you wish to change the format you need to override the type.
   See the `value_type` in [component derive docs](https://docs.rs/utoipa/1.1.0/utoipa/derive.Component.html).
 * **uuid** Add support for [uuid](https://github.com/uuid-rs/uuid). `Uuid` type will be presented as `String` with
   format `uuid` in OpenAPI spec.
 * **smallvec** Add support for [smallvec](https://crates.io/crates/smallvec). `SmallVec` will be treated as `Vec`.
+* **openapi_extensions** Adds traits and functions that provide extra convenience functions.
+  See the [`request_body` docs](https://docs.rs/utoipa/latest/utoipa/openapi/request_body) for an example.
 
 Utoipa implicitly has partial support for `serde` attributes. See [docs](https://docs.rs/utoipa/1.1.0/utoipa/derive.Component.html#partial-serde-attributes-support) for more details.
 
@@ -121,7 +123,7 @@ Create a handler that would handle your business logic and add `path` proc attri
 mod pet_api {
     /// Get pet by id
     ///
-    /// Get pet from database by pet id  
+    /// Get pet from database by pet id
     #[utoipa::path(
         get,
         path = "/pets/{id}",
@@ -249,5 +251,5 @@ This would produce api doc something similar to:
 
 Licensed under either of [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT) license at your option.
 
-Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this crate 
-by you, shall be dual licensed, without any additional terms or conditions. 
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this crate
+by you, shall be dual licensed, without any additional terms or conditions.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,9 @@
 //! * **uuid** Add support for [uuid](https://github.com/uuid-rs/uuid). `Uuid` type will be presented as `String` with
 //!   format `uuid` in OpenAPI spec.
 //! * **smallvec** Add support for [smallvec](https://crates.io/crates/smallvec). `SmallVec` will be treated as `Vec`.
+//! * **openapi_extensions** Adds convenience functions for documenting common scenarios, such as JSON request bodies and responses.
+//!   See the [`request_body`](https://docs.rs/utoipa/latest/utoipa/openapi/request_body/index.html) and
+//!   [`response`](https://docs.rs/utoipa/latest/utoipa/openapi/response/index.html) docs for examples.
 //!
 //! Utoipa implicitly has partial support for `serde` attributes. See [component derive][serde] for more details.
 //!
@@ -114,7 +117,7 @@
 //! mod pet_api {
 //! #     use utoipa::OpenApi;
 //! #     use utoipa::Component;
-//! #     
+//! #
 //! #     #[derive(Component)]
 //! #     struct Pet {
 //! #       id: u64,
@@ -123,7 +126,7 @@
 //! #     }
 //!     /// Get pet by id
 //!     ///
-//!     /// Get pet from database by pet id  
+//!     /// Get pet from database by pet id
 //!     #[utoipa::path(
 //!         get,
 //!         path = "/pets/{id}",
@@ -149,7 +152,7 @@
 //! ```rust
 //! # mod pet_api {
 //! #     use utoipa::Component;
-//! #     
+//! #
 //! #     #[derive(Component)]
 //! #     struct Pet {
 //! #       id: u64,
@@ -159,7 +162,7 @@
 //! #
 //! #     /// Get pet by id
 //! #     ///
-//! #     /// Get pet from database by pet id  
+//! #     /// Get pet from database by pet id
 //! #     #[utoipa::path(
 //! #         get,
 //! #         path = "/pets/{id}",
@@ -345,7 +348,7 @@ pub trait Component {
 /// #
 /// /// Get pet by id
 /// ///
-/// /// Get pet from database by pet database id  
+/// /// Get pet from database by pet database id
 /// #[utoipa::path(
 ///     get,
 ///     path = "/pets/{id}",

--- a/src/openapi/request_body.rs
+++ b/src/openapi/request_body.rs
@@ -90,13 +90,13 @@ impl RequestBodyBuilder {
 ///
 #[cfg(feature = "openapi_extensions")]
 pub trait RequestBodyExt {
+    /// Add [`Content`] to [`RequestBody`] referring to a schema
+    /// with Content-Type `application/json`.
     fn json_component_ref(self, ref_name: &str) -> Self;
 }
 
 #[cfg(feature = "openapi_extensions")]
 impl RequestBodyExt for RequestBody {
-    /// Add [`Content`] to [`RequestBody`] referring to a component-schema
-    /// with Content-Type `application/json`.
     fn json_component_ref(mut self, ref_name: &str) -> RequestBody {
         self.content.insert(
             "application/json".to_string(),
@@ -109,8 +109,6 @@ impl RequestBodyExt for RequestBody {
 
 #[cfg(feature = "openapi_extensions")]
 impl RequestBodyExt for RequestBodyBuilder {
-    /// Add [`Content`] to [`RequestBody`] referring to a component-schema
-    /// with Content-Type `application/json`.
     fn json_component_ref(self, ref_name: &str) -> RequestBodyBuilder {
         self.content(
             "application/json",

--- a/src/openapi/request_body.rs
+++ b/src/openapi/request_body.rs
@@ -57,9 +57,60 @@ impl RequestBodyBuilder {
     }
 }
 
+/// Trait with convenience functions for documenting request bodies.
+///
+/// This trait requires a feature-flag to enable:
+/// ```text
+/// [dependencies]
+/// utoipa = { version = "1", features = ["openapi_extensions"] }
+/// ```
+///
+/// Once enabled, with a single method call we can add [`Content`] to our RequestBodyBuilder
+/// that references a [`crate::Component`] schema using content-tpe "application/json":
+///
+/// ```rust
+/// use utoipa::openapi::request_body::{RequestBodyBuilder, RequestBodyBuilderExt};
+///
+/// let request = RequestBodyBuilder::new().json_component_ref("EmailPayload").build();
+/// ```
+///
+/// If serialized to JSON, the above will result in a requestBody schema like this:
+///
+/// ```json
+/// {
+///   "content": {
+///     "application/json": {
+///       "schema": {
+///         "$ref": "#/components/schemas/EmailPayload"
+///       }
+///     }
+///   }
+/// }
+/// ```
+///
+#[cfg(feature = "openapi_extensions")]
+pub trait RequestBodyBuilderExt {
+    fn json_component_ref(self, ref_name: &str) -> Self;
+}
+
+#[cfg(feature = "openapi_extensions")]
+impl RequestBodyBuilderExt for RequestBodyBuilder {
+    /// Add [`Content`] to [`RequestBody`] referring to a component-schema
+    /// with Content-Type `application/json`.
+    fn json_component_ref(self, ref_name: &str) -> RequestBodyBuilder {
+        self.content(
+            "application/json",
+            crate::openapi::Content::new(crate::openapi::Ref::from_component_name(ref_name)),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::RequestBody;
+    use assert_json_diff::assert_json_eq;
+    use serde_json::json;
+
+    use super::{Content, RequestBody, RequestBodyBuilder, Required};
 
     #[test]
     fn request_body_new() {
@@ -68,5 +119,54 @@ mod tests {
         assert!(request_body.content.is_empty());
         assert_eq!(request_body.description, None);
         assert!(request_body.required.is_none());
+    }
+
+    #[test]
+    fn request_body_builder() -> Result<(), serde_json::Error> {
+        let request_body = RequestBodyBuilder::new()
+            .description(Some("A sample requestBody"))
+            .required(Some(Required::True))
+            .content(
+                "application/json",
+                Content::new(crate::openapi::Ref::from_component_name("EmailPayload")),
+            )
+            .build();
+        let serialized = serde_json::to_string_pretty(&request_body)?;
+        println!("serialized json:\n {}", serialized);
+        assert_json_eq!(
+            request_body,
+            json!({
+            "description": "A sample requestBody",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EmailPayload"
+                }
+              }
+            },
+            "required": true
+          })
+        );
+        Ok(())
+    }
+    #[cfg(feature = "openapi_extensions")]
+    use super::RequestBodyBuilderExt;
+
+    #[cfg(feature = "openapi_extensions")]
+    #[test]
+    fn request_body_builder_ext() {
+        let request_body = RequestBodyBuilder::new().json_component_ref("EmailPayload").build();
+        assert_json_eq!(
+            request_body,
+            json!({
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/schemas/EmailPayload"
+                    }
+                  }
+                }
+              })
+        );
     }
 }

--- a/src/openapi/response.rs
+++ b/src/openapi/response.rs
@@ -152,15 +152,19 @@ impl ResponseBuilder {
 ///
 #[cfg(feature = "openapi_extensions")]
 pub trait ResponseExt {
+    /// Add [`Content`] to [`Response`] referring to a schema
+    /// with Content-Type `application/json`.
     fn json_component_ref(self, ref_name: &str) -> Self;
+
+    /// Add [`Content`] to [`Response`] referring to a response
+    /// with Content-Type `application/json`.
     fn json_response_ref(self, ref_name: &str) -> Self;
 }
 
 
 #[cfg(feature = "openapi_extensions")]
 impl ResponseExt for Response {
-    /// Add [`Content`] to [`Response`] referring to a component-schema
-    /// with Content-Type `application/json`.
+
     fn json_component_ref(mut self, ref_name: &str) -> Response {
         self.content.insert(
             "application/json".to_string(),
@@ -169,8 +173,6 @@ impl ResponseExt for Response {
         self
     }
 
-    /// Add [`Content`] to [`Response`] referring to a component-response
-    /// with Content-Type `application/json`.
     fn json_response_ref(mut self, ref_name: &str) -> Response {
         self.content.insert(
             "application/json".to_string(),
@@ -182,8 +184,7 @@ impl ResponseExt for Response {
 
 #[cfg(feature = "openapi_extensions")]
 impl ResponseExt for ResponseBuilder {
-    /// Add [`Content`] to [`Response`] referring to a component-schema
-    /// with Content-Type `application/json`.
+
     fn json_component_ref(self, ref_name: &str) -> ResponseBuilder {
         self.content(
             "application/json",
@@ -191,8 +192,6 @@ impl ResponseExt for ResponseBuilder {
         )
     }
 
-    /// Add [`Content`] to [`Response`] referring to a component-response
-    /// with Content-Type `application/json`.
     fn json_response_ref(self, ref_name: &str) -> ResponseBuilder {
         self.content(
             "application/json",

--- a/src/openapi/response.rs
+++ b/src/openapi/response.rs
@@ -114,14 +114,129 @@ impl ResponseBuilder {
     }
 }
 
+/// Trait with convenience functions for documenting response bodies.
+///
+/// This trait requires a feature-flag to enable:
+/// ```text
+/// [dependencies]
+/// utoipa = { version = "1", features = ["openapi_extensions"] }
+/// ```
+///
+/// Once enabled, with a single method call we can add [`Content`] to our ResponseBuilder
+/// that references a responses (or component) schema using content-tpe "application/json":
+///
+/// ```rust
+/// use utoipa::openapi::response::{ResponseBuilder, ResponseBuilderExt};
+///
+/// let request = ResponseBuilder::new()
+///     .description("A sample response")
+///     .json_response_ref("MyResponsePayload").build();
+/// // Alternately for component, use
+/// // let request = ResponseBuilder::new().json_component_ref("MyResponsePayload").build();
+/// ```
+///
+/// If serialized to JSON, the above will result in a response schema like this:
+///
+/// ```json
+/// {
+///   "description": "A sample response",
+///   "content": {
+///     "application/json": {
+///       "schema": {
+///         "$ref": "#/components/responses/MyResponsePayload"
+///       }
+///     }
+///   }
+/// }
+/// ```
+///
+#[cfg(feature = "openapi_extensions")]
+pub trait ResponseBuilderExt {
+    fn json_component_ref(self, ref_name: &str) -> Self;
+    fn json_response_ref(self, ref_name: &str) -> Self;
+}
+
+#[cfg(feature = "openapi_extensions")]
+impl ResponseBuilderExt for ResponseBuilder {
+    /// Add [`Content`] to [`Response`] referring to a component-schema
+    /// with Content-Type `application/json`.
+    fn json_component_ref(self, ref_name: &str) -> ResponseBuilder {
+        self.content(
+            "application/json",
+            Content::new(crate::openapi::Ref::from_component_name(ref_name)),
+        )
+    }
+
+    /// Add [`Content`] to [`Response`] referring to a component-response
+    /// with Content-Type `application/json`.
+    fn json_response_ref(self, ref_name: &str) -> ResponseBuilder {
+        self.content(
+            "application/json",
+            Content::new(crate::openapi::Ref::from_response_name(ref_name)),
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::Responses;
+    use assert_json_diff::assert_json_eq;
+    use serde_json::json;
+    use super::{Content, Responses, ResponseBuilder};
 
     #[test]
     fn responses_new() {
         let responses = Responses::new();
 
         assert!(responses.responses.is_empty());
+    }
+
+    #[test]
+    fn response_builder() -> Result<(), serde_json::Error> {
+        let request_body = ResponseBuilder::new()
+            .description("A sample response")
+            .content(
+                "application/json",
+                Content::new(crate::openapi::Ref::from_response_name("MyResponsePayload")),
+            )
+            .build();
+        let serialized = serde_json::to_string_pretty(&request_body)?;
+        println!("serialized json:\n {}", serialized);
+        assert_json_eq!(
+            request_body,
+            json!({
+            "description": "A sample response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/responses/MyResponsePayload"
+                }
+              }
+            }
+          })
+        );
+        Ok(())
+    }
+    #[cfg(feature = "openapi_extensions")]
+    use super::ResponseBuilderExt;
+
+    #[cfg(feature = "openapi_extensions")]
+    #[test]
+    fn response_builder_ext() {
+        let request_body = ResponseBuilder::new()
+            .description("A sample response")
+            .json_response_ref("MyResponsePayload").build();
+        assert_json_eq!(
+            request_body,
+            json!({
+                "description": "A sample response",
+                "content": {
+                  "application/json": {
+                    "schema": {
+                      "$ref": "#/components/responses/MyResponsePayload"
+                    }
+                  }
+                }
+              })
+        );
     }
 }

--- a/src/openapi/schema.rs
+++ b/src/openapi/schema.rs
@@ -671,6 +671,12 @@ impl Ref {
         Self::new(&format!("#/components/schemas/{}", component_name.into()))
     }
 
+    /// Construct a new [`Ref`] from provided response name. This will create a [`Ref`] that
+    /// references the reusable response.
+    pub fn from_response_name<I: Into<String>>(response_name: I) -> Self {
+        Self::new(&format!("#/components/responses/{}", response_name.into()))
+    }
+
     to_array_builder!();
 }
 


### PR DESCRIPTION
Following our [discussion](https://github.com/juhaku/utoipa/discussions/236) on adding some helper functions for documenting a JSON `requestBody` or `response`, this PR includes the following, all gated by the feature-flag suggested in the discussion, `openapi_extensions`:

- New Trait `RequestBodyExt` for easily documenting JSON `requestBody` content (implemented for `RequestBodyBuilder` ).
- New Trait `ResponseExt` for easily documenting JSON `response` content (implemented for `ResponseBuilder`).
- Includes tests for new traits and methods
- Includes documentation for these traits

In addition, the following changes are also included:
- Adds `from_response_name` for `Ref` struct for `"#/components/responses/SomeObject"` references
- Adds `-F openapi_extensions` to `cargo tests` github actions workflow

## Questions

Having traits in this case may be unnecessary because these methods are only implemented in each case for a single `struct`. We could do one of the following [with these traits]:

- Create a _single_ trait that is shared by `RequestBodyBuilder` and `ResponseBuilder` (instead of two separate traits). The trait could include common shared things, but _may_ result in people using `response` objects in requests or otherwise blending the two different types. (A single shared trait is originally how I did this in my own project.)
- Drop the traits and implement these as methods directly on `RequestBodyBuilder` and `ResponseBuilder`.
- Alternatively, I could keep the two new traits but also implement `RequestBodyBuilderExt` (probably renaming the trait) for `RequestBody` and `ResponseBuilderExt` for `Response` (also renaming the trait) instead of just for the builders and then having traits would probably be justified.

Happy to implement one of the above or leave this as-is. Also, happy to take any feedback or make any changes requested.