### PR TITLE
Rename handlers to paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Tie the `Schema` and the endpoint above to the OpenApi schema with following `Op
 use utoipa::OpenApi;
 
 #[derive(OpenApi)]
-#[openapi(handlers(pet_api::get_pet_by_id), components(schemas(Pet)))]
+#[openapi(paths(pet_api::get_pet_by_id), components(schemas(Pet)))]
 struct ApiDoc;
 
 println!("{}", ApiDoc::openapi().to_pretty_json().unwrap());

--- a/examples/actix-web-multiple-api-docs-with-scopes/src/main.rs
+++ b/examples/actix-web-multiple-api-docs-with-scopes/src/main.rs
@@ -9,11 +9,11 @@ async fn main() -> Result<(), impl Error> {
     env_logger::init();
 
     #[derive(OpenApi)]
-    #[openapi(handlers(api1::hello1))]
+    #[openapi(paths(api1::hello1))]
     struct ApiDoc1;
 
     #[derive(OpenApi)]
-    #[openapi(handlers(api2::hello2))]
+    #[openapi(paths(api2::hello2))]
     struct ApiDoc2;
 
     HttpServer::new(move || {

--- a/examples/rocket-0_4-hello/src/main.rs
+++ b/examples/rocket-0_4-hello/src/main.rs
@@ -11,7 +11,7 @@ use utoipa_swagger_ui::Config;
 
 fn main() {
     #[derive(OpenApi)]
-    #[openapi(handlers(hello))]
+    #[openapi(paths(hello))]
     struct ApiDoc;
 
     rocket::ignite()

--- a/examples/rocket-todo/src/main.rs
+++ b/examples/rocket-todo/src/main.rs
@@ -15,7 +15,7 @@ fn rocket() -> Rocket<Build> {
 
     #[derive(OpenApi)]
     #[openapi(
-        handlers(
+        paths(
             todo::get_tasks,
             todo::create_todo,
             todo::mark_done,

--- a/examples/todo-actix/src/main.rs
+++ b/examples/todo-actix/src/main.rs
@@ -30,7 +30,7 @@ async fn main() -> Result<(), impl Error> {
 
     #[derive(OpenApi)]
     #[openapi(
-        handlers(
+        paths(
             todo::get_todos,
             todo::create_todo,
             todo::delete_todo,

--- a/examples/todo-axum/src/main.rs
+++ b/examples/todo-axum/src/main.rs
@@ -17,7 +17,7 @@ use crate::todo::Store;
 async fn main() -> Result<(), Error> {
     #[derive(OpenApi)]
     #[openapi(
-        handlers(
+        paths(
             todo::list_todos,
             todo::search_todos,
             todo::create_todo,

--- a/examples/todo-tide/src/main.rs
+++ b/examples/todo-tide/src/main.rs
@@ -18,7 +18,7 @@ async fn main() -> std::io::Result<()> {
 
     #[derive(OpenApi)]
     #[openapi(
-        handlers(
+        paths(
             todo::list_todos,
             todo::create_todo,
             todo::delete_todo,

--- a/examples/todo-warp/src/main.rs
+++ b/examples/todo-warp/src/main.rs
@@ -20,7 +20,7 @@ async fn main() {
 
     #[derive(OpenApi)]
     #[openapi(
-        handlers(todo::list_todos, todo::create_todo, todo::delete_todo),
+        paths(todo::list_todos, todo::create_todo, todo::delete_todo),
         components(
             schemas(todo::Todo)
         ),

--- a/examples/warp-multiple-api-docs/src/main.rs
+++ b/examples/warp-multiple-api-docs/src/main.rs
@@ -16,11 +16,11 @@ async fn main() {
     let config = Arc::new(Config::new(["/api-doc1.json", "/api-doc2.json"]));
 
     #[derive(OpenApi)]
-    #[openapi(handlers(api1::hello1))]
+    #[openapi(paths(api1::hello1))]
     struct ApiDoc1;
 
     #[derive(OpenApi)]
-    #[openapi(handlers(api2::hello2))]
+    #[openapi(paths(api2::hello2))]
     struct ApiDoc2;
 
     let api_doc1 = warp::path("api-doc1.json")
@@ -59,7 +59,9 @@ async fn serve_swagger(
     config: Arc<Config<'static>>,
 ) -> Result<Box<dyn Reply + 'static>, Rejection> {
     if full_path.as_str() == "/swagger-ui" {
-        return Ok(Box::new(warp::redirect::found(Uri::from_static("/swagger-ui/"))));
+        return Ok(Box::new(warp::redirect::found(Uri::from_static(
+            "/swagger-ui/",
+        ))));
     }
 
     let path = tail.as_str();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@
 //! # }
 //! # use utoipa::OpenApi;
 //! #[derive(OpenApi)]
-//! #[openapi(handlers(pet_api::get_pet_by_id), components(schemas(Pet)))]
+//! #[openapi(paths(pet_api::get_pet_by_id), components(schemas(Pet)))]
 //! struct ApiDoc;
 //!
 //! println!("{}", ApiDoc::openapi().to_pretty_json().unwrap());
@@ -232,7 +232,7 @@ pub use utoipa_gen::*;
 /// ```rust
 /// use utoipa::OpenApi;
 /// #[derive(OpenApi)]
