### PR TITLE
#297 - Allow using default and range matched status responses

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -502,7 +502,7 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///
 /// # Responses Attributes
 ///
-/// * `status = ...` Is valid http status code. E.g. _`200`_
+/// * `status = ...` Is either a valid http status code integer. E.g. _`200`_ or a string value representing a range such as `"4XX"` or `"default"`.
 /// * `description = "..."` Define description for the response as str.
 /// * `body = ...` Optional response body object type. When left empty response does not expect to send any
 ///   response body. Should be an identifier or slice. E.g _`Pet`_ or _`[Pet]`_. Where the type implments [`ToSchema`][to_schema],
@@ -524,6 +524,7 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// responses(
 ///     (status = 200, description = "success response"),
 ///     (status = 404, description = "resource missing"),
+///     (status = "5XX", description = "server error"),
 /// )
 /// ```
 ///

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -186,7 +186,7 @@ impl ToTokens for Responses<'_> {
                         })
                     }
                     Response::Value(response) => {
-                        let code = &response.status_code.to_string();
+                        let code = &response.status_code;
                         acc.extend(quote! { .response(#code, #response) });
                     }
                 }

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -81,6 +81,12 @@ fn derive_path_with_multiple_simple_responses() {
         "responses.500.description" = r#""server error""#, "Response description"
         "responses.500.content" = r#"null"#, "Response content"
         "responses.500.headers" = r#"null"#, "Response headers"
+        "responses.5XX.description" = r#""all other server errors""#, "Response description"
+        "responses.5XX.content" = r#"null"#, "Response content"
+        "responses.5XX.headers" = r#"null"#, "Response headers"
+        "responses.default.description" = r#""default""#, "Response description"
+        "responses.default.content" = r#"null"#, "Response content"
+        "responses.default.headers" = r#"null"#, "Response headers"
     }
 }
 

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -58,7 +58,9 @@ test_fn! {
         (status = 200, description = "success"),
         (status = 401, description = "unauthorized"),
         (status = 404, description = "not found"),
-        (status = 500, description = "server error")
+        (status = 500, description = "server error"),
+        (status = "5XX", description = "all other server errors"),
+        (status = "default", description = "default")
     )
 }
 


### PR DESCRIPTION
To hopefully close https://github.com/juhaku/utoipa/issues/297

Changes the macro to allow passing strings for the response status code.

This is necessary to use things like "default" or "5XX"