### PR TITLE
Keep existing url config in utoipa-swagger-ui

### DIFF
--- a/utoipa-swagger-ui/src/axum.rs
+++ b/utoipa-swagger-ui/src/axum.rs
@@ -34,7 +34,11 @@ where
         );
 
         let config = if let Some(config) = swagger_ui.config {
-            config.configure_defaults(urls)
+            if config.url.is_some() || !config.urls.is_empty() {
+                config
+            } else {
+                config.configure_defaults(urls)
+            }
         } else {
             Config::new(urls)
         };


### PR DESCRIPTION
Hello,

# TL; DR

I found a bug in axum extension about `url` config.
So far if you set url config, the config could be overridden.
This PR resolves this by checking `url` and `urls` field beforehand.

# Background

In my application, API is versioned and each endpoint has a prefix of `/v1`.
Axum has `nest` method to roll up endpoints, and I can achieve this API versioning.

About Swagger UI, swagger's endpoint also has to starts from `/v1` and this is easily achieved by below

```rust
SwaggerUi::new("/swagger/*tail")
    .url("/openapi.json", openapi)
```

But swagger will read `/openapi.json` so I have to change this to `/v1/openapi.json`.

I have to set `url` config to make Swagger UI accessible in endpoint `/v1/swagger` and I wrote below code.

```rust
let config = Config::from("/v1/openapi.json");
let swagger = SwaggerUi::new("/swagger/*tail")
    .url("/openapi.json", openapi)
    .config(config);
```

But this has been overridden.

# Caveats

I wrote in above, axum has `nest` method and can roll up routes.
To resolve my issue, I decided to attach `url` config to `SwaggerUI` but I feel it's also OK to add `base_path` field to `Config` and automatically apply base path to `SwaggerUIBundle`.
If you like the latter approach, I will resubmit PR.

Thank you for checking.