### PR TITLE
Refactor enums

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
           if [[ "${{ matrix.testset }}" == "utoipa" ]] && [[ ${{ steps.changes.outputs.utoipa_changed }} == true ]]; then
             cargo test -p utoipa --features openapi_extensions,yaml
           elif [[ "${{ matrix.testset }}" == "utoipa-gen" ]] && [[ ${{ steps.changes.outputs.gen_changed }} == true ]]; then
-            cargo test -p utoipa-gen --features utoipa/actix_extras,chrono,decimal,json,utoipa/uuid,utoipa/json,utoipa/time,time
+            cargo test -p utoipa-gen --features utoipa/actix_extras,chrono,decimal,json,utoipa/uuid,utoipa/json,utoipa/time,time,utoipa/repr
 
             cargo test -p utoipa-gen --test path_response_derive_test_no_serde_json --no-default-features
             cargo test -p utoipa-gen --test schema_derive_no_serde_json --no-default-features

--- a/README.md
+++ b/README.md
@@ -76,8 +76,8 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also awesome type of beer :be
 - **smallvec** Add support for [smallvec](https://crates.io/crates/smallvec). `SmallVec` will be treated as `Vec`.
 - **openapi_extensions** Adds traits and functions that provide extra convenience functions.
   See the [`request_body` docs](https://docs.rs/utoipa/latest/utoipa/openapi/request_body) for an example.
-- **repr** Add support for `repr(u*)` and `repr(i*)` attributes for fieldless enums.
-  See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html) for more details.
+- **repr** Add support for [repr_serde](https://github.com/dtolnay/serde-repr)'s `repr(u*)` and `repr(i*)` attributes to unit type enums for
+  C-like enum representation. See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html) for more details.
 
 Utoipa implicitly has partial support for `serde` attributes. See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html#partial-serde-attributes-support) for more details.
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ echo "Testing crate: $crate..."
 if [[ "$crate" == "utoipa" ]]; then
     cargo test -p utoipa --features openapi_extensions
 elif [[ "$crate" == "utoipa-gen" ]]; then
-    cargo test -p utoipa-gen --features utoipa/actix_extras,chrono,decimal,json,utoipa/uuid,utoipa/json,utoipa/time,time
+    cargo test -p utoipa-gen --features utoipa/actix_extras,chrono,decimal,json,utoipa/uuid,utoipa/json,utoipa/time,time,utoipa/repr
 
     cargo test -p utoipa-gen --test path_response_derive_test_no_serde_json --no-default-features
     cargo test -p utoipa-gen --test schema_derive_no_serde_json --no-default-features

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -727,9 +727,9 @@ impl SimpleEnum<'_> {
 //     }
 // }
 
-struct EnumRepresentation<'e, T: quote::ToTokens>(Option<&'e TypePath>, Array<T>);
+struct EnumRepresentation<'e, 'a, T: quote::ToTokens>(Option<&'e TypePath>, Array<'a, T>);
 
