### PR TITLE
Feature serde default

### DIFF
--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -38,6 +38,7 @@ jobs:
       - name: Get release info
         id: release_info
         run: |
+          module="${{ matrix.crate }}"
           version=$(cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name | test("'"$module"'$")) | .version')
           prerelease=false
           if [[ "$version" =~ .*-.* ]]; then

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -1,15 +1,13 @@
 [package]
 name = "utoipa-gen"
 description = "Code generation implementation for utoipa"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["openapi", "codegen", "proc-macro", "documentation", "compile-time"]
 repository = "https://github.com/juhaku/utoipa"
-authors = [
-  "Juha Kukkonen <juha7kukkonen@gmail.com>"
-]
+authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
 
 [lib]
 proc-macro = true
@@ -19,7 +17,7 @@ proc-macro2 = "1.0"
 syn = { version = "1.0", features = ["full"] }
 quote = "1.0"
 proc-macro-error = "1.0"
-regex = { version = "1.5", optional = true } 
+regex = { version = "1.5", optional = true }
 lazy_static = { version = "1.4", optional = true }
 uuid = { version = "1", optional = true }
 
@@ -27,15 +25,15 @@ uuid = { version = "1", optional = true }
 utoipa = { path = "../utoipa", default-features = false }
 serde_json = "1"
 serde = "1"
-actix-web = { version = "4", features = [ "macros" ], default-features = false }
+actix-web = { version = "4", features = ["macros"], default-features = false }
 axum = "0.5"
 paste = "1"
 rocket = "0.5.0-rc.1"
-smallvec = { version = "1.9.0", features = [ "serde" ] }
+smallvec = { version = "1.9.0", features = ["serde"] }
 rust_decimal = "1"
-chrono = { version  = "0.4", features = ["serde"] }
+chrono = { version = "0.4", features = ["serde"] }
 assert-json-diff = "2"
-time = { version = "0.3.11", features = [ "serde-human-readable" ] }
+time = { version = "0.3.11", features = ["serde-human-readable"] }
 
 [features]
 debug = []

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -294,6 +294,7 @@ pub mod serde {
     pub struct SerdeValue {
         pub skip: Option<bool>,
         pub rename: Option<String>,
+        pub default: Option<bool>,
     }
 
     impl SerdeValue {
@@ -310,6 +311,7 @@ pub mod serde {
                                 value.rename = Some(literal)
                             };
                         }
+                        TokenTree::Ident(ident) if ident == "default" => value.default = Some(true),
                         _ => (),
                     }
 
