### PR TITLE
Allow custom SchemaFormats

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -76,8 +76,9 @@ use ext::ArgumentResolver;
 /// # Unnamed Field Struct Optional Configuration Options for `#[schema(...)]`
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
 /// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
-/// * `format = ...` Any variant of a [`SchemaFormat`][format] to use for the property. By default the format is derived from
-///   the type of the property according OpenApi spec.
+/// * `format = ...` May either be variant of the [`KnownFormat`][known_format] enum, or otherwise
+///   an open value as a string. By default the format is derived from the type of the property
+///   according OpenApi spec.
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
 ///   This is useful in cases where the default type does not correspond to the actual type e.g. when
 ///   any third-party types are used which are not [`ToSchema`][to_schema]s nor [`primitive` types][primitive].
@@ -86,8 +87,9 @@ use ext::ArgumentResolver;
 /// # Named Fields Optional Configuration Options for `#[schema(...)]`
 /// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
 /// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
-/// * `format = ...` Any variant of a [`SchemaFormat`][format] to use for the property. By default the format is derived from
-///   the type of the property according OpenApi spec.
+/// * `format = ...` May either be variant of the [`KnownFormat`][known_format] enum, or otherwise
+///   an open value as a string. By default the format is derived from the type of the property
+///   according OpenApi spec.
 /// * `write_only` Defines property is only used in **write** operations *POST,PUT,PATCH* but not in *GET*
 /// * `read_only` Defines property is only used in **read** operations *GET* but not in *POST,PUT,PATCH*
 /// * `xml(...)` Can be used to define [`Xml`][xml] object properties applicable to named fields.
@@ -368,7 +370,7 @@ use ext::ArgumentResolver;
 /// ```
 ///
 /// Enforce type being used in OpenAPI spec to [`String`] with `value_type` and set format to octet stream
-/// with [`SchemaFormat::Binary`][binary].
+/// with [`SchemaFormat::KnownFormat(KnownFormat::Binary)`][binary].
 /// ```rust
 /// # use utoipa::ToSchema;
 /// #[derive(ToSchema)]
@@ -420,8 +422,8 @@ use ext::ArgumentResolver;
 /// More examples for _`value_type`_ in [`IntoParams` derive docs][into_params].
 ///
 /// [to_schema]: trait.ToSchema.html
-/// [format]: openapi/schema/enum.SchemaFormat.html
-/// [binary]: openapi/schema/enum.SchemaFormat.html#variant.Binary
+/// [known_format]: openapi/schema/enum.KnownFormat.html
+/// [binary]: openapi/schema/enum.KnownFormat.html#variant.Binary
 /// [xml]: openapi/xml/struct.Xml.html
 /// [into_params]: derive.IntoParams.html
 /// [primitive]: https://doc.rust-lang.org/std/primitive/index.html

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use utoipa::{
     openapi::{
         path::{Parameter, ParameterBuilder, ParameterIn},
-        Array, ObjectBuilder, SchemaFormat,
+        Array, KnownFormat, ObjectBuilder, SchemaFormat,
     },
     IntoParams, OpenApi, ToSchema,
 };
@@ -360,7 +360,7 @@ fn path_with_struct_variables_with_into_params() {
                     .schema(Some(
                         ObjectBuilder::new()
                             .schema_type(utoipa::openapi::SchemaType::Integer)
-                            .format(Some(SchemaFormat::Int64)),
+                            .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64))),
                     ))
                     .parameter_in(ParameterIn::Path)
                     .build(),

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1548,6 +1548,21 @@ fn derive_struct_component_field_type_override_with_format() {
 }
 
 #[test]
+fn derive_struct_component_field_type_override_with_custom_format() {
+    let post = api_doc! {
+        struct Post {
+            #[schema(value_type = String, format = "uri")]
+            value: String,
+        }
+    };
+
+    assert_value! {post=>
+        "properties.value.type" = r#""string""#, "Post value type"
+        "properties.value.format" = r#""uri""#, "Post value format"
+    }
+}
+
+#[test]
 fn derive_struct_component_field_type_override_with_format_with_vec() {
     let post = api_doc! {
         struct Post {

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -306,7 +306,7 @@ pub trait OpenApi {
 ///                 "id",
 ///                 utoipa::openapi::ObjectBuilder::new()
 ///                     .schema_type(utoipa::openapi::SchemaType::Integer)
-///                     .format(Some(utoipa::openapi::SchemaFormat::Int64)),
+///                     .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int64))),
 ///             )
 ///             .required("id")
 ///             .property(
@@ -318,7 +318,7 @@ pub trait OpenApi {
 ///                 "age",
 ///                 utoipa::openapi::ObjectBuilder::new()
 ///                     .schema_type(utoipa::openapi::SchemaType::Integer)
-///                     .format(Some(utoipa::openapi::SchemaFormat::Int32)),
+///                     .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int32))),
 ///             )
 ///             .example(Some(serde_json::json!({
 ///               "name": "bob the cat", "id": 1
@@ -407,7 +407,7 @@ pub trait ToSchema {
 ///                         .schema(
 ///                             Some(utoipa::openapi::ObjectBuilder::new()
 ///                                 .schema_type(utoipa::openapi::SchemaType::Integer)
-///                                 .format(Some(utoipa::openapi::SchemaFormat::Int64))),
+///                                 .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int64)))),
 ///                         ),
 ///                 )
 ///                 .tag("pet_api"),
@@ -532,7 +532,7 @@ pub trait Modify {
 ///                 .schema(Some(
 ///                     utoipa::openapi::ObjectBuilder::new()
 ///                         .schema_type(utoipa::openapi::SchemaType::Integer)
-///                         .format(Some(utoipa::openapi::SchemaFormat::Int64)),
+///                         .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int64))),
 ///                 ))
 ///                 .build(),
 ///             utoipa::openapi::path::ParameterBuilder::new()

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -11,7 +11,8 @@ pub use self::{
     response::{Response, ResponseBuilder, Responses, ResponsesBuilder},
     schema::{
         AllOf, AllOfBuilder, Array, ArrayBuilder, Components, ComponentsBuilder, Discriminator,
-        Object, ObjectBuilder, OneOf, OneOfBuilder, Ref, Schema, SchemaFormat, SchemaType, ToArray,
+        KnownFormat, Object, ObjectBuilder, OneOf, OneOfBuilder, Ref, Schema, SchemaFormat,
+        SchemaType, ToArray,
     },
     security::SecurityRequirement,
     server::{Server, ServerBuilder, ServerVariable, ServerVariableBuilder},

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -1117,10 +1117,20 @@ impl Default for SchemaType {
 
 /// Additional format for [`SchemaType`] to fine tune the data type used. If the **format** is not
 /// supported by the UI it may default back to [`SchemaType`] alone.
+/// Format is an open value, so you can use any formats, even not those defined by the
+/// OpenAPI Specification.
+#[derive(Serialize, Deserialize, Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[serde(rename_all = "lowercase", untagged)]
+pub enum SchemaFormat {
+    KnownFormat(KnownFormat),
+    Custom(String),
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[serde(rename_all = "lowercase")]
-pub enum SchemaFormat {
+pub enum KnownFormat {
     /// 32 bit integer.
     Int32,
     /// 64 bit integer.
@@ -1138,7 +1148,7 @@ pub enum SchemaFormat {
     /// ISO-8601 full date time [FRC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14).
     #[serde(rename = "date-time")]
     DateTime,
-    /// Hint to UI to obsucre input.
+    /// Hint to UI to obscure input.
     Password,
     /// Used with [`String`] values to indicate value is in UUID format.
     ///
@@ -1172,7 +1182,7 @@ mod tests {
                                     "id",
                                     ObjectBuilder::new()
                                         .schema_type(SchemaType::Integer)
-                                        .format(Some(SchemaFormat::Int32))
+                                        .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                                         .description(Some("Id of credential"))
                                         .default(Some(json!(1i32))),
                                 )
@@ -1340,7 +1350,7 @@ mod tests {
                 "id",
                 ObjectBuilder::new()
                     .schema_type(SchemaType::Integer)
-                    .format(Some(SchemaFormat::Int32))
+                    .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                     .description(Some("Id of credential"))
                     .default(Some(json!(1i32))),
             ),
@@ -1357,7 +1367,7 @@ mod tests {
                     "id",
                     ObjectBuilder::new()
                         .schema_type(SchemaType::Integer)
-                        .format(Some(SchemaFormat::Int32))
+                        .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                         .description(Some("Id of credential"))
                         .default(Some(json!(1i32))),
                 ),


### PR DESCRIPTION
As per the OpenAPI spec, allows custom values to be used as a format.

Closes https://github.com/juhaku/utoipa/issues/307