-impl<'e, T> EnumRepresentation<'e, T>
+impl<'e, 'a, T> EnumRepresentation<'e, 'a, T>
 where
     T: quote::ToTokens,
 {
@@ -757,7 +757,7 @@ trait TaggedEnumRepresentation {
     fn to_tagged_tokens(&self, tag: &str) -> TokenStream;
 }
 
-impl<'e, T> TaggedEnumRepresentation for EnumRepresentation<'e, T>
+impl<'e, 'a, T> TaggedEnumRepresentation for EnumRepresentation<'e, 'a, T>
 where
     T: quote::ToTokens,
 {
@@ -768,8 +768,9 @@ where
         let items = values
             .iter()
             .map(|enum_value| {
+                let values = [enum_value];
                 let enum_tokens =
-                    EnumRepresentation(*enum_type, Array::Owned(vec![enum_value])).to_tokens();
+                    EnumRepresentation(*enum_type, Array::Borrowed(&values)).to_tokens();
 
                 quote! {
                     utoipa::openapi::schema::ObjectBuilder::new()

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1299,21 +1299,6 @@ where
     }
 }
 
-// impl<T> IntoIterator for Array<'_, T>
-// where
-//     T: Sized + ToTokens,
-// {
-//     type Item = T;
-//     type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
-
-//     fn into_iter(self) -> Self::IntoIter {
-//         match self {
-//             Array::Owned(owned) => owned.into_iter(),
-//             Array::Borrowed(borrowed) => borrowed.into_iter(),
-//         }
-//     }
-// }
-
 impl<'a, T> Deref for Array<'a, T>
 where
     T: Sized + ToTokens,

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1280,16 +1280,17 @@ pub fn into_params(input: TokenStream) -> TokenStream {
 /// Tokenizes slice or Vec of tokenizable items as array either with reference (`&[...]`)
 /// or without correctly to OpenAPI JSON.
 #[cfg_attr(feature = "debug", derive(Debug))]
-enum Array<T>
+enum Array<'a, T>
 where
     T: Sized + ToTokens,
 {
     Owned(Vec<T>),
+    Borrowed(&'a [T]),
 }
 
-impl<T> Array<T> where T: ToTokens + Sized {}
+impl<T> Array<'_, T> where T: ToTokens + Sized {}
 
-impl<V> FromIterator<V> for Array<V>
+impl<V> FromIterator<V> for Array<'_, V>
 where
     V: Sized + ToTokens,
 {
@@ -1298,44 +1299,48 @@ where
     }
 }
 
-impl<T> IntoIterator for Array<T>
+// impl<T> IntoIterator for Array<'_, T>
+// where
+//     T: Sized + ToTokens,
+// {
+//     type Item = T;
+//     type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
+
+//     fn into_iter(self) -> Self::IntoIter {
+//         match self {
+//             Array::Owned(owned) => owned.into_iter(),
+//             Array::Borrowed(borrowed) => borrowed.into_iter(),
+//         }
+//     }
+// }
+
+impl<'a, T> Deref for Array<'a, T>
 where
     T: Sized + ToTokens,
 {
-    type Item = T;
-    type IntoIter = <Vec<T> as IntoIterator>::IntoIter;
-
-    fn into_iter(self) -> Self::IntoIter {
-        match self {
-            Array::Owned(owned) => owned.into_iter(),
-        }
-    }
-}
-
-impl<T> Deref for Array<T>
-where
-    T: Sized + ToTokens,
-{
-    type Target = Vec<T>;
+    type Target = [T];
 
     fn deref(&self) -> &Self::Target {
         match self {
-            Self::Owned(vec) => vec,
+            Self::Owned(vec) => vec.as_slice(),
+            Self::Borrowed(slice) => *slice,
         }
     }
 }
 
-impl<T> ToTokens for Array<T>
+impl<T> ToTokens for Array<'_, T>
 where
     T: Sized + ToTokens,
 {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
-        let Array::Owned(values) = self;
+        let values = match self {
+            Self::Owned(values) => values.iter(),
+            Self::Borrowed(values) => values.iter(),
+        };
 
         tokens.append(Group::new(
             proc_macro2::Delimiter::Bracket,
             values
-                .iter()
                 .fold(Punctuated::new(), |mut punctuated, item| {
                     punctuated.push_value(item);
                     punctuated.push_punct(Punct::new(',', proc_macro2::Spacing::Alone));

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -25,8 +25,8 @@ pub struct OpenApiAttr {
     paths: Punctuated<ExprPath, Comma>,
     components: Components,
     modifiers: Punctuated<Modifier, Comma>,
-    security: Option<Array<SecurityRequirementAttr>>,
-    tags: Option<Array<Tag>>,
+    security: Option<Array<'static, SecurityRequirementAttr>>,
+    tags: Option<Array<'static, Tag>>,
     external_docs: Option<ExternalDocs>,
 }
 

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -73,7 +73,7 @@ pub struct PathAttr<'p> {
     operation_id: Option<String>,
     tag: Option<String>,
     params: Vec<Parameter<'p>>,
-    security: Option<Array<SecurityRequirementAttr>>,
+    security: Option<Array<'p, SecurityRequirementAttr>>,
     context_path: Option<String>,
 }
 
@@ -513,7 +513,7 @@ struct Operation<'a> {
     parameters: &'a Vec<Parameter<'a>>,
     request_body: Option<&'a RequestBodyAttr<'a>>,
     responses: &'a Vec<Response<'a>>,
-    security: Option<&'a Array<SecurityRequirementAttr>>,
+    security: Option<&'a Array<'a, SecurityRequirementAttr>>,
 }
 
 impl ToTokens for Operation<'_> {

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -653,6 +653,14 @@ fn derive_simple_enum_serde_tag() {
         }
     };
 
+    // #[derive(ToSchema, Serialize)]
+    // #[serde(tag = "tag")]
+    // enum Bar {
+    //     A,
+    //     B,
+    //     C,
+    // }
+
     assert_json_eq!(
         value,
         json!({

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -653,14 +653,6 @@ fn derive_simple_enum_serde_tag() {
         }
     };
 
-    // #[derive(ToSchema, Serialize)]
-    // #[serde(tag = "tag")]
-    // enum Bar {
-    //     A,
-    //     B,
-    //     C,
-    // }
-
     assert_json_eq!(
         value,
         json!({

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -737,15 +737,15 @@ fn derive_complex_unnamed_field_reference_with_comment() {
 }
 
 #[test]
-fn derive_enum_with_unnamed_single_field_with_tag() {
+fn derive_enum_with_unnamed_primitive_field_with_tag() {
     #[derive(Serialize)]
     struct ReferenceValue(String);
 
     let value: Value = api_doc! {
         #[derive(Serialize)]
-        #[serde(tag = "enum")]
+        #[serde(tag = "tag")]
         enum EnumWithReference {
-            Value(ReferenceValue),
+            Value(String),
         }
     };
 
@@ -756,10 +756,94 @@ fn derive_enum_with_unnamed_single_field_with_tag() {
                 {
                     "type": "object",
                     "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": ["Value"]
+                        },
+                    },
+                    "required": ["tag"]
+                },
+            ],
+        })
+    );
+}
+
+// TODO fixme https://github.com/juhaku/utoipa/issues/285#issuecomment-1249625860
+#[test]
+#[ignore = "fix me, see: https://github.com/juhaku/utoipa/issues/285#issuecomment-1249625860"]
+fn derive_enum_with_unnamed_single_field_with_tag() {
+    #[derive(Serialize)]
+    struct ReferenceValue(String);
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "enum")]
+        enum EnumWithReference {
+            Value(String),
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "enum": {
+                            "type": "string",
+                            "enum": ["Value"]
+
+                        },
                         "Value": {
                             "$ref": "#/components/schemas/ReferenceValue",
                         },
                     },
+                    "required": ["enum"]
+                },
+            ],
+        })
+    );
+}
+
+// TODO fixme https://github.com/juhaku/utoipa/issues/285#issuecomment-1249625860
+#[test]
+#[ignore = "fix me, see: https://github.com/juhaku/utoipa/issues/285#issuecomment-1249625860"]
+fn derive_enum_with_named_fields_with_reference_with_tag() {
+    #[derive(Serialize)]
+    struct ReferenceValue(String);
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "enum")]
+        enum EnumWithReference {
+            Value {
+                field: ReferenceValue,
+                a: String
+            },
+            // UnnamedValue(ReferenceValue),
+            UnitValue,
+        }
+    };
+
+    println!("{}", serde_json::to_string_pretty(&value).unwrap());
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "enum": {
+                            "type": "string",
+                            "enum": ["Value"]
+
+                        },
+                        "Value": {
+                            "$ref": "#/components/schemas/ReferenceValue",
+                        },
+                    },
+                    "required": ["enum"]
                 },
             ],
         })

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -738,9 +738,6 @@ fn derive_complex_unnamed_field_reference_with_comment() {
 
 #[test]
 fn derive_enum_with_unnamed_primitive_field_with_tag() {
-    #[derive(Serialize)]
-    struct ReferenceValue(String);
-
     let value: Value = api_doc! {
         #[derive(Serialize)]
         #[serde(tag = "tag")]
@@ -766,6 +763,71 @@ fn derive_enum_with_unnamed_primitive_field_with_tag() {
             ],
         })
     );