@@ -328,11 +330,12 @@ pub mod serde {
     pub struct SerdeContainer {
         pub rename_all: Option<RenameRule>,
         pub tag: Option<String>,
+        pub default: Option<bool>,
     }
 
     impl SerdeContainer {
-        /// Parse a single serde attribute, currently `rename_all = ...` and `tag = ...` attributes
-        /// are supported.
+        /// Parse a single serde attribute, currently `rename_all = ...`, `tag = ...` and
+        /// `defaut = ...` attributes are supported.
         fn parse_attribute(&mut self, ident: Ident, next: Cursor) -> syn::Result<()> {
             match ident.to_string().as_str() {
                 "rename_all" => {
@@ -348,6 +351,9 @@ pub mod serde {
                     if let Some((literal, _span)) = parse_next_lit_str(next) {
                         self.tag = Some(literal)
                     }
+                }
+                "default" => {
+                    self.default = Some(true);
                 }
                 _ => {}
             }

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -259,13 +259,7 @@ impl ToTokens for NamedStructSchema<'_> {
                     .property(#name, #schema_property)
                 });
 
-                // TODO check also container rule? should it then be in separate function?
-                if !schema_property.is_option()
-                    && field_rule
-                        .as_ref()
-                        .map(|rule| rule.default.is_none())
-                        .unwrap_or(true)
-                {
+                if !schema_property.is_option() && !is_default(&container_rules, &field_rule) {
                     tokens.extend(quote! {
                         .required(#name)
                     })
@@ -287,6 +281,18 @@ impl ToTokens for NamedStructSchema<'_> {
             })
         }
     }
+}
+
+#[inline]
+fn is_default(container_rules: &Option<SerdeContainer>, field_rule: &Option<SerdeValue>) -> bool {
+    *container_rules
+        .as_ref()
+        .and_then(|rule| rule.default.as_ref())
+        .unwrap_or(&false)
+        || *field_rule
+            .as_ref()
+            .and_then(|rule| rule.default.as_ref())
+            .unwrap_or(&false)
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -259,7 +259,13 @@ impl ToTokens for NamedStructSchema<'_> {
                     .property(#name, #schema_property)
                 });
 
-                if !schema_property.is_option() {
+                // TODO check also container rule? should it then be in separate function?
+                if !schema_property.is_option()
+                    && field_rule
+                        .as_ref()
+                        .map(|rule| rule.default.is_none())
+                        .unwrap_or(true)
+                {
                     tokens.extend(quote! {
                         .required(#name)
                     })

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -113,7 +113,7 @@ use ext::ArgumentResolver;
 ///
 /// # Partial `#[serde(...)]` attributes support
 ///
-/// ToSchema derive has partial support for [serde attributes](https://serde.rs/attributes.html). These supported attributes will reflect to the
+/// ToSchema derive has partial support for [serde attributes]. These supported attributes will reflect to the
 /// generated OpenAPI doc. For example if _`#[serde(skip)]`_ is defined the attribute will not show up in the OpenAPI spec at all since it will not never
 /// be serialized anyway. Similarly the _`rename`_ and _`rename_all`_ will reflect to the generated OpenAPI doc.
 ///
@@ -121,6 +121,7 @@ use ext::ArgumentResolver;
 /// * `rename = "..."` Supported **only** in field or variant level.
 /// * `skip = "..."` Supported  **only** in field or variant level.
 /// * `tag = "..."` Supported in container level.
+/// * `default` Supported in container level and field level according to [serde attributes].
 ///
 /// Other _`serde`_ attributes works as is but does not have any effect on the generated OpenAPI doc.
 ///
@@ -166,6 +167,17 @@ use ext::ArgumentResolver;
 ///         names: Option<Vec<String>>
 ///     },
 /// }
+/// ```
+///
+/// Add serde `default` attribute for MyValue struct. Similarly `default` could be added to
+/// individual fields as well. If `default` is given the field's affected will be treated
+/// as optional.
+/// ```rust
+///  #[derive(utoipa::ToSchema, serde::Deserialize, Default)]
+///  #[serde(default)]
+///  struct MyValue {
+///      field: String
+///  }
 /// ```
 ///
 /// # Generic schemas with aliases
@@ -366,6 +378,7 @@ use ext::ArgumentResolver;
 /// [xml]: openapi/xml/struct.Xml.html
 /// [into_params]: derive.IntoParams.html
 /// [primitive]: https://doc.rust-lang.org/std/primitive/index.html
+/// [serde attributes]: https://serde.rs/attributes.html
 pub fn derive_to_schema(input: TokenStream) -> TokenStream {
     let DeriveInput {
         attrs,

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1805,3 +1805,26 @@ fn derive_component_with_smallvec_feature() {
         })
     )
 }
+
+#[test]
+fn derive_schema_with_default_field() {
+    let value = api_doc! {
+        #[derive(serde::Deserialize)]
+        struct MyValue {
+            #[serde(default)]
+            field: String
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "field": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        })
+    )
+}

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1828,3 +1828,26 @@ fn derive_schema_with_default_field() {
         })
     )
 }
+
+#[test]
+fn derive_schema_with_default_struct() {
+    let value = api_doc! {
+        #[derive(serde::Deserialize, Default)]
+        #[serde(default)]
+        struct MyValue {
+            field: String
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "field": {
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        })
+    )
+}

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -1,18 +1,22 @@
 [package]
 name = "utoipa"
 description = "Compile time generated OpenAPI documentation for Rust"
-version = "2.0.1"
+version = "2.1.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
-keywords = ["rest-api", "openapi", "auto-generate", "documentation", "compile-time"]
+keywords = [
+    "rest-api",
+    "openapi",
+    "auto-generate",
+    "documentation",
+    "compile-time",
+]
 # documentation = ""
 # homepage = ""
 repository = "https://github.com/juhaku/utoipa"
 categories = ["web-programming"]
-authors = [
-  "Juha Kukkonen <juha7kukkonen@gmail.com>"
-]
+authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
 
 [features]
 default = ["json"]
@@ -33,8 +37,8 @@ openapi_extensions = []
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 serde_yaml = { version = "0.9", optional = true }
-utoipa-gen = { version = "2.0.1", path = "../utoipa-gen" }
-indexmap = { version="1", features = ["serde"] }
+utoipa-gen = { version = "2.1.0", path = "../utoipa-gen" }
+indexmap = { version = "1", features = ["serde"] }
 
 [dev-dependencies]
 assert-json-diff = "2"


### PR DESCRIPTION
Add serde `default` attribute support for `ToSchema` derive macro. Attribute can
be used struct and field level on structs having named fields. Update `ToSchema`
derive trait docs.