-/// #[openapi(handlers())]
+/// #[openapi()]
 /// struct OpenApiDoc;
 /// ```
 ///

--- a/src/openapi/path.rs
+++ b/src/openapi/path.rs
@@ -201,7 +201,7 @@ builder! {
         /// List of tags used for groupping operations.
         ///
         /// When used with derive [`#[utoipa::path(...)]`][derive_path] attribute macro the default
-        /// value used will be resolved from handler path provided in `#[openapi(handlers(...))]` with
+        /// value used will be resolved from handler path provided in `#[openapi(paths(...))]` with
         /// [`#[derive(OpenApi)]`][derive_openapi] macro. If path resolves to `None` value `crate` will
         /// be used by default.
         ///

--- a/tests/path_derive.rs
+++ b/tests/path_derive.rs
@@ -16,7 +16,7 @@ macro_rules! test_api_fn_doc {
     ( $handler:path, operation: $operation:expr, path: $path:literal ) => {{
         use utoipa::OpenApi;
         #[derive(OpenApi, Default)]
-        #[openapi(handlers($handler))]
+        #[openapi(paths($handler))]
         struct ApiDoc;
 
         let doc = &serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -73,7 +73,7 @@ macro_rules! test_path_operation {
             paste!{
                 use utoipa::OpenApi;
                 #[derive(OpenApi, Default)]
-                #[openapi(handlers(
+                #[openapi(paths(
                     [<mod_ $name>]::test_operation
                  ))]
                 struct ApiDoc;
@@ -425,7 +425,7 @@ fn derive_path_params_map() {
 
     use utoipa::OpenApi;
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(use_maps))]
+    #[openapi(paths(use_maps))]
     struct ApiDoc;
 
     let operation: Value = test_api_fn_doc! {
@@ -521,7 +521,7 @@ fn derive_path_params_intoparams() {
 
     use utoipa::OpenApi;
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(list))]
+    #[openapi(paths(list))]
     struct ApiDoc;
 
     let operation: Value = test_api_fn_doc! {
@@ -671,7 +671,7 @@ fn derive_path_params_into_params_with_value_type() {
     fn get_foo(query: Filter) {}
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo))]
+    #[openapi(paths(get_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -786,7 +786,7 @@ fn derive_path_params_into_params_with_raw_identifier() {
     fn get_foo(query: Filter) {}
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo))]
+    #[openapi(paths(get_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -829,7 +829,7 @@ fn derive_path_with_into_responses() {
     fn get_foo() {}
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo))]
+    #[openapi(paths(get_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();

--- a/tests/path_derive_actix.rs
+++ b/tests/path_derive_actix.rs
@@ -39,7 +39,7 @@ mod mod_derive_path_actix {
 #[test]
 fn derive_path_one_value_actix_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(mod_derive_path_actix::get_foo_by_id))]