+}
+
+#[test]
+fn derive_complex_enum_with_schema_properties() {
+    let value: Value = api_doc! {
+        /// This is the description
+        #[derive(Serialize)]
+        #[schema(example = json!(EnumWithProperites::Variant2{name: String::from("foobar")}),
+            default = json!(EnumWithProperites::Variant{id: String::from("1")}))]
+        enum EnumWithProperites {
+            Variant {
+                id: String
+            },
+            Variant2{
+                name: String
+            }
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "description": "This is the description",
+            "default": {
+                "Variant": {
+                    "id": "1"
+                }
+            },
+            "example": {
+                "Variant2": {
+                    "name": "foobar"
+                }
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "Variant": {
+                            "properties": {
+                                "id": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["id"],
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                        "Variant2": {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["name"],
+                            "type": "object"
+                        }
+                    },
+                    "type": "object"
+                }
+            ]
+        })
+    )
 }
 
 // TODO fixme https://github.com/juhaku/utoipa/issues/285#issuecomment-1249625860

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -32,7 +32,7 @@ uuid = ["utoipa-gen/uuid"]
 time = ["utoipa-gen/time"]
 smallvec = ["utoipa-gen/smallvec"]
 openapi_extensions = []
-repr = ["json", "utoipa-gen/repr"]
+repr = ["utoipa-gen/repr"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -74,8 +74,8 @@
 //! * **openapi_extensions** Adds convenience functions for documenting common scenarios, such as JSON request bodies and responses.
 //!   See the [`request_body`](https://docs.rs/utoipa/latest/utoipa/openapi/request_body/index.html) and
 //!   [`response`](https://docs.rs/utoipa/latest/utoipa/openapi/response/index.html) docs for examples.
-//! * **repr** Add support for `repr(u*)` and `repr(i*)` attributes for fieldless enums.
-//!   See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html) for more details.
+//! * **repr** Add support for [repr_serde](https://github.com/dtolnay/serde-repr)'s `repr(u*)` and `repr(i*)` attributes to unit type enums for
+//!   C-like enum representation. See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html) for more details.
 //!
 //! Utoipa implicitly has partial support for `serde` attributes. See [`ToSchema` derive][serde] for more details.
 //!

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -365,7 +365,7 @@ pub struct Object {
     /// Enum variants of fields that can be represented as `unit` type `enums`
     #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "repr")]
-    enum_values: Option<Vec<Value>>,
+    pub enum_values: Option<Vec<Value>>,
 
     /// Vector of required field names.
     #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -237,25 +237,41 @@ impl Default for Schema {
     }
 }
 
