### PR TITLE
Allow using a response reference in the list of responses

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -551,7 +551,7 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///
 /// ```text
 /// responses(
-///     (status = 200, response_ref = ReusableResponse)
+///     (status = 200, response = ReusableResponse)
 /// )
 /// ```
 ///

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -545,6 +545,16 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// )
 /// ```
 ///
+/// **Reference a reusable response type:**
+///
+/// `ReusableResponse` must be a type that implements [`ToResponse`][to_response_trait]
+///
+/// ```text
+/// responses(
+///     (status = 200, response_ref = ReusableResponse)
+/// )
+/// ```
+///
 /// ## Responses from `IntoResponses`
 ///
 /// Responses for a path can be specified with one or more types that implement
@@ -868,6 +878,7 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// [style]: openapi/path/enum.ParameterStyle.html
 /// [into_responses_trait]: trait.IntoResponses.html
 /// [into_params_derive]: derive.IntoParams.html
+/// [to_response_trait]: trait.ToResponse.html
 ///
 /// [^json]: **json** feature need to be enabled for `json!(...)` type to work.
 ///

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -10,7 +10,6 @@ use syn::{
 };
 
 use crate::{parse_utils, AnyValue, Type};
-use crate::component::schema;
 
 use super::{property::Property, ContentTypeResolver};
 

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -64,24 +64,27 @@ impl Parse for ResponseValue<'_> {
 
             match attribute_name {
                 "status" => {
-                    response.status_code =
-                        parse_utils::parse_next(input, || {
-                            let lookahead = input.lookahead1();
-                            if lookahead.peek(LitInt) {
-                                input.parse::<LitInt>()?.base10_parse()
-                            } else if lookahead.peek(LitStr) {
-                                let value = input.parse::<LitStr>()?.value();
-                                if !VALID_STATUS_RANGES.contains(&value.as_str()) {
-                                    return Err(Error::new(
-                                        input.span(),
-                                        format!("{} {}", INVALID_STATUS_RANGE_MESSAGE, VALID_STATUS_RANGES.join(", ")),
-                                    ))
-                                }
-                                Ok(value)
-                            } else {
-                                Err(lookahead.error())
+                    response.status_code = parse_utils::parse_next(input, || {
+                        let lookahead = input.lookahead1();
+                        if lookahead.peek(LitInt) {
+                            input.parse::<LitInt>()?.base10_parse()
+                        } else if lookahead.peek(LitStr) {
+                            let value = input.parse::<LitStr>()?.value();
+                            if !VALID_STATUS_RANGES.contains(&value.as_str()) {
+                                return Err(Error::new(
+                                    input.span(),
+                                    format!(
+                                        "{} {}",
+                                        INVALID_STATUS_RANGE_MESSAGE,
+                                        VALID_STATUS_RANGES.join(", ")
+                                    ),
+                                ));
                             }
-                        })?
+                            Ok(value)
+                        } else {
+                            Err(lookahead.error())
+                        }
+                    })?
                 }
                 "description" => {
                     response.description = parse_utils::parse_next_literal_str(input)?;

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -57,7 +57,7 @@ impl<'r> ResponseTuple<'r> {
         }
     }
 
-    // Sets the `reference` attribute, this will fail if an incompatible attribute has already been set
+    // Use with the `response` attribute, this will fail if an incompatible attribute has already been set
     fn set_ref_type(&mut self, span: Span, ty: Type<'r>) -> syn::Result<()> {
         match &mut self.inner {
             None => self.inner = Some(ResponseTupleInner::Ref(ty)),

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -5,6 +5,7 @@ use assert_json_diff::assert_json_eq;
 use paste::paste;
 use serde_json::{json, Value};
 use std::collections::HashMap;
+use utoipa::openapi::schema::RefOr;
 use utoipa::{
     openapi::{Response, ResponseBuilder, ResponsesBuilder},
     IntoParams, IntoResponses, OpenApi, ToSchema,
@@ -814,7 +815,7 @@ fn derive_path_with_into_responses() {
     }
 
     impl IntoResponses for MyResponse {
-        fn responses() -> BTreeMap<String, Response> {
+        fn responses() -> BTreeMap<String, RefOr<Response>> {
             let responses = ResponsesBuilder::new()
                 .response("200", ResponseBuilder::new().description("Ok"))
                 .response("404", ResponseBuilder::new().description("Not Found"))

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -3,9 +3,7 @@
 use assert_json_diff::assert_json_eq;
 use serde_json::{json, Value};
 use utoipa::openapi::Response;
-use utoipa::openapi::SchemaType::String;
 use utoipa::ToResponse;
-use std::string::String as StdString;
 
 mod common;
 
@@ -98,8 +96,11 @@ fn derive_path_with_multiple_simple_responses() {
 struct ReusableResponse;
 
 impl ToResponse for ReusableResponse {
-    fn response() -> (StdString, Response) {
-        (StdString::from("ReusableResponseName"), Response::new("reusable response"))
+    fn response() -> (String, Response) {
+        (
+            String::from("ReusableResponseName"),
+            Response::new("reusable response"),
+        )
     }
 }
 
@@ -107,7 +108,7 @@ test_fn! {
     module: reusable_responses,
     responses: (
         (status = 200, description = "success"),
-        (status = "default", response_ref = crate::ReusableResponse)
+        (status = "default", response = crate::ReusableResponse)
     )
 }
 
@@ -119,7 +120,6 @@ fn derive_path_with_reusable_responses() {
         "responses.200.description" = r#""success""#, "Response description"
         "responses.default.$ref" = "\"#/components/responses/ReusableResponseName\"", "Response reference"
     }
-
 }
 
 macro_rules! test_response_types {

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -217,6 +217,7 @@ pub mod openapi;
 
 use std::collections::BTreeMap;
 
+use crate::openapi::schema::RefOr;
 use openapi::Response;
 pub use utoipa_gen::*;
 
@@ -565,7 +566,7 @@ pub trait IntoParams {
 /// ```
 /// use std::collections::BTreeMap;
 /// use utoipa::{
-///     openapi::{Response, ResponseBuilder, ResponsesBuilder},
+///     openapi::{Response, ResponseBuilder, ResponsesBuilder, schema::RefOr},
 ///     IntoResponses,
 /// };
 ///
@@ -575,7 +576,7 @@ pub trait IntoParams {
 /// }
 ///
 /// impl IntoResponses for MyResponse {
-///     fn responses() -> BTreeMap<String, Response> {
+///     fn responses() -> BTreeMap<String, RefOr<Response>> {
 ///         ResponsesBuilder::new()
 ///             .response("200", ResponseBuilder::new().description("Ok"))
 ///             .response("404", ResponseBuilder::new().description("Not Found"))
@@ -586,7 +587,7 @@ pub trait IntoParams {
 /// ```
 pub trait IntoResponses {
     /// Returns an ordered map of response codes to responses.
-    fn responses() -> BTreeMap<String, Response>;
+    fn responses() -> BTreeMap<String, RefOr<Response>>;
 }
 
 /// This trait is implemented to document a type which represents a single response which can be

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -362,8 +362,14 @@ impl OperationBuilder {
     ///
     /// * `code` must be valid HTTP status code.
     /// * `response` is instances of [`Response`].
-    pub fn response<S: Into<String>>(mut self, code: S, response: Response) -> Self {
-        self.responses.responses.insert(code.into(), response);
+    pub fn response<S: Into<String>, R: Into<RefOr<Response>>>(
+        mut self,
+        code: S,
+        response: R,
+    ) -> Self {
+        self.responses
+            .responses
+            .insert(code.into(), response.into());
 
         self
     }

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
 use crate::openapi::schema::RefOr;
+use crate::openapi::Ref;
 use crate::IntoResponses;
 
 use super::{build_fn, builder, from, header::Header, new, set_value, Content};
@@ -155,6 +156,12 @@ impl ResponseBuilder {
 impl From<ResponseBuilder> for RefOr<Response> {
     fn from(builder: ResponseBuilder) -> Self {
         Self::T(builder.build())
+    }
+}
+
+impl From<Ref> for RefOr<Response> {
+    fn from(r: Ref) -> Self {
+        Self::Ref(r)
     }
 }
 


### PR DESCRIPTION
First of all this updates the Responses struct to have:

```rust
pub responses: BTreeMap<String, RefOr<Response>>,
```

Which should now correctly match the way the OpenAPI specs work:

```yaml
      responses:
        '200':
          description: Success
        '400':
          "$ref": "#/components/responses/BadRequest"
```

And then it enables you to use a reference in the `path` macro:

```
    responses: (
        (status = 200, description = "Success"),
        (status = 400, response = crate::BadRequestResponse),
    )
```

where `crate::BadRequestResponse` is a type that implements `ToResponse` and is used in:

```rust
#[openapi(
    components(
        responses(
            crate::BadRequestResponse,
        )
    ),
)]
```

(Note I had to use `response ` instead of just `ref` since it is a reserved keyword)

This should close https://github.com/juhaku/utoipa/issues/300