+    #[openapi(paths(mod_derive_path_actix::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -82,7 +82,7 @@ mod mod_derive_path_unnamed_regex_actix {
 #[test]
 fn derive_path_with_unnamed_regex_actix_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(mod_derive_path_unnamed_regex_actix::get_foo_by_id))]
+    #[openapi(paths(mod_derive_path_unnamed_regex_actix::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -125,7 +125,7 @@ mod mod_derive_path_named_regex_actix {
 #[test]
 fn derive_path_with_named_regex_actix_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(mod_derive_path_named_regex_actix::get_foo_by_id))]
+    #[openapi(paths(mod_derive_path_named_regex_actix::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -164,7 +164,7 @@ fn derive_path_with_multiple_args() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(mod_derive_path_multiple_args::get_foo_by_id))]
+    #[openapi(paths(mod_derive_path_multiple_args::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -212,7 +212,7 @@ fn derive_complex_actix_web_path() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(mod_derive_complex_actix_path::get_foo_by_id))]
+    #[openapi(paths(mod_derive_complex_actix_path::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -254,7 +254,7 @@ fn derive_path_with_multiple_args_with_descriptions() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(mod_derive_path_multiple_args::get_foo_by_id))]
+    #[openapi(paths(mod_derive_path_multiple_args::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -300,7 +300,7 @@ fn derive_path_with_context_path() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo))]
+    #[openapi(paths(get_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -382,7 +382,7 @@ fn path_with_struct_variables_with_into_params() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo))]
+    #[openapi(paths(get_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -450,7 +450,7 @@ fn derive_path_with_struct_variables_with_into_params() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo))]
+    #[openapi(paths(get_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -524,7 +524,7 @@ fn derive_path_with_multiple_instances_same_path_params() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo, delete_foo))]
+    #[openapi(paths(get_foo, delete_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -567,7 +567,7 @@ fn derive_path_with_multiple_into_params_names() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo))]
+    #[openapi(paths(get_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -640,7 +640,7 @@ fn derive_into_params_with_custom_attributes() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo), components(schemas(Sort)))]
+    #[openapi(paths(get_foo), components(schemas(Sort)))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -724,7 +724,7 @@ fn derive_into_params_in_another_module() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(foo_todos))]
+    #[openapi(paths(foo_todos))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -761,7 +761,7 @@ macro_rules! test_derive_path_operations {
         #[test]
         fn $name() {
             #[derive(OpenApi, Default)]
-            #[openapi(handlers($mod::test_operation))]
+            #[openapi(paths($mod::test_operation))]
             struct ApiDoc;
 
             let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();

--- a/tests/path_derive_axum_test.rs
+++ b/tests/path_derive_axum_test.rs
@@ -47,7 +47,7 @@ fn derive_path_params_into_params_axum() {
     async fn get_person(person: Path<Person>, query: Query<custom::Filter>) {}
 
     #[derive(OpenApi)]
-    #[openapi(handlers(get_person))]
+    #[openapi(paths(get_person))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -117,7 +117,7 @@ fn get_todo_with_extension() {
     fn list_todos(Extension(store): Extension<Arc<Store>>) {}
 
     #[derive(OpenApi)]
-    #[openapi(handlers(list_todos))]
+    #[openapi(paths(list_todos))]
     struct ApiDoc;
 
     serde_json::to_value(ApiDoc::openapi())
@@ -144,7 +144,7 @@ fn derive_path_params_into_params_unnamed() {
     async fn get_person(person: Path<IdAndName>) {}
 
     #[derive(OpenApi)]
-    #[openapi(handlers(get_person))]
+    #[openapi(paths(get_person))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();

--- a/tests/path_derive_rocket.rs
+++ b/tests/path_derive_rocket.rs
@@ -22,7 +22,7 @@ fn resolve_route_with_simple_url() {
     }
 
     #[derive(OpenApi)]
-    #[openapi(handlers(rocket_route_operation::hello))]
+    #[openapi(paths(rocket_route_operation::hello))]
     struct ApiDoc;
 
     let openapi = ApiDoc::openapi();
@@ -48,7 +48,7 @@ fn resolve_get_with_multiple_args() {
     }
 
     #[derive(OpenApi)]
-    #[openapi(handlers(rocket_get_operation::hello))]
+    #[openapi(paths(rocket_get_operation::hello))]
     struct ApiDoc;
 
     let openapi = ApiDoc::openapi();
@@ -105,7 +105,7 @@ fn resolve_get_with_optional_query_args() {
     }
 
     #[derive(OpenApi)]
-    #[openapi(handlers(rocket_get_operation::hello))]
+    #[openapi(paths(rocket_get_operation::hello))]
     struct ApiDoc;
 
     let openapi = ApiDoc::openapi();
@@ -154,7 +154,7 @@ fn resolve_path_arguments_not_same_order() {
     }
 
     #[derive(OpenApi)]
-    #[openapi(handlers(rocket_get_operation::hello))]
+    #[openapi(paths(rocket_get_operation::hello))]
     struct ApiDoc;
 
     let openapi = ApiDoc::openapi();
@@ -203,7 +203,7 @@ fn resolve_get_path_with_anonymous_parts() {
     }
 
     #[derive(OpenApi)]
-    #[openapi(handlers(rocket_get_operation::hello))]
+    #[openapi(paths(rocket_get_operation::hello))]
     struct ApiDoc;
 
     let openapi = ApiDoc::openapi();
@@ -261,7 +261,7 @@ fn resolve_get_path_with_tail() {
     }
 
     #[derive(OpenApi)]
-    #[openapi(handlers(rocket_get_operation::hello))]
+    #[openapi(paths(rocket_get_operation::hello))]
     struct ApiDoc;
 
     let openapi = ApiDoc::openapi();
@@ -308,7 +308,7 @@ fn resolve_get_path_and_update_params() {
     }
 
     #[derive(OpenApi)]
-    #[openapi(handlers(rocket_get_operation::hello))]
+    #[openapi(paths(rocket_get_operation::hello))]
     struct ApiDoc;
 
     let openapi = ApiDoc::openapi();
@@ -373,7 +373,7 @@ fn resolve_path_query_params_from_form() {
     }
 
     #[derive(OpenApi)]
-    #[openapi(handlers(rocket_get_operation::hello))]
+    #[openapi(paths(rocket_get_operation::hello))]
     struct ApiDoc;
 
     let openapi = ApiDoc::openapi();
@@ -438,7 +438,7 @@ macro_rules! test_derive_path_operations {
                 }
 
                 #[derive(OpenApi)]
-                #[openapi(handlers(rocket_operation::hello))]
+                #[openapi(paths(rocket_operation::hello))]
                 struct ApiDoc;
 
                 let openapi = ApiDoc::openapi();

--- a/tests/path_parameter_derive_actix.rs
+++ b/tests/path_parameter_derive_actix.rs
@@ -33,7 +33,7 @@ mod derive_params_multiple_actix {
 #[test]
 fn derive_path_parameter_multiple_with_matching_names_and_types_actix_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_params_multiple_actix::get_foo_by_id))]
+    #[openapi(paths(derive_params_multiple_actix::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -89,7 +89,7 @@ mod derive_parameters_multiple_no_matching_names_actix {
 #[test]
 fn derive_path_parameter_multiple_no_matching_names_acitx_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_parameters_multiple_no_matching_names_actix::get_foo_by_id))]