-builder! {
-    OneOfBuilder;
+/// OneOf [Discriminator Object][discriminator] component holds
+/// multiple components together where API endpoint could return any of them.
+///
+/// See [`Schema::OneOf`] for more details.
+///
+/// [discriminator]: https://spec.openapis.org/oas/latest.html#components-object
+#[derive(Serialize, Deserialize, Clone, Default)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct OneOf {
+    /// Components of _OneOf_ component.
+    #[serde(rename = "oneOf")]
+    pub items: Vec<RefOr<Schema>>,
 
-    /// OneOf [Discriminator Object][discriminator] component holds
-    /// multiple components together where API endpoint could return any of them.
-    ///
-    /// See [`Schema::OneOf`] for more details.
-    ///
-    /// [discriminator]: https://spec.openapis.org/oas/latest.html#components-object
-    #[derive(Serialize, Deserialize, Clone, Default)]
-    #[cfg_attr(feature = "debug", derive(Debug))]
-    pub struct OneOf {
-        /// Components of _OneOf_ component.
-        #[serde(rename = "oneOf")]
-        pub items: Vec<RefOr<Schema>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 
-        #[serde(skip_serializing_if = "Option::is_none")]
-        pub description: Option<String>,
-    }
+    /// Default value which is provided when user has not provided the input in Swagger UI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(feature = "serde_json")]
+    pub default: Option<Value>,
+
+    /// Default value which is provided when user has not provided the input in Swagger UI.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(not(feature = "serde_json"))]
+    pub default: Option<String>,
+
+    /// Example shown in UI of the value for richier documentation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(feature = "serde_json")]
+    pub example: Option<Value>,
+
+    /// Example shown in UI of the value for richier documentation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg(not(feature = "serde_json"))]
+    pub example: Option<String>,
 }
 
 impl OneOf {
@@ -281,12 +297,34 @@ impl OneOf {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             items: Vec::with_capacity(capacity),
-            description: None,
+            ..Default::default()
         }
     }
 }
 
