### PR TITLE
Chore rename Any to Object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,3 @@
-exclude = [
-  ".git*",
-  ".github"
-]
-
 [workspace]
 members = [
   "utoipa",

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -216,10 +216,10 @@ impl<'t> TypeTree<'t> {
         }))
     }
 
-    /// `Any` virtual type is used when generic object is required in OpenAPI spec. Typically used
+    /// `Object` virtual type is used when generic object is required in OpenAPI spec. Typically used
     /// with `value_type` attribute to hinder the actual type.
-    fn is_any(&self) -> bool {
-        self.is("Any")
+    fn is_object(&self) -> bool {
+        self.is("Object")
     }
 }
 

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -479,7 +479,7 @@ impl ToTokens for ParamType<'_> {
                             tokens.extend(quote_spanned! {component_path.span()=>
                                 <#component_path as utoipa::ToSchema>::schema()
                             })
-                        } else if component.is_any() {
+                        } else if component.is_object() {
                             tokens.extend(quote! {
                                 utoipa::openapi::ObjectBuilder::new()
                             });

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -836,7 +836,7 @@ where
                             .attrs
                             .map(|attributes| attributes.is_inline())
                             .unwrap_or(false);
-                        if type_tree.is_any() {
+                        if type_tree.is_object() {
                             tokens.extend(quote! { utoipa::openapi::ObjectBuilder::new() })
                         } else {
                             let type_path = &**type_tree.path.as_ref().unwrap();

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -81,7 +81,7 @@ use ext::ArgumentResolver;
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
 ///   This is useful in cases where the default type does not correspond to the actual type e.g. when
 ///   any third-party types are used which are not [`ToSchema`][to_schema]s nor [`primitive` types][primitive].
-///    Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Any`_.
+///    Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Object`_.
 ///
 /// # Named Fields Optional Configuration Options for `#[schema(...)]`
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
@@ -94,7 +94,7 @@ use ext::ArgumentResolver;
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
 ///   This is useful in cases where the default type does not correspond to the actual type e.g. when
 ///   any third-party types are used which are not [`ToSchema`][to_schema]s nor [`primitive` types][primitive].
-///    Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Any`_.
+///    Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Object`_.
 /// * `inline` If the type of this field implements [`ToSchema`][to_schema], then the schema definition
 ///   will be inlined. **warning:** Don't use this for recursive data types!
 ///
@@ -343,7 +343,7 @@ use ext::ArgumentResolver;
 /// };
 /// ```
 ///
-/// Use a virtual `Any` type to render generic `object` in OpenAPI spec.
+/// Use a virtual `Object` type to render generic `object` in OpenAPI spec.
 /// ```rust
 /// # use utoipa::ToSchema;
 /// # mod custom {
@@ -353,7 +353,7 @@ use ext::ArgumentResolver;
 /// # struct Bar;
 /// #[derive(ToSchema)]
 /// struct Value {
-///     #[schema(value_type = Any)]
+///     #[schema(value_type = Object)]
 ///     field: Bar,
 /// };
 /// ```
@@ -1020,8 +1020,8 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
 ///   This is useful in cases where the default type does not correspond to the actual type e.g. when
 ///   any third-party types are used which are not [`ToSchema`][to_schema]s nor [`primitive` types][primitive].
-///    Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Any`_.
-///    _`Any`_ will be rendered as generic OpenAPI object.
+///    Value can be any Rust type what normally could be used to serialize to JSON or custom type such as _`Object`_.
+///    _`Object`_ will be rendered as generic OpenAPI object.
 /// * `inline` If set, the schema for this field's type needs to be a [`ToSchema`][to_schema], and
 ///   the schema definition will be inlined.
 ///
@@ -1133,14 +1133,14 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// }
 /// ```
 ///
-/// Override `String` with `Any` using `value_type` attribute. _`Any`_ will render as `type: object` in OpenAPI spec.
+/// Override `String` with `Object` using `value_type` attribute. _`Object`_ will render as `type: object` in OpenAPI spec.
 /// ```rust
 /// # use utoipa::IntoParams;
 /// #
 /// #[derive(IntoParams)]
 /// #[into_params(parameter_in = Query)]
 /// struct Filter {
-///     #[param(value_type = Any)]
+///     #[param(value_type = Object)]
 ///     id: String,
 /// }
 /// ```

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -641,7 +641,7 @@ fn derive_path_params_into_params_with_value_type() {
     struct Filter {
         #[param(value_type = i64, style = Simple)]
         id: String,
-        #[param(value_type = Any)]
+        #[param(value_type = Object)]
         another_id: String,
         #[param(value_type = Vec<Vec<String>>)]
         value1: Vec<i64>,
@@ -649,9 +649,9 @@ fn derive_path_params_into_params_with_value_type() {
         value2: Vec<i64>,
         #[param(value_type = Option<String>)]
         value3: i64,
-        #[param(value_type = Option<Any>)]
+        #[param(value_type = Option<Object>)]
         value4: i64,
-        #[param(value_type = Vec<Any>)]
+        #[param(value_type = Vec<Object>)]
         value5: i64,
         #[param(value_type = Vec<Foo>)]
         value6: i64,

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1388,10 +1388,10 @@ fn derive_unnamed_struct_schema_type_override_with_format() {
 }
 
 #[test]
-fn derive_struct_override_type_with_any_type() {
+fn derive_struct_override_type_with_object_type() {
     let value = api_doc! {
         struct Value {
-            #[schema(value_type = Any)]
+            #[schema(value_type = Object)]
             field: String,
         }
     };
@@ -1631,7 +1631,7 @@ fn derive_component_with_into_params_value_type() {
         struct Random {
             #[schema(value_type = i64)]
             id: String,
-            #[schema(value_type = Any)]
+            #[schema(value_type = Object)]
             another_id: String,
             #[schema(value_type = Vec<Vec<String>>)]
             value1: Vec<i64>,
@@ -1639,9 +1639,9 @@ fn derive_component_with_into_params_value_type() {
             value2: Vec<i64>,
             #[schema(value_type = Option<String>)]
             value3: i64,
-            #[schema(value_type = Option<Any>)]
+            #[schema(value_type = Option<Object>)]
             value4: i64,
-            #[schema(value_type = Vec<Any>)]
+            #[schema(value_type = Vec<Object>)]
             value5: i64,
             #[schema(value_type = Vec<Foo>)]
             value6: i64,

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -42,4 +42,3 @@ assert-json-diff = "2"
 
 [package.metadata.docs.rs]
 features = ["json", "actix_extras", "axum_extras"]
-


### PR DESCRIPTION
Rename value_type `Any` to `Object` to make it follow more closely
OpenAPI spec.