+    #[openapi(paths(derive_parameters_multiple_no_matching_names_actix::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -138,7 +138,7 @@ mod derive_params_from_method_args_actix {
 #[test]
 fn derive_params_from_method_args_actix_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_params_from_method_args_actix::get_foo_by_id))]
+    #[openapi(paths(derive_params_from_method_args_actix::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();

--- a/tests/path_parameter_derive_test.rs
+++ b/tests/path_parameter_derive_test.rs
@@ -28,7 +28,7 @@ mod derive_params_all_options {
 #[test]
 fn derive_path_parameters_with_all_options_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_params_all_options::get_foo_by_id))]
+    #[openapi(paths(derive_params_all_options::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -69,7 +69,7 @@ mod derive_params_minimal {
 #[test]
 fn derive_path_parameters_minimal_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_params_minimal::get_foo_by_id))]
+    #[openapi(paths(derive_params_minimal::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -111,7 +111,7 @@ mod derive_params_multiple {
 #[test]
 fn derive_path_parameter_multiple_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_params_multiple::get_foo_by_id))]
+    #[openapi(paths(derive_params_multiple::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -166,7 +166,7 @@ mod mod_derive_parameters_all_types {
 #[test]
 fn derive_parameters_with_all_types() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(mod_derive_parameters_all_types::get_foo_by_id))]