+/// Builder for [`OneOf`] with chainable configuration methods to create a new [`OneOf`].
+#[derive(Default)]
+pub struct OneOfBuilder {
+    items: Vec<RefOr<Schema>>,
+    
+    description: Option<String>,
+
+    #[cfg(feature = "serde_json")]
+    default: Option<Value>,
+
+    #[cfg(not(feature = "serde_json"))]
+    default: Option<String>,
+
+    #[cfg(feature = "serde_json")]
+    example: Option<Value>,
+
+    #[cfg(not(feature = "serde_json"))]
+    example: Option<String>,
+}
+
 impl OneOfBuilder {
+    new!(pub OneOfBuilder);
+
     /// Adds a given [`Schema`] to [`OneOf`] [Discriminator Object][discriminator]
     ///
     /// [discriminator]: https://spec.openapis.org/oas/latest.html#components-object
@@ -301,8 +339,36 @@ impl OneOfBuilder {
         set_value!(self description description.map(|description| description.into()))
     }
 
+    /// Add or change default value for the object which is provided when user has not provided the input in Swagger UI.
+    #[cfg(feature = "serde_json")]
+    pub fn default(mut self, default: Option<Value>) -> Self {
+        set_value!(self default default)
+    }
+
+    /// Add or change default value for the object which is provided when user has not provided the input in Swagger UI.
+    #[cfg(not(feature = "serde_json"))]
+    pub fn default<I: Into<String>>(mut self, default: Option<I>) -> Self {
+        set_value!(self default default.map(|default| default.into()))
+    }
+
+    /// Add or change example shown in UI of the value for richier documentation.
+    #[cfg(feature = "serde_json")]
+    pub fn example(mut self, example: Option<Value>) -> Self {
+        set_value!(self example example)
+    }
+
+    /// Add or change example shown in UI of the value for richier documentation.
+    #[cfg(not(feature = "serde_json"))]
+    pub fn example<I: Into<String>>(mut self, example: Option<I>) -> Self {
+        set_value!(self example example.map(|example| example.into()))
+    }
+
     to_array_builder!();
+
+    build_fn!(pub OneOf items, description, default, example);
 }
+
+from!(OneOf OneOfBuilder items, description, default, example);
 
 impl From<OneOf> for Schema {
     fn from(one_of: OneOf) -> Self {


### PR DESCRIPTION
Refactor enum implemenation by keeping things DRY. This PR adds
better foundation over furhter development of features concerning enums.

Aslo remove the limitation of not allowing `schema` attribute to be used on
`oneOf` complex enum type. This allows defining of `default` and `example`
attribute over complex enum via `schema` attribute of `ToSchema` derive macro.

The enum refactoring is not complete but this PR will be first one in the serie of 
coming improvements and new features.

relates to #285 