### PR TITLE
Make response content ordered

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -451,7 +451,8 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///   [primitive Rust types][primitive] and _`application/json`_ for struct and complex enum types.
 ///   Content type can also be slice of **content_type** values if the endpoint support returning multiple
 ///  response content types. E.g _`["application/json", "text/xml"]`_ would indicate that endpoint can return both
-///  _`json`_ and _`xml`_ formats.
+///  _`json`_ and _`xml`_ formats. **The order** of the content types define the default example show first in
+///  the Swagger UI. Swagger UI wil use the first _`content_type`_ value as a default example.
 /// * `headers(...)` Slice of response headers that are returned back to a caller.
 /// * `example = ...` Can be either `json!(...)` or literal str that can be parsed to json. `json!`
 ///   should be something that `serde_json::json!` can parse as a `serde_json::Value`. [^json]

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -35,6 +35,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.9", optional = true }
 utoipa-gen = { version = "1.1.0", path = "../utoipa-gen" }
+indexmap = { version="1", features = ["serde"] }
 
 [dev-dependencies]
 assert-json-diff = "2"

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -103,7 +103,7 @@ builder! {
         /// Map of response [`Content`] objects identified by response body content type e.g `application/json`.
         ///
         /// [`Content`]s are stored within [`IndexMap`] to retain their insertion order. Swagger UI
-        /// will create and show default example according the first entry in `content` map.
+        /// will create and show default example according to the first entry in `content` map.
         #[serde(skip_serializing_if = "IndexMap::is_empty", default)]
         pub content: IndexMap<String, Content>,
     }

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -3,6 +3,7 @@
 //! [responses]: https://spec.openapis.org/oas/latest.html#responses-object
 use std::collections::BTreeMap;
 
+use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::IntoResponses;
@@ -100,8 +101,11 @@ builder! {
         pub headers: BTreeMap<String, Header>,
 
         /// Map of response [`Content`] objects identified by response body content type e.g `application/json`.
-        #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
-        pub content: BTreeMap<String, Content>,
+        ///
+        /// [`Content`]s are stored within [`IndexMap`] to retain their insertion order. Swagger UI
+        /// will create and show default example according the first entry in `content` map.
+        #[serde(skip_serializing_if = "IndexMap::is_empty", default)]
+        pub content: IndexMap<String, Content>,
     }
 }
 


### PR DESCRIPTION
Add indexmap dependency for Response contents for retaining insertion
order. Update docs about the behavior and how Swagger UI decides to show
the default example.

fixes #237 with updated docs.