+    #[openapi(paths(mod_derive_parameters_all_types::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -238,7 +238,7 @@ mod derive_params_without_args {
 #[test]
 fn derive_params_without_fn_args() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_params_without_args::get_foo_by_id))]
+    #[openapi(paths(derive_params_without_args::get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
@@ -274,7 +274,7 @@ fn derive_params_with_params_ext() {
     }
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(get_foo_by_id))]
+    #[openapi(paths(get_foo_by_id))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();

--- a/tests/path_response_derive_test.rs
+++ b/tests/path_response_derive_test.rs
@@ -24,7 +24,7 @@ macro_rules! api_doc {
     ( module: $module:expr ) => {{
         use utoipa::OpenApi;
         #[derive(OpenApi, Default)]
-        #[openapi(handlers($module::get_foo))]
+        #[openapi(paths($module::get_foo))]
         struct ApiDoc;
 
         let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();

--- a/tests/path_response_derive_test_no_serde_json.rs
+++ b/tests/path_response_derive_test_no_serde_json.rs
@@ -22,7 +22,7 @@ fn derive_response_with_string_example_compiles_success() {
     use utoipa::OpenApi;
 
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(response_with_string_example::get_foo))]
+    #[openapi(paths(response_with_string_example::get_foo))]
     struct ApiDoc;
     ApiDoc::openapi();
 }

--- a/tests/request_body_derive_test.rs
+++ b/tests/request_body_derive_test.rs
@@ -36,7 +36,7 @@ test_fn! {
 #[test]
 fn derive_path_request_body_simple_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_simple::post_foo))]
+    #[openapi(paths(derive_request_body_simple::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -57,7 +57,7 @@ test_fn! {
 #[test]
 fn derive_path_request_body_simple_array_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_simple_array::post_foo))]
+    #[openapi(paths(derive_request_body_simple_array::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -80,7 +80,7 @@ test_fn! {
 #[test]
 fn derive_request_body_option_array_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_option_array::post_foo))]
+    #[openapi(paths(derive_request_body_option_array::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -103,7 +103,7 @@ test_fn! {
 #[test]
 fn derive_request_body_primitive_simple_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_primitive_simple::post_foo))]
+    #[openapi(paths(derive_request_body_primitive_simple::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -126,7 +126,7 @@ test_fn! {
 #[test]
 fn derive_request_body_primitive_array_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_primitive_simple_array::post_foo))]
+    #[openapi(paths(derive_request_body_primitive_simple_array::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -149,7 +149,7 @@ test_fn! {
 #[test]
 fn derive_request_body_complex_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_complex::post_foo))]
+    #[openapi(paths(derive_request_body_complex::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -180,7 +180,7 @@ test_fn! {
 #[test]
 fn derive_request_body_complex_success_inline() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_complex_inline::post_foo))]
+    #[openapi(paths(derive_request_body_complex_inline::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -221,7 +221,7 @@ test_fn! {
 #[test]
 fn derive_request_body_complex_success_array() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_complex_array::post_foo))]
+    #[openapi(paths(derive_request_body_complex_array::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -255,7 +255,7 @@ test_fn! {
 #[test]
 fn derive_request_body_complex_success_inline_array() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_complex_inline_array::post_foo))]
