### PR TITLE
Add discriminator schema

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -120,7 +120,7 @@ use ext::ArgumentResolver;
 /// * `rename_all = "..."` Supported in container level.
 /// * `rename = "..."` Supported **only** in field or variant level.
 /// * `skip = "..."` Supported  **only** in field or variant level.
-/// * `tag = "..."` Supported in container level.
+/// * `tag = "..."` Supported in container level. `tag` attribute also works as a [discriminator field][discriminator] for an enum.
 /// * `default` Supported in container level and field level according to [serde attributes].
 ///
 /// Other _`serde`_ attributes works as is but does not have any effect on the generated OpenAPI doc.
@@ -426,6 +426,7 @@ use ext::ArgumentResolver;
 /// [into_params]: derive.IntoParams.html
 /// [primitive]: https://doc.rust-lang.org/std/primitive/index.html
 /// [serde attributes]: https://serde.rs/attributes.html
+/// [discriminator]: openapi/schema/struct.Discriminator.html
 /// [enum_schema]: derive.ToSchema.html#enum-optional-configuration-options-for-schema
 pub fn derive_to_schema(input: TokenStream) -> TokenStream {
     let DeriveInput {

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -761,6 +761,9 @@ fn derive_enum_with_unnamed_primitive_field_with_tag() {
                     "required": ["tag"]
                 },
             ],
+            "discriminator": {
+                "propertyName": "tag"
+            }
         })
     );
 }
@@ -1228,6 +1231,9 @@ fn derive_complex_enum_serde_tag() {
                     ],
                 },
             ],
+            "discriminator": {
+                "propertyName": "tag"
+            }
         })
     );
 }
@@ -1289,6 +1295,9 @@ fn derive_complex_enum_serde_tag_title() {
                     ],
                 },
             ],
+            "discriminator": {
+                "propertyName": "tag"
+            }
         })
     );
 }

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -10,8 +10,8 @@ pub use self::{
     path::{PathItem, PathItemType, Paths, PathsBuilder},
     response::{Response, ResponseBuilder, Responses, ResponsesBuilder},
     schema::{
-        Array, ArrayBuilder, Components, ComponentsBuilder, Object, ObjectBuilder, OneOf,
-        OneOfBuilder, Ref, Schema, SchemaFormat, SchemaType, ToArray,
+        Array, ArrayBuilder, Components, ComponentsBuilder, Discriminator, Object, ObjectBuilder,
+        OneOf, OneOfBuilder, Ref, Schema, SchemaFormat, SchemaType, ToArray,
     },
     security::SecurityRequirement,
     server::{Server, ServerBuilder, ServerVariable, ServerVariableBuilder},

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -240,7 +240,7 @@ impl Default for Schema {
 /// OpenAPI [Discriminator][discriminator] object which can be optionally used together with
 /// [`OneOf`] composite object.
 /// 
-/// [discriminator]: https://swagger.io/specification/#discriminator-object
+/// [discriminator]: https://spec.openapis.org/oas/latest.html#discriminator-object
 #[derive(Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "debug", derive(Debug))]


### PR DESCRIPTION
Add discriminator schema. For now if serde `tag` is defined the discriminator field will be set to the `tag` attribute value in OneOf composite object.

fixes #287