### PR TITLE
Chore unify Object and Property component

### DIFF
--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -460,7 +460,7 @@ impl ToTokens for ParamType<'_> {
                         let schema_type = SchemaType(type_path);
 
                         tokens.extend(quote! {
-                            utoipa::openapi::PropertyBuilder::new().schema_type(#schema_type)
+                            utoipa::openapi::ObjectBuilder::new().schema_type(#schema_type)
                         });
 
                         let format: SchemaFormat = (type_path).into();

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -416,7 +416,7 @@ impl SimpleEnum<'_> {
                     utoipa::openapi::schema::ObjectBuilder::new()
                         .property(
                             #tag,
-                            utoipa::openapi::schema::PropertyBuilder::new()
+                            utoipa::openapi::schema::ObjectBuilder::new()
                                 .schema_type(utoipa::openapi::SchemaType::String)
                                 .enum_values::<[&str; 1], &str>(Some([#enum_value]))
                         )
@@ -439,7 +439,7 @@ impl SimpleEnum<'_> {
     fn variants_tokens(enum_values: Array<String>) -> TokenStream {
         let len = enum_values.len();
         quote! {
-            utoipa::openapi::PropertyBuilder::new()
+            utoipa::openapi::ObjectBuilder::new()
             .schema_type(utoipa::openapi::SchemaType::String)
             .enum_values::<[&str; #len], &str>(Some(#enum_values))
         }
@@ -503,7 +503,7 @@ impl ComplexEnum<'_> {
         variant_title: Option<SchemaAttr<Title>>,
     ) -> TokenStream {
         quote! {
-            utoipa::openapi::PropertyBuilder::new()
+            utoipa::openapi::ObjectBuilder::new()
                 #variant_title
                 .schema_type(utoipa::openapi::SchemaType::String)
                 .enum_values::<[&str; 1], &str>(Some([#variant_name]))
@@ -794,7 +794,7 @@ where
                         let schema_type = SchemaType(type_path);
 
                         tokens.extend(quote! {
-                            utoipa::openapi::PropertyBuilder::new().schema_type(#schema_type)
+                            utoipa::openapi::ObjectBuilder::new().schema_type(#schema_type)
                         });
 
                         let format: SchemaFormat = (type_path).into();

--- a/utoipa-gen/src/path/property.rs
+++ b/utoipa-gen/src/path/property.rs
@@ -27,7 +27,7 @@ impl ToTokens for Property<'_> {
 
         if schema_type.is_primitive() {
             let mut schema = quote! {
-                utoipa::openapi::PropertyBuilder::new().schema_type(#schema_type)
+                utoipa::openapi::ObjectBuilder::new().schema_type(#schema_type)
             };
 
             let format: SchemaFormat = schema_type.0.into();

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use utoipa::{
     openapi::{
         path::{Parameter, ParameterBuilder, ParameterIn},
-        Array, PropertyBuilder, SchemaFormat,
+        Array, ObjectBuilder, SchemaFormat,
     },
     IntoParams, OpenApi, ToSchema,
 };
@@ -328,14 +328,14 @@ fn path_with_struct_variables_with_into_params() {
                 ParameterBuilder::new()
                     .name("name")
                     .schema(Some(
-                        PropertyBuilder::new().schema_type(utoipa::openapi::SchemaType::String),
+                        ObjectBuilder::new().schema_type(utoipa::openapi::SchemaType::String),
                     ))
                     .parameter_in(ParameterIn::Path)
                     .build(),
                 ParameterBuilder::new()
                     .name("id")
                     .schema(Some(
-                        PropertyBuilder::new()
+                        ObjectBuilder::new()
                             .schema_type(utoipa::openapi::SchemaType::Integer)
                             .format(Some(SchemaFormat::Int64)),
                     ))
@@ -358,7 +358,7 @@ fn path_with_struct_variables_with_into_params() {
             vec![ParameterBuilder::new()
                 .name("age")
                 .schema(Some(Array::new(
-                    PropertyBuilder::new().schema_type(utoipa::openapi::SchemaType::String),
+                    ObjectBuilder::new().schema_type(utoipa::openapi::SchemaType::String),
                 )))
                 .parameter_in(ParameterIn::Query)
                 .build()]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -303,19 +303,19 @@ pub trait OpenApi {
 ///         utoipa::openapi::ObjectBuilder::new()
 ///             .property(
 ///                 "id",
-///                 utoipa::openapi::PropertyBuilder::new()
+///                 utoipa::openapi::ObjectBuilder::new()
 ///                     .schema_type(utoipa::openapi::SchemaType::Integer)
 ///                     .format(Some(utoipa::openapi::SchemaFormat::Int64)),
 ///             )
 ///             .required("id")
 ///             .property(
 ///                 "name",
-///                 utoipa::openapi::Property::new(utoipa::openapi::SchemaType::String),
+///                 utoipa::openapi::Object::with_type(utoipa::openapi::SchemaType::String),
 ///             )
 ///             .required("name")
 ///             .property(
 ///                 "age",
-///                 utoipa::openapi::PropertyBuilder::new()
+///                 utoipa::openapi::ObjectBuilder::new()
 ///                     .schema_type(utoipa::openapi::SchemaType::Integer)
 ///                     .format(Some(utoipa::openapi::SchemaFormat::Int32)),
 ///             )
@@ -404,7 +404,7 @@ pub trait ToSchema {
 ///                         .deprecated(Some(utoipa::openapi::Deprecated::False))
 ///                         .description(Some("Pet database id to get Pet for"))
 ///                         .schema(
-///                             Some(utoipa::openapi::PropertyBuilder::new()
+///                             Some(utoipa::openapi::ObjectBuilder::new()
 ///                                 .schema_type(utoipa::openapi::SchemaType::Integer)
 ///                                 .format(Some(utoipa::openapi::SchemaFormat::Int64))),
 ///                         ),
@@ -529,7 +529,7 @@ pub trait Modify {
 ///                 .parameter_in(parameter_in_provider().unwrap_or_default())
 ///                 .description(Some("Id of pet"))
 ///                 .schema(Some(
-///                     utoipa::openapi::PropertyBuilder::new()
+///                     utoipa::openapi::ObjectBuilder::new()
 ///                         .schema_type(utoipa::openapi::SchemaType::Integer)
 ///                         .format(Some(utoipa::openapi::SchemaFormat::Int64)),
 ///                 ))
@@ -540,7 +540,7 @@ pub trait Modify {
 ///                 .parameter_in(parameter_in_provider().unwrap_or_default())
 ///                 .description(Some("Name of pet"))
 ///                 .schema(Some(
-///                     utoipa::openapi::PropertyBuilder::new()
+///                     utoipa::openapi::ObjectBuilder::new()
 ///                         .schema_type(utoipa::openapi::SchemaType::String),
 ///                 ))
 ///                 .build(),

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -11,7 +11,7 @@ pub use self::{
     response::{Response, ResponseBuilder, Responses, ResponsesBuilder},
     schema::{
         Array, ArrayBuilder, Components, ComponentsBuilder, Object, ObjectBuilder, OneOf,
-        OneOfBuilder, Property, PropertyBuilder, Ref, Schema, SchemaFormat, SchemaType, ToArray,
+        OneOfBuilder, Ref, Schema, SchemaFormat, SchemaType, ToArray,
     },
     security::SecurityRequirement,
     server::{Server, ServerBuilder, ServerVariable, ServerVariableBuilder},

--- a/utoipa/src/openapi/header.rs
+++ b/utoipa/src/openapi/header.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{build_fn, builder, from, new, set_value, Property, Schema, SchemaType};
+use super::{build_fn, builder, from, new, set_value, Object, Schema, SchemaType};
 
 builder! {
     HeaderBuilder;
@@ -34,8 +34,8 @@ impl Header {
     /// Create new [`Header`] with integer type.
     /// ```rust
     /// # use utoipa::openapi::header::Header;
-    /// # use utoipa::openapi::{Property, SchemaType};
-    /// let header = Header::new(Property::new(SchemaType::Integer));
+    /// # use utoipa::openapi::{Object, SchemaType};
+    /// let header = Header::new(Object::with_type(SchemaType::Integer));
     /// ```
     ///
     /// Create a new [`Header`] with default type `String`
@@ -55,7 +55,7 @@ impl Default for Header {
     fn default() -> Self {
         Self {
             description: Default::default(),
-            schema: Property::new(SchemaType::String).into(),
+            schema: Object::with_type(SchemaType::String).into(),
         }
     }
 }

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -49,7 +49,7 @@ builder! {
         ///
         /// [schema]: https://spec.openapis.org/oas/latest.html#schema-object
         #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
-        pub schemas: BTreeMap<String, RefOr<Schema>>,
+        pub schemas: BTreeMap<String, Schema>,
 
         /// Map of reusable response name, to [OpenAPI Response Object][response]s or [OpenAPI
         /// Reference][reference]s to [OpenAPI Response Object][response]s.
@@ -115,7 +115,7 @@ impl ComponentsBuilder {
     /// Add [`Schema`] to [`Components`].
     ///
     /// Accpets two arguments where first is name of the schema and second is the schema itself.
-    pub fn schema<S: Into<String>, I: Into<RefOr<Schema>>>(mut self, name: S, schema: I) -> Self {
+    pub fn schema<S: Into<String>, I: Into<Schema>>(mut self, name: S, schema: I) -> Self {
         self.schemas.insert(name.into(), schema.into());
 
         self
@@ -141,7 +141,7 @@ impl ComponentsBuilder {
     /// ```
     pub fn schemas_from_iter<
         I: IntoIterator<Item = (S, C)>,
-        C: Into<RefOr<Schema>>,
+        C: Into<Schema>,
         S: Into<String>,
     >(
         mut self,
@@ -356,11 +356,11 @@ pub struct Object {
     pub enum_values: Option<Vec<String>>,
 
     /// Vector of required field names.
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub required: Vec<String>,
 
     /// Map of fields with their [`Schema`] types.
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default = "BTreeMap::new")]
     pub properties: BTreeMap<String, Schema>,
 
     /// Additional [`Schema`] for non specified fields (Useful for typed maps).
@@ -407,6 +407,7 @@ impl Object {
     ///
     /// Create [`string`] object type which can be used to define `string` field of an object.
     /// ```rust
+    /// # use utoipa::openapi::schema::{Object, SchemaType};
     /// let object = Object::with_type(SchemaType::String);
     /// ```
     pub fn with_type(schema_type: SchemaType) -> Self {
@@ -829,7 +830,7 @@ mod tests {
             .paths(Paths::new())
             .components(Some(
                 ComponentsBuilder::new()
-                    .schema("Person", RefOr::Ref(Ref::new("#/components/PersonModel")))
+                    .schema("Person", Ref::new("#/components/PersonModel"))
                     .schema(
                         "Credential",
                         Schema::from(


### PR DESCRIPTION
Unify Object and Property component into one. Reasoning to this is
OpenAPI spec does not have a separate type for `object` and `property`.
Also the types were almost the same thus unifying them is reasonable
because any `property` is actually a `object` as well.

This also mitigates possibly serde serialization and deserialization
issues where the serde is unable to correctly select deserialization
implementation. Limiting the possibly choises to one is always one round
trip less.