### PR TITLE
Feature serde default for ToSchema

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -294,6 +294,7 @@ pub mod serde {
     pub struct SerdeValue {
         pub skip: Option<bool>,
         pub rename: Option<String>,
+        pub default: Option<bool>,
     }
 
     impl SerdeValue {
@@ -310,6 +311,7 @@ pub mod serde {
                                 value.rename = Some(literal)
                             };
                         }
+                        TokenTree::Ident(ident) if ident == "default" => value.default = Some(true),
                         _ => (),
                     }
 
@@ -328,11 +330,12 @@ pub mod serde {
     pub struct SerdeContainer {
         pub rename_all: Option<RenameRule>,
         pub tag: Option<String>,
+        pub default: Option<bool>,
     }
 
     impl SerdeContainer {
-        /// Parse a single serde attribute, currently `rename_all = ...` and `tag = ...` attributes
-        /// are supported.
+        /// Parse a single serde attribute, currently `rename_all = ...`, `tag = ...` and
+        /// `defaut = ...` attributes are supported.
         fn parse_attribute(&mut self, ident: Ident, next: Cursor) -> syn::Result<()> {
             match ident.to_string().as_str() {
                 "rename_all" => {
@@ -348,6 +351,9 @@ pub mod serde {
                     if let Some((literal, _span)) = parse_next_lit_str(next) {
                         self.tag = Some(literal)
                     }
+                }
+                "default" => {
+                    self.default = Some(true);
                 }
                 _ => {}
             }

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -259,13 +259,7 @@ impl ToTokens for NamedStructSchema<'_> {
                     .property(#name, #schema_property)
                 });
 
-                // TODO check also container rule? should it then be in separate function?
-                if !schema_property.is_option()
-                    && field_rule
-                        .as_ref()
-                        .map(|rule| rule.default.is_none())
-                        .unwrap_or(true)
-                {
+                if !schema_property.is_option() && !is_default(&container_rules, &field_rule) {
                     tokens.extend(quote! {
                         .required(#name)
                     })
@@ -287,6 +281,18 @@ impl ToTokens for NamedStructSchema<'_> {
             })
         }
     }
+}
+
+#[inline]
+fn is_default(container_rules: &Option<SerdeContainer>, field_rule: &Option<SerdeValue>) -> bool {
+    *container_rules
+        .as_ref()
+        .and_then(|rule| rule.default.as_ref())
+        .unwrap_or(&false)
+        || *field_rule
+            .as_ref()
+            .and_then(|rule| rule.default.as_ref())
+            .unwrap_or(&false)
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -259,7 +259,13 @@ impl ToTokens for NamedStructSchema<'_> {
                     .property(#name, #schema_property)
                 });
 
-                if !schema_property.is_option() {
+                // TODO check also container rule? should it then be in separate function?
+                if !schema_property.is_option()
+                    && field_rule
+                        .as_ref()
+                        .map(|rule| rule.default.is_none())
+                        .unwrap_or(true)
+                {
                     tokens.extend(quote! {
                         .required(#name)
                     })

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -113,7 +113,7 @@ use ext::ArgumentResolver;
 ///
 /// # Partial `#[serde(...)]` attributes support
 ///
-/// ToSchema derive has partial support for [serde attributes](https://serde.rs/attributes.html). These supported attributes will reflect to the
+/// ToSchema derive has partial support for [serde attributes]. These supported attributes will reflect to the
 /// generated OpenAPI doc. For example if _`#[serde(skip)]`_ is defined the attribute will not show up in the OpenAPI spec at all since it will not never
 /// be serialized anyway. Similarly the _`rename`_ and _`rename_all`_ will reflect to the generated OpenAPI doc.
 ///
@@ -121,6 +121,7 @@ use ext::ArgumentResolver;
 /// * `rename = "..."` Supported **only** in field or variant level.
 /// * `skip = "..."` Supported  **only** in field or variant level.
 /// * `tag = "..."` Supported in container level.
+/// * `default` Supported in container level and field level according to [serde attributes].
 ///
 /// Other _`serde`_ attributes works as is but does not have any effect on the generated OpenAPI doc.
 ///
@@ -166,6 +167,17 @@ use ext::ArgumentResolver;
 ///         names: Option<Vec<String>>
 ///     },
 /// }
+/// ```
+///
+/// Add serde `default` attribute for MyValue struct. Similarly `default` could be added to
+/// individual fields as well. If `default` is given the field's affected will be treated
+/// as optional.
+/// ```rust
+///  #[derive(utoipa::ToSchema, serde::Deserialize, Default)]
+///  #[serde(default)]
+///  struct MyValue {
+///      field: String
+///  }
 /// ```
 ///
 /// # Generic schemas with aliases
@@ -366,6 +378,7 @@ use ext::ArgumentResolver;
 /// [xml]: openapi/xml/struct.Xml.html
 /// [into_params]: derive.IntoParams.html
 /// [primitive]: https://doc.rust-lang.org/std/primitive/index.html
+/// [serde attributes]: https://serde.rs/attributes.html
 pub fn derive_to_schema(input: TokenStream) -> TokenStream {
     let DeriveInput {
         attrs,

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1805,3 +1805,26 @@ fn derive_component_with_smallvec_feature() {
         })
     )
 }
+
+#[test]
+fn derive_schema_with_default_field() {
+    let value = api_doc! {
+        #[derive(serde::Deserialize)]
+        struct MyValue {
+            #[serde(default)]
+            field: String
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "field": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        })
+    )
+}

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1828,3 +1828,26 @@ fn derive_schema_with_default_field() {
         })
     )
 }
+
+#[test]
+fn derive_schema_with_default_struct() {
+    let value = api_doc! {
+        #[derive(serde::Deserialize, Default)]
+        #[serde(default)]
+        struct MyValue {
+            field: String
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "field": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        })
+    )
+}


### PR DESCRIPTION
Add support for serde `default` attribute for `ToSchema` trait. `default` attribute
can be used in struct level or field level on a struct having named fields.