+    #[openapi(paths(derive_request_body_complex_inline_array::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -299,7 +299,7 @@ test_fn! {
 #[test]
 fn derive_request_body_simple_inline_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_simple_inline::post_foo))]
+    #[openapi(paths(derive_request_body_simple_inline::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -338,7 +338,7 @@ test_fn! {
 #[test]
 fn derive_request_body_complex_required_explisit_false_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_complex_required_explisit::post_foo))]
+    #[openapi(paths(derive_request_body_complex_required_explisit::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -361,7 +361,7 @@ test_fn! {
 #[test]
 fn derive_request_body_complex_primitive_array_success() {
     #[derive(OpenApi, Default)]
-    #[openapi(handlers(derive_request_body_complex_primitive_array::post_foo))]
+    #[openapi(paths(derive_request_body_complex_primitive_array::post_foo))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
@@ -385,7 +385,7 @@ test_fn! {
 fn derive_request_body_primitive_ref_path_success() {
     #[derive(OpenApi, Default)]
     #[openapi(
-        handlers(derive_request_body_primitive_ref_path::post_foo),
+        paths(derive_request_body_primitive_ref_path::post_foo),
         components(schemas(derive_request_body_primitive_ref_path::Foo as path::to::Foo))
     )]
     struct ApiDoc;

--- a/tests/utoipa_gen_test.rs
+++ b/tests/utoipa_gen_test.rs
@@ -79,7 +79,7 @@ mod pet_api {
 
 #[derive(Default, OpenApi)]
 #[openapi(
-    handlers(pet_api::get_pet_by_id),
+    paths(pet_api::get_pet_by_id),
     components(schemas(Pet, GenericC, GenericD)),
     modifiers(&Foo),
     security(

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -879,9 +879,11 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// **Accepted argument attributes:**
 ///
-/// * `handlers(...)`  List of method references having attribute [`#[utoipa::path]`][path] macro.
-/// * `components(...)` List of [`ToSchema`][to_schema]s in OpenAPI schema.
-/// * `responses(...)` List of types that implement
+/// * `paths(...)`  List of method references having attribute [`#[utoipa::path]`][path] macro.
+/// * `components(schemas(...), responses(...))` Takes available _`component`_ configurations. Currently only
+///    _`schema`_ and _`response`_ components are supported.
+///    * `schemas(...)` List of [`ToSchema`][to_schema]s in OpenAPI schema.
+///    * `responses(...)` List of types that implement
 /// [`ToResponse`][to_response_trait].
 /// * `modifiers(...)` List of items implementing [`Modify`][modify] trait for runtime OpenApi modification.
 ///   See the [trait documentation][modify] for more details.
@@ -935,7 +937,7 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// #[derive(OpenApi)]
 /// #[openapi(
-///     handlers(get_pet, get_status),
+///     paths(get_pet, get_status),
 ///     components(schemas(Pet, Status)),
 ///     security(
 ///         (),

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -22,7 +22,7 @@ mod info;
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct OpenApiAttr {
-    handlers: Punctuated<ExprPath, Comma>,
+    paths: Punctuated<ExprPath, Comma>,
     components: Components,
     modifiers: Punctuated<Modifier, Comma>,
     security: Option<Array<SecurityRequirementAttr>>,
@@ -50,8 +50,8 @@ impl Parse for OpenApiAttr {
             let attribute = &*ident.to_string();
 
             match attribute {
-                "handlers" => {
-                    openapi.handlers = parse_utils::parse_punctuated_within_parenthesis(input)?;
+                "paths" => {
+                    openapi.paths = parse_utils::parse_punctuated_within_parenthesis(input)?;
                 }
                 "components" => {
                     openapi.components = input.parse()?;
@@ -251,7 +251,7 @@ impl ToTokens for OpenApi {
         let modifiers = &attributes.modifiers;
         let modifiers_len = modifiers.len();
 
-        let path_items = impl_paths(&attributes.handlers);
+        let path_items = impl_paths(&attributes.paths);
 
         let securities = attributes.security.as_ref().map(|securities| {
             quote! {

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -50,7 +50,7 @@
 //! # use utoipa::OpenApi;
 //! # use std::net::Ipv4Addr;
 //! # #[derive(OpenApi)]
-//! # #[openapi(handlers())]
+//! # #[openapi()]
 //! # struct ApiDoc;
 //! HttpServer::new(move || {
 //!         App::new()
@@ -131,7 +131,7 @@ struct SwaggerUiDist;
 /// # use utoipa_swagger_ui::SwaggerUi;
 /// # use utoipa::OpenApi;
 /// # #[derive(OpenApi)]
-/// # #[openapi(handlers())]
+/// # #[openapi()]
 /// # struct ApiDoc;
 /// let swagger = SwaggerUi::new("/swagger-ui/{_:.*}")
 ///     .url("/api-doc/openapi.json", ApiDoc::openapi());
@@ -142,7 +142,7 @@ struct SwaggerUiDist;
 /// # use utoipa_swagger_ui::{SwaggerUi, Config, oauth};
 /// # use utoipa::OpenApi;
 /// # #[derive(OpenApi)]
-/// # #[openapi(handlers())]
+/// # #[openapi()]
 /// # struct ApiDoc;
 /// let swagger = SwaggerUi::new("/swagger-ui/{_:.*}")
 ///     .url("/api-doc/openapi.json", ApiDoc::openapi())
@@ -206,7 +206,7 @@ impl SwaggerUi {
     /// # use utoipa_swagger_ui::SwaggerUi;
     /// # use utoipa::OpenApi;
     /// # #[derive(OpenApi)]
-    /// # #[openapi(handlers())]
+    /// # #[openapi()]
     /// # struct ApiDoc;
     /// let swagger = SwaggerUi::new("/swagger-ui/{_:.*}")
     ///     .url("/api-doc/openapi.json", ApiDoc::openapi());
@@ -231,10 +231,10 @@ impl SwaggerUi {
     /// # use utoipa_swagger_ui::{SwaggerUi, Url};
     /// # use utoipa::OpenApi;
     /// # #[derive(OpenApi)]
-    /// # #[openapi(handlers())]
+    /// # #[openapi()]
     /// # struct ApiDoc;
     /// # #[derive(OpenApi)]
-    /// # #[openapi(handlers())]
+    /// # #[openapi()]
     /// # struct ApiDoc2;
     /// let swagger = SwaggerUi::new("/swagger-ui/{_:.*}")
     ///     .urls(
@@ -261,7 +261,7 @@ impl SwaggerUi {
     /// # use utoipa_swagger_ui::{SwaggerUi, oauth};
     /// # use utoipa::OpenApi;
     /// # #[derive(OpenApi)]
-    /// # #[openapi(handlers())]
+    /// # #[openapi()]
     /// # struct ApiDoc;
     /// let swagger = SwaggerUi::new("/swagger-ui/{_:.*}")
     ///     .url("/api-doc/openapi.json", ApiDoc::openapi())
@@ -291,7 +291,7 @@ impl SwaggerUi {
     /// # use utoipa_swagger_ui::{SwaggerUi, Config};
     /// # use utoipa::OpenApi;
     /// # #[derive(OpenApi)]
-    /// # #[openapi(handlers())]
+    /// # #[openapi()]
     /// # struct ApiDoc;
     /// let swagger = SwaggerUi::new("/swagger-ui/{_:.*}")
     ///     .url("/api-doc/openapi.json", ApiDoc::openapi())
@@ -543,7 +543,7 @@ pub struct Config<'a> {
     #[serde(skip)]
     oauth: Option<oauth::Config>,
 
-    /// [ layout ] the layout of Swagger UI uses, default is "StandaloneLayout"
+    /// The layout of Swagger UI uses, default is `"StandaloneLayout"`
     layout: &'a str,
 }
 


### PR DESCRIPTION
Rename `handlers` attribute of `OpenApi` derive macro to `paths` to make it
consistent with OpenAPI spec.

```rust
#[derive(OpenApi)]
#[openapi(
    paths(...)
)]
struct ApiDoc;
```