### PR TITLE
Move Ref type from Schema

### DIFF
--- a/utoipa/src/openapi/content.rs
+++ b/utoipa/src/openapi/content.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 #[cfg(feature = "serde_json")]
 use serde_json::Value;
 
-use super::{build_fn, encoding::Encoding, from, new, set_value, Schema};
+use super::{build_fn, encoding::Encoding, from, new, schema::RefOr, set_value, Schema};
 
 /// Content holds request body content or response content.
 #[derive(Serialize, Deserialize, Default, Clone)]
@@ -14,7 +14,7 @@ use super::{build_fn, encoding::Encoding, from, new, set_value, Schema};
 #[non_exhaustive]
 pub struct Content {
     /// Schema used in response body or request body.
-    pub schema: Schema,
+    pub schema: RefOr<Schema>,
 
     /// Example for request body or response body.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -39,7 +39,7 @@ pub struct Content {
 }
 
 impl Content {
-    pub fn new<I: Into<Schema>>(schema: I) -> Self {
+    pub fn new<I: Into<RefOr<Schema>>>(schema: I) -> Self {
         Self {
             schema: schema.into(),
             ..Self::default()
@@ -50,7 +50,7 @@ impl Content {
 /// Builder for [`Content`] with chainable configuration methods to create a new [`Content`].
 #[derive(Default)]
 pub struct ContentBuilder {
-    schema: Schema,
+    schema: RefOr<Schema>,
 
     #[cfg(feature = "serde_json")]
     example: Option<Value>,
@@ -67,7 +67,7 @@ impl ContentBuilder {
     new!(pub ContentBuilder);
 
     /// Add schema.
-    pub fn schema<I: Into<Schema>>(mut self, component: I) -> Self {
+    pub fn schema<I: Into<RefOr<Schema>>>(mut self, component: I) -> Self {
         set_value!(self schema component.into())
     }
 

--- a/utoipa/src/openapi/header.rs
+++ b/utoipa/src/openapi/header.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{build_fn, builder, from, new, set_value, Object, Schema, SchemaType};
+use super::{build_fn, builder, from, new, schema::RefOr, set_value, Object, Schema, SchemaType};
 
 builder! {
     HeaderBuilder;
@@ -17,7 +17,7 @@ builder! {
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct Header {
         /// Schema of header type.
-        pub schema: Schema,
+        pub schema: RefOr<Schema>,
 
         /// Additional descripiton of the header value.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -43,7 +43,7 @@ impl Header {
     /// # use utoipa::openapi::header::Header;
     /// let header = Header::default();
     /// ```
-    pub fn new<C: Into<Schema>>(component: C) -> Self {
+    pub fn new<C: Into<RefOr<Schema>>>(component: C) -> Self {
         Self {
             schema: component.into(),
             ..Default::default()
@@ -62,7 +62,7 @@ impl Default for Header {
 
 impl HeaderBuilder {
     /// Add schema of header.
-    pub fn schema<I: Into<Schema>>(mut self, component: I) -> Self {
+    pub fn schema<I: Into<RefOr<Schema>>>(mut self, component: I) -> Self {
         set_value!(self schema component.into())
     }
 

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -11,6 +11,7 @@ use super::{
     build_fn, builder, from, new,
     request_body::RequestBody,
     response::{Response, Responses},
+    schema::RefOr,
     set_value, Deprecated, ExternalDocs, Required, Schema, SecurityRequirement, Server,
 };
 
@@ -441,7 +442,7 @@ pub struct Parameter {
     // pub allow_empty_value: bool, this is going to be removed from further open api spec releases
     /// Schema of the parameter. Typically [`Schema::Property`] is used.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub schema: Option<Schema>,
+    pub schema: Option<RefOr<Schema>>,
 
     /// Describes how [`Parameter`] is being serialized depending on [`Parameter::schema`] (type of a content).
     /// Default value is based on [`ParameterIn`].
@@ -506,7 +507,7 @@ pub struct ParameterBuilder {
 
     deprecated: Option<Deprecated>,
 
-    schema: Option<Schema>,
+    schema: Option<RefOr<Schema>>,
 
     style: Option<ParameterStyle>,
 
@@ -558,7 +559,7 @@ impl ParameterBuilder {
     }
 
     /// Add or change [`Parameter`]s schema.
-    pub fn schema<I: Into<Schema>>(mut self, component: Option<I>) -> Self {
+    pub fn schema<I: Into<RefOr<Schema>>>(mut self, component: Option<I>) -> Self {
         set_value!(self schema component.map(|component| component.into()))
     }
 


### PR DESCRIPTION
Move Ref type from Schema type to unify types with existin Response
implementation and to make API follow more closely the OpenAPI spec.