### PR TITLE
Add caution on export rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ mod pet_api {
 }
 ```
 
+This attribute macro substantially create another function named with `__path_` prefix.
+So when you implement `some_handler` function in different file and want to export this, make sure `__path_some_handler` in the module can also be accessible from the root.
+
 Tie the `Schema` and the endpoint above to the OpenApi schema with following `OpenApi` derive proc macro.
 
 ```rust


### PR DESCRIPTION
Hello,

Thank you for developing such an awesome project.
I'm developing an application with Rust and Axum and I've found this crate is very helpful for documenting API spec.

When I started to use `utoipa`, I was stuck in how to export handler function since I put the handler function in different file and exported this.
And finally I solved this with exporting a function named with `__path_` suffix.

When developing a big project, many people can split modules and cut off handler function in different file.
So I think this message would be very helpful for those people.

Thank you checking !