### PR TITLE
Fix deserialization of content encoding

### DIFF
--- a/utoipa/src/openapi/content.rs
+++ b/utoipa/src/openapi/content.rs
@@ -34,7 +34,7 @@ pub struct Content {
     ///
     /// The encoding object SHALL only apply to `request_body` objects when the media type is
     /// multipart or `application/x-www-form-urlencoded`.
-    #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub encoding: BTreeMap<String, Encoding>,
 }
 


### PR DESCRIPTION
I have some complex custom response specs that I would like to deserialize from JSON rather than build it manually, currently I get errors when the encoding block is missing