### PR TITLE
Fix trait support for TypeTree

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -23,7 +23,7 @@ fn get_deprecated(attributes: &[Attribute]) -> Option<Deprecated> {
 }
 
 #[cfg_attr(feature = "debug", derive(Debug, PartialEq))]
-pub enum TypeTreeValue<'t> {
+enum TypeTreeValue<'t> {
     TypePath(&'t TypePath),
     Path(&'t Path),
 }
@@ -53,7 +53,7 @@ impl<'t> TypeTree<'t> {
             Type::Group(group) => Self::get_type_paths(group.elem.as_ref()),
             Type::Array(array) => Self::get_type_paths(&array.elem),
             Type::TraitObject(trait_object) => {
-                let types = trait_object
+                trait_object
                     .bounds
                     .iter()
                     .find_map(|bound| {
@@ -62,9 +62,7 @@ impl<'t> TypeTree<'t> {
                             syn::TypeParamBound::Lifetime(_) => None
                         }
                     })
-                    .map(|path| vec![TypeTreeValue::Path(path)]).unwrap_or_else(Vec::new);
-
-                types
+                    .map(|path| vec![TypeTreeValue::Path(path)]).unwrap_or_else(Vec::new)
             }
             _ => abort_call_site!(
                 "unexpected type in component part get type path, expected one of: Path, Reference, Group"
@@ -194,9 +192,8 @@ impl<'t> TypeTree<'t> {
         let mut is = self
             .path
             .as_ref()
-            .map(|value| {
-                value
-                    .segments
+            .map(|path| {
+                path.segments
                     .last()
                     .expect("expected at least one segment in TreeTypeValue path")
                     .ident
@@ -215,7 +212,7 @@ impl<'t> TypeTree<'t> {
         let is = self
             .path
             .as_mut()
-            .map(|value| value.segments.iter().any(|segment| &segment.ident == ident))
+            .map(|path| path.segments.iter().any(|segment| &segment.ident == ident))
             .unwrap_or(false);
 
         if is {

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -457,6 +457,7 @@ impl ToTokens for ParamType<'_> {
                 match component.value_type {
                     ValueType::Primitive => {
                         let type_path = &**component.path.as_ref().unwrap();
+                        // let type_path = &**component.path.as_ref().unwrap();
                         let schema_type = SchemaType(type_path);
 
                         tokens.extend(quote! {
@@ -471,7 +472,7 @@ impl ToTokens for ParamType<'_> {
                         }
                     }
                     ValueType::Object => {
-                        let component_path = component
+                        let component_path = &**component
                             .path
                             .as_ref()
                             .expect("component should have a path");
@@ -485,7 +486,6 @@ impl ToTokens for ParamType<'_> {
                             });
                         } else {
                             let name: String = component_path
-                                .path
                                 .segments
                                 .last()
                                 .expect("Expected there to be at least one element in the path")

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -457,7 +457,6 @@ impl ToTokens for ParamType<'_> {
                 match component.value_type {
                     ValueType::Primitive => {
                         let type_path = &**component.path.as_ref().unwrap();
-                        // let type_path = &**component.path.as_ref().unwrap();
                         let schema_type = SchemaType(type_path);
 
                         tokens.extend(quote! {

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1062,7 +1062,6 @@ where
 
                 match type_tree.value_type {
                     ValueType::Primitive => {
-                        // let type_path = &**type_tree.path.as_ref().unwrap();
                         let type_path = &**type_tree.path.as_ref().unwrap();
                         let schema_type = SchemaType(type_path);
 
@@ -1113,7 +1112,6 @@ where
                             tokens.extend(quote! { utoipa::openapi::ObjectBuilder::new() })
                         } else {
                             let type_path = &**type_tree.path.as_ref().unwrap();
-                            // let type_path = &**type_tree.path.as_ref().unwrap();
                             if is_inline {
                                 tokens.extend(quote_spanned! {type_path.span() =>
                                     <#type_path as utoipa::ToSchema>::schema()

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1,12 +1,10 @@
-use std::fmt::Debug;
-
 use proc_macro2::{Ident, TokenStream};
 use proc_macro_error::{abort, ResultExt};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     parse::Parse, parse_quote, punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute,
-    Data, Field, Fields, FieldsNamed, FieldsUnnamed, Generics, PathArguments, Token, TypePath,
-    Variant, Visibility,
+    Data, Field, Fields, FieldsNamed, FieldsUnnamed, Generics, Path, PathArguments, Token,
+    TypePath, Variant, Visibility,
 };
 
 use crate::{
@@ -824,7 +822,10 @@ where
         } = self;
         let len = values.len();
         let (schema_type, enum_type) = if let Some(ty) = *enum_type {
-            (SchemaType(ty).to_token_stream(), ty.into_token_stream())
+            (
+                SchemaType(&ty.path).to_token_stream(),
+                ty.into_token_stream(),
+            )
         } else {
             (
                 SchemaType(&parse_quote!(str)).to_token_stream(),
@@ -1061,6 +1062,7 @@ where
 
                 match type_tree.value_type {
                     ValueType::Primitive => {
+                        // let type_path = &**type_tree.path.as_ref().unwrap();
                         let type_path = &**type_tree.path.as_ref().unwrap();
                         let schema_type = SchemaType(type_path);
 
@@ -1111,6 +1113,7 @@ where
                             tokens.extend(quote! { utoipa::openapi::ObjectBuilder::new() })
                         } else {
                             let type_path = &**type_tree.path.as_ref().unwrap();
+                            // let type_path = &**type_tree.path.as_ref().unwrap();
                             if is_inline {
                                 tokens.extend(quote_spanned! {type_path.span() =>
                                     <#type_path as utoipa::ToSchema>::schema()
@@ -1133,11 +1136,11 @@ where
 
 /// Reformat a path reference string that was generated using [`quote`] to be used as a nice compact schema reference,
 /// by removing spaces between colon punctuation and `::` and the path segments.
-pub(crate) fn format_path_ref(path: &TypePath) -> String {
-    let mut path: TypePath = path.clone();
+pub(crate) fn format_path_ref(path: &Path) -> String {
+    let mut path = path.clone();
 
     // Generics and path arguments are unsupported
-    if let Some(last_segment) = path.path.segments.last_mut() {
+    if let Some(last_segment) = path.segments.last_mut() {
         last_segment.arguments = PathArguments::None;
     }
 

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 
 use proc_macro2::TokenStream;
-use syn::{punctuated::Punctuated, token::Comma, ItemFn, TypePath};
+use syn::{punctuated::Punctuated, token::Comma, ItemFn, Path};
 
 use crate::path::PathOperation;
 
@@ -22,7 +22,7 @@ pub mod rocket;
 pub struct ValueArgument<'a> {
     pub name: Option<Cow<'a, str>>,
     pub argument_in: ArgumentIn,
-    pub type_path: Option<Cow<'a, TypePath>>,
+    pub type_path: Option<Cow<'a, Path>>,
     pub is_array: bool,
     pub is_option: bool,
 }
@@ -32,7 +32,7 @@ pub struct ValueArgument<'a> {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct IntoParamsType<'a> {
     pub parameter_in_provider: TokenStream,
-    pub type_path: Option<Cow<'a, TypePath>>,
+    pub type_path: Option<Cow<'a, syn::Path>>,
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -131,13 +131,14 @@ impl PathOperationResolver for PathOperations {}
     feature = "rocket_extras"
 ))]
 pub mod fn_arg {
+
     use std::borrow::Cow;
 
     use proc_macro2::{Ident, TokenStream};
     use proc_macro_error::abort;
     #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
     use quote::quote;
-    use syn::{punctuated::Punctuated, token::Comma, Pat, PatType, TypePath};
+    use syn::{punctuated::Punctuated, token::Comma, Pat, PatType};
 
     use crate::component::TypeTree;
     #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
@@ -217,7 +218,7 @@ pub mod fn_arg {
     #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
     pub(super) fn with_parameter_in(
         arg: FnArg<'_>,
-    ) -> Option<(Option<Cow<'_, TypePath>>, TokenStream)> {
+    ) -> Option<(Option<std::borrow::Cow<'_, syn::Path>>, TokenStream)> {
         let parameter_in_provider = if arg.ty.is("Path") {
             quote! { || Some (utoipa::openapi::path::ParameterIn::Path) }
         } else if arg.ty.is("Query") {
@@ -239,7 +240,7 @@ pub mod fn_arg {
     }
 
     pub(super) fn into_into_params_type(
-        (type_path, parameter_in_provider): (Option<Cow<'_, TypePath>>, TokenStream),
+        (type_path, parameter_in_provider): (Option<Cow<'_, syn::Path>>, TokenStream),
     ) -> IntoParamsType<'_> {
         IntoParamsType {
             parameter_in_provider,

--- a/utoipa-gen/src/ext/rocket.rs
+++ b/utoipa-gen/src/ext/rocket.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Ident, TokenStream};
 use proc_macro_error::abort;
 use quote::quote;
 use regex::{Captures, Regex};
-use syn::{parse::Parse, LitStr, Token, TypePath};
+use syn::{parse::Parse, LitStr, Token};
 
 use crate::{
     component::{GenericType, TypeTree, ValueType},
@@ -90,7 +90,7 @@ fn to_anonymous_value_arg<'a>(macro_arg: MacroArg) -> ValueArgument<'a> {
 
 fn with_parameter_in(
     named_args: &[MacroArg],
-) -> impl Fn(FnArg) -> Option<(Option<Cow<'_, TypePath>>, TokenStream)> + '_ {
+) -> impl Fn(FnArg) -> Option<(Option<Cow<'_, syn::Path>>, TokenStream)> + '_ {
     move |arg: FnArg| {
         let parameter_in = named_args.iter().find_map(|macro_arg| match macro_arg {
             MacroArg::Path(path) => {
@@ -137,7 +137,7 @@ fn with_argument_in(named_args: &[MacroArg]) -> impl Fn(FnArg) -> Option<(FnArg,
 }
 
 #[inline]
-fn get_value_type(ty: TypeTree<'_>) -> Option<Cow<TypePath>> {
+fn get_value_type(ty: TypeTree<'_>) -> Option<Cow<syn::Path>> {
     // TODO abort if map
     match ty.generic_type {
         Some(GenericType::Vec)

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1398,7 +1398,7 @@ impl ToTokens for Required {
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Clone)]
 struct Type<'a> {
-    ty: Cow<'a, TypePath>,
+    ty: Cow<'a, syn::Path>,
     is_array: bool,
     is_option: bool,
     is_inline: bool,
@@ -1410,9 +1410,9 @@ impl<'a> Type<'a> {
         feature = "rocket_extras",
         feature = "axum_extras"
     ))]
-    pub fn new(type_path: Cow<'a, TypePath>, is_array: bool, is_option: bool) -> Self {
+    pub fn new(path: Cow<'a, syn::Path>, is_array: bool, is_option: bool) -> Self {
         Self {
-            ty: type_path,
+            ty: path,
             is_array,
             is_option,
             is_inline: false,
@@ -1560,7 +1560,7 @@ impl Parse for ArrayOrOptionType<'_> {
             };
 
             Ok(Type {
-                ty: Cow::Owned(path),
+                ty: Cow::Owned(path.path),
                 is_array,
                 is_option,
                 is_inline: false,

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -355,6 +355,7 @@ impl ToTokens for Components {
                 let component_name: String = component
                     .alias
                     .as_ref()
+                    .map(|path| &path.path)
                     .map(schema::format_path_ref)
                     .unwrap_or_else(|| ident.to_token_stream().to_string());
 

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -164,7 +164,7 @@ impl<'p> PathAttr<'p> {
                         if let Some(into_params_argument) =
                             into_params_types
                                 .iter_mut()
-                                .find(|argument| matches!(&argument.type_path, Some(path) if path.path == parameter.path.path))
+                                .find(|argument| matches!(&argument.type_path, Some(path) if path.as_ref() == &parameter.path.path))
                         {
                             parameter.update_parameter_in(
                                 &mut into_params_argument.parameter_in_provider,

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -117,7 +117,7 @@ impl<'p> ValueParameter<'p> {
     ))]
     pub fn update_parameter_type(
         &mut self,
-        type_path: Option<Cow<'p, syn::TypePath>>,
+        type_path: Option<Cow<'p, syn::Path>>,
         is_array: bool,
         is_option: bool,
     ) {

--- a/utoipa-gen/src/path/property.rs
+++ b/utoipa-gen/src/path/property.rs
@@ -17,7 +17,7 @@ impl<'a> Property<'a> {
     }
 
     pub fn schema_type(&'a self) -> SchemaType<'a> {
-        SchemaType(&*self.0.ty)
+        SchemaType(&self.0.ty)
     }
 }
 

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -149,6 +149,8 @@ fn derive_path_with_multiple_args() {
         use actix_web::{get, web, HttpResponse, Responder};
         use serde_json::json;
 
+        trait Store {}
+
         #[utoipa::path(
             responses(
                 (status = 200, description = "success response")
@@ -156,7 +158,10 @@ fn derive_path_with_multiple_args() {
         )]
         #[get("/foo/{id}/bar/{digest}")]
         #[allow(unused)]
-        async fn get_foo_by_id(path: web::Path<(i64, String)>) -> impl Responder {
+        async fn get_foo_by_id(
+            path: web::Path<(i64, String)>,
+            data: web::Data<&dyn Store>,
+        ) -> impl Responder {
             let (id, digest) = path.into_inner();
             HttpResponse::Ok().json(json!({ "id": &format!("{:?} {:?}", id, digest) }))
         }

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -149,8 +149,6 @@ fn derive_path_with_multiple_args() {
         use actix_web::{get, web, HttpResponse, Responder};
         use serde_json::json;
 
-        trait Store {}
-
         #[utoipa::path(
             responses(
                 (status = 200, description = "success response")
@@ -158,10 +156,7 @@ fn derive_path_with_multiple_args() {
         )]
         #[get("/foo/{id}/bar/{digest}")]
         #[allow(unused)]
-        async fn get_foo_by_id(
-            path: web::Path<(i64, String)>,
-            data: web::Data<&dyn Store>,
-        ) -> impl Responder {
+        async fn get_foo_by_id(path: web::Path<(i64, String)>) -> impl Responder {
             let (id, digest) = path.into_inner();
             HttpResponse::Ok().json(json!({ "id": &format!("{:?} {:?}", id, digest) }))
         }
@@ -194,6 +189,29 @@ fn derive_path_with_multiple_args() {
         "[1].schema.type" = r#""string""#, "Parameter schema type"
         "[1].schema.format" = r#"null"#, "Parameter schema format"
     };
+}
+
+#[test]
+fn derive_path_with_dyn_trait_compiles() {
+    use actix_web::{get, web, HttpResponse, Responder};
+    use serde_json::json;
+
+    trait Store {}
+
+    #[utoipa::path(
+        responses(
+            (status = 200, description = "success response")
+        ),
+    )]
+    #[get("/foo/{id}/bar/{digest}")]
+    #[allow(unused)]
+    async fn get_foo_by_id(
+        path: web::Path<(i64, String)>,
+        data: web::Data<&dyn Store>,
+    ) -> impl Responder {
+        let (id, digest) = path.into_inner();
+        HttpResponse::Ok().json(json!({ "id": &format!("{:?} {:?}", id, digest) }))
+    }
 }
 
 #[test]

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -38,8 +38,8 @@ builder! {
 
     /// Implements [OpenAPI Components Object][components] which holds supported
     /// reusable objects.
-    /// 
-    /// Components can hold either reusable types themselves or references to other reusable 
+    ///
+    /// Components can hold either reusable types themselves or references to other reusable
     /// types.
     ///
     /// [components]: https://spec.openapis.org/oas/latest.html#components-object
@@ -217,7 +217,7 @@ impl ComponentsBuilder {
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum Schema {
-    /// Defines object schema. Object is either `object` hodling **properties** which are other [`Schema`]s 
+    /// Defines object schema. Object is either `object` hodling **properties** which are other [`Schema`]s
     /// or can be a field within the [`Object`].
     Object(Object),
     /// Defines array schema from another schema. Typically used with
@@ -231,9 +231,9 @@ pub enum Schema {
     OneOf(OneOf),
 
     /// Creates a _AnyOf_ type [composite Object][composite] shcema.
-    /// 
+    ///
     /// [composite]: https://spec.openapis.org/oas/latest.html#components-object
-    AllOf(AllOf)
+    AllOf(AllOf),
 }
 
 impl Default for Schema {
@@ -244,7 +244,7 @@ impl Default for Schema {
 
 /// OpenAPI [Discriminator][discriminator] object which can be optionally used together with
 /// [`OneOf`] composite object.
-/// 
+///
 /// [discriminator]: https://spec.openapis.org/oas/latest.html#discriminator-object
 #[derive(Serialize, Deserialize, Clone, Default)]
 #[serde(rename_all = "camelCase")]
@@ -257,9 +257,9 @@ pub struct Discriminator {
 
 impl Discriminator {
     /// Construct a new [`Discriminator`] object with property name.
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// Create a new [`Discriminator`] object for `pet_type` property.
     /// ```rust
     /// # use utoipa::openapi::schema::Discriminator;
@@ -312,7 +312,7 @@ pub struct OneOf {
     /// Optional discriminator field can be used to aid deserialization, serialization and validation of a
     /// specific schema.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discriminator: Option<Discriminator>
+    pub discriminator: Option<Discriminator>,
 }
 
 impl OneOf {
@@ -347,7 +347,7 @@ impl OneOf {
 #[derive(Default)]
 pub struct OneOfBuilder {
     items: Vec<RefOr<Schema>>,
-    
+
     description: Option<String>,
 
     #[cfg(feature = "serde_json")]
@@ -362,7 +362,7 @@ pub struct OneOfBuilder {
     #[cfg(not(feature = "serde_json"))]
     example: Option<String>,
 
-    discriminator: Option<Discriminator>
+    discriminator: Option<Discriminator>,
 }
 
 impl OneOfBuilder {
@@ -472,7 +472,7 @@ pub struct AllOf {
     /// Optional discriminator field can be used to aid deserialization, serialization and validation of a
     /// specific schema.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub discriminator: Option<Discriminator>
+    pub discriminator: Option<Discriminator>,
 }
 
 impl AllOf {
@@ -507,7 +507,7 @@ impl AllOf {
 #[derive(Default)]
 pub struct AllOfBuilder {
     items: Vec<RefOr<Schema>>,
-    
+
     description: Option<String>,
 
     #[cfg(feature = "serde_json")]
@@ -522,7 +522,7 @@ pub struct AllOfBuilder {
     #[cfg(not(feature = "serde_json"))]
     example: Option<String>,
 
-    discriminator: Option<Discriminator>
+    discriminator: Option<Discriminator>,
 }
 
 impl AllOfBuilder {
@@ -624,7 +624,6 @@ pub struct Object {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cfg(feature = "serde_json")]
     pub default: Option<Value>,
-
 
     /// Default value which is provided when user has not provided the input in Swagger UI.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -931,10 +930,9 @@ impl From<Ref> for RefOr<Schema> {
     }
 }
 
-
-/// A [`Ref`] or some other type `T`. 
-/// 
-/// Typically used in combination with [`Components`] and is an union type between [`Ref`] and any 
+/// A [`Ref`] or some other type `T`.
+///
+/// Typically used in combination with [`Components`] and is an union type between [`Ref`] and any
 /// other given type such as [`Schema`] or [`Response`].
 #[derive(Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -1376,10 +1374,7 @@ mod tests {
                 "Comp",
                 Schema::from(
                     ObjectBuilder::new()
-                        .property(
-                            "name",
-                            ObjectBuilder::new().schema_type(SchemaType::String),
-                        )
+                        .property("name", ObjectBuilder::new().schema_type(SchemaType::String))
                         .required("name"),
                 ),
             )])
@@ -1404,10 +1399,7 @@ mod tests {
     #[test]
     fn reserialize_deserialized_object_component() {
         let prop = ObjectBuilder::new()
-            .property(
-                "name",
-                ObjectBuilder::new().schema_type(SchemaType::String),
-            )
+            .property("name", ObjectBuilder::new().schema_type(SchemaType::String))
             .required("name")
             .build();
 
@@ -1423,9 +1415,7 @@ mod tests {
 
     #[test]
     fn reserialize_deserialized_property() {
-        let prop = ObjectBuilder::new()
-            .schema_type(SchemaType::String)
-            .build();
+        let prop = ObjectBuilder::new().schema_type(SchemaType::String).build();
 
         let serialized_components = serde_json::to_string(&prop).unwrap();
         let deserialized_components: Object =


### PR DESCRIPTION
Previously using `dyn` in handler arguments caused the TypeTree resolvation to fail because there wa no support for trait. This will fix that by adding support for trait types for TypeTree.

fixes #292 