### PR TITLE
Refactor IntoParams attribute parsing functionality

### DIFF
--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -3,11 +3,11 @@ use std::mem;
 use proc_macro2::{Ident, Span, TokenStream};
 use proc_macro_error::abort;
 use quote::{quote, ToTokens};
-use syn::{parenthesized, parse::Parse};
+use syn::{parenthesized, parse::Parse, LitStr};
 
-use crate::{parse_utils, schema_type::SchemaFormat, AnyValue};
+use crate::{parse_utils, path::parameter::ParameterStyle, schema_type::SchemaFormat, AnyValue};
 
-use super::{schema, GenericType, TypeTree};
+use super::{schema, serde::RenameRule, GenericType, TypeTree};
 
 pub trait Name {
     fn get_name() -> &'static str;
@@ -36,6 +36,11 @@ pub enum Feature {
     ReadOnly(ReadOnly),
     Title(Title),
     Nullable(Nullable),
+    Rename(Rename),
+    RenameAll(RenameAll),
+    Style(Style),
+    AllowReserve(AllowReserved),
+    Explode(Explode),
 }
 
 impl Feature {
@@ -52,6 +57,11 @@ impl Feature {
             "read_only" => ReadOnly::parse(input).map(Self::ReadOnly),
             "title" => Title::parse(input).map(Self::Title),
             "nullable" => Nullable::parse(input).map(Self::Nullable),
+            "rename" => Rename::parse(input).map(Self::Rename),
+            "rename_all" => RenameAll::parse(input).map(Self::RenameAll),
+            "style" => Style::parse(input).map(Self::Style),
+            "allow_reserved" => AllowReserved::parse(input).map(Self::AllowReserve),
+            "explode" => Explode::parse(input).map(Self::Explode),
             _unexpected => Err(syn::Error::new(ident.span(), format!("unexpected name: {}, expected one of: default, example, inline, xml, format, value_type, write_only, read_only, title", _unexpected))),
         }
     }
@@ -62,18 +72,35 @@ impl ToTokens for Feature {
         let feature = match &self {
             Feature::Default(default) => quote! { .default(Some(#default)) },
             Feature::Example(example) => quote! { .example(Some(#example)) },
-            Feature::Inline(inline) => quote! { .inline(Some(#inline)) },
             Feature::XmlAttr(xml) => quote! { .xml(Some(#xml)) },
             Feature::Format(format) => quote! { .format(Some(#format)) },
             Feature::WriteOnly(write_only) => quote! { .write_only(Some(#write_only)) },
             Feature::ReadOnly(read_only) => quote! { .read_only(Some(#read_only)) },
             Feature::Title(title) => quote! { .title(Some(#title)) },
             Feature::Nullable(nullable) => quote! { .nullable(#nullable) },
+            Feature::Rename(rename) => rename.to_token_stream(),
+            Feature::Style(style) => quote! { .style(Some(#style)) },
+            Feature::AllowReserve(allow_reserved) => {
+                quote! { .allow_reserved(Some(#allow_reserved)) }
+            }
+            Feature::Explode(explode) => quote! { .explode(Some(#explode)) },
+            Feature::RenameAll(_) => {
+                abort! {
+                    Span::call_site(),
+                    "RenameAll feature does not support `ToTokens`"
+                }
+            }
             Feature::ValueType(_) => {
                 abort! {
                     Span::call_site(),
                     "ValueType feature does not support `ToTokens`";
                     help = "ValueType is supposed to be used with `TypeTree` in same manner as a resolved struct/field type.";
+                }
+            }
+            Feature::Inline(_) => {
+                abort! {
+                    Span::call_site(),
+                    "Inline feature does not support `ToTokens`"
                 }
             }
         };
@@ -125,12 +152,6 @@ pub struct Inline(bool);
 impl Parse for Inline {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         parse_utils::parse_bool_or_true(input).map(Self)
-    }
-}
-
-impl ToTokens for Inline {
-    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        tokens.extend(self.0.to_token_stream())
     }
 }
 
@@ -294,6 +315,108 @@ impl ToTokens for Nullable {
 
 name!(Nullable = "nullable");
 
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone)]
+pub struct Rename(String);
+
+impl Rename {
+    pub fn into_value(self) -> String {
+        self.0
+    }
+}
+
+impl Parse for Rename {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        parse_utils::parse_next_literal_str(input).map(Self)
+    }
+}
+
+impl ToTokens for Rename {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(self.0.to_token_stream())
+    }
+}
+
+name!(Rename = "rename");
+
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone)]
+pub struct RenameAll(RenameRule);
+
+impl Parse for RenameAll {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let litstr = parse_utils::parse_next(input, || input.parse::<LitStr>())?;
+
+        litstr
+            .value()
+            .parse::<RenameRule>()
+            .map_err(|error| syn::Error::new(litstr.span(), error.to_string()))
+            .map(Self)
+    }
+}
+
+name!(RenameAll = "rename_all");
+
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone)]
+pub struct Style(ParameterStyle);
+
+impl From<ParameterStyle> for Style {
+    fn from(style: ParameterStyle) -> Self {
+        Self(style)
+    }
+}
+
+impl Parse for Style {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        parse_utils::parse_next(input, || input.parse::<ParameterStyle>().map(Self))
+    }
+}
+
+impl ToTokens for Style {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.to_tokens(tokens)
+    }
+}
+
+name!(Style = "style");
+
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone)]
+pub struct AllowReserved(bool);
+
+impl Parse for AllowReserved {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        parse_utils::parse_bool_or_true(input).map(Self)
+    }
+}
+
+impl ToTokens for AllowReserved {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.to_tokens(tokens)
+    }
+}
+
+name!(AllowReserved = "allow_reserved");
+
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Clone)]
+pub struct Explode(bool);
+
+impl Parse for Explode {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        parse_utils::parse_bool_or_true(input).map(Self)
+    }
+}
+
+impl ToTokens for Explode {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.to_tokens(tokens)
+    }
+}
+
+name!(Explode = "explode");
+
 macro_rules! parse_features {
     ($ident:ident as $( $feature:path ),*) => {
         {
@@ -369,6 +492,10 @@ impl ToTokensExt for Vec<Feature> {
 
 pub trait FeaturesExt {
     fn pop_by(&mut self, op: impl FnMut(&Feature) -> bool) -> Option<Feature>;
+
+    fn find_value_type_feature_as_value_type(&mut self) -> Option<super::features::ValueType>;
+
+    fn find_rename_feature_as_rename(&mut self) -> Option<Rename>;
 }
 
 impl FeaturesExt for Vec<Feature> {
@@ -377,4 +504,42 @@ impl FeaturesExt for Vec<Feature> {
             .position(op)
             .map(|index| self.swap_remove(index))
     }
+
+    fn find_value_type_feature_as_value_type(&mut self) -> Option<super::features::ValueType> {
+        self.pop_by(|feature| matches!(feature, Feature::ValueType(_)))
+            .and_then(|feature| match feature {
+                Feature::ValueType(value_type) => Some(value_type),
+                _ => None,
+            })
+    }
+
+    fn find_rename_feature_as_rename(&mut self) -> Option<Rename> {
+        self.pop_by(|feature| matches!(feature, Feature::Rename(_)))
+            .and_then(|feature| match feature {
+                Feature::Rename(rename) => Some(rename),
+                _ => None,
+            })
+    }
 }
+
+pub trait IntoInner<T> {
+    fn into_inner(self) -> T;
+}
+
+macro_rules! impl_into_inner {
+    ($ident:ident) => {
+        impl crate::component::features::IntoInner<Vec<Feature>> for $ident {
+            fn into_inner(self) -> Vec<Feature> {
+                self.0
+            }
+        }
+
+        impl crate::component::features::IntoInner<Option<Vec<Feature>>> for Option<$ident> {
+            fn into_inner(self) -> Option<Vec<Feature>> {
+                self.map(crate::component::features::IntoInner::into_inner)
+            }
+        }
+    };
+}
+
+pub(crate) use impl_into_inner;

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -5,29 +5,9 @@ use syn::{
 };
 
 use crate::component::features::{
-    parse_features, Default, Example, Feature, Format, Inline, Nullable, ReadOnly, Title,
-    ValueType, WriteOnly, XmlAttr,
+    impl_into_inner, parse_features, Default, Example, Feature, Format, Inline, Nullable, ReadOnly,
+    Title, ValueType, WriteOnly, XmlAttr,
 };
-
-pub trait IntoInner<T> {
-    fn into_inner(self) -> T;
-}
-
-macro_rules! impl_into_inner {
-    ($ident:ident) => {
-        impl IntoInner<Vec<Feature>> for $ident {
-            fn into_inner(self) -> Vec<Feature> {
-                self.0
-            }
-        }
-
-        impl IntoInner<Option<Vec<Feature>>> for Option<$ident> {
-            fn into_inner(self) -> Option<Vec<Feature>> {
-                self.map(IntoInner::into_inner)
-            }
-        }
-    };
-}
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct NamedFieldStructFeatures(Vec<Feature>);

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1081,12 +1081,14 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// deriving `IntoParams`:
 ///
 /// * `names(...)` Define comma seprated list of names for unnamed fields of struct used as a path parameter.
+///    __Only__ supported on __unnamed structs__.
 /// * `style = ...` Defines how all parameters are serialized by [`ParameterStyle`][style]. Default
 ///    values are based on _`parameter_in`_ attribute.
 /// * `parameter_in = ...` =  Defines where the parameters of this field are used with a value from
 ///    [`openapi::path::ParameterIn`][in_enum]. There is no default value, if this attribute is not
 ///    supplied, then the value is determined by the `parameter_in_provider` in
 ///    [`IntoParams::into_params()`](trait.IntoParams.html#tymethod.into_params).
+/// * `rename_all = ...` Can be provided to alternatively to the serde's `rename_all` attribute. Effectively provides same functionality.
 ///
 /// # IntoParams Field Attributes for `#[param(...)]`
 ///
@@ -1104,6 +1106,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///    _`Object`_ will be rendered as generic OpenAPI object.
 /// * `inline` If set, the schema for this field's type needs to be a [`ToSchema`][to_schema], and
 ///   the schema definition will be inlined.
+/// * `rename = ...` Can be provided to alternatively to the serde's `rename` attribute. Effectively provides same functionality.
 ///
 /// **Note!** `#[into_params(...)]` is only supported on unnamed struct types to declare names for the arguments.
 ///
@@ -1124,6 +1127,18 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// #[into_params(names("id", "name"))]
 /// struct IdAndName(u64, String);
 /// ```
+///
+/// # Partial `#[serde(...)]` attributes support
+///
+/// IntoParams derive has partial support for [serde attributes]. These supported attributes will reflect to the
+/// generated OpenAPI doc. For example the _`rename`_ and _`rename_all`_ will reflect to the generated OpenAPI doc.
+///
+/// * `rename_all = "..."` Supported in container level.
+/// * `rename = "..."` Supported **only** in field.
+/// * `default` Supported in container level and field level according to [serde attributes].
+///
+/// Other _`serde`_ attributes works as is but does not have any effect on the generated OpenAPI doc.
+///
 /// # Examples
 ///
 /// Demonstrate [`IntoParams`][into_params] usage with resolving `Path` and `Query` parameters
@@ -1273,6 +1288,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// [style]: openapi/path/enum.ParameterStyle.html
 /// [in_enum]: utoipa/openapi/path/enum.ParameterIn.html
 /// [primitive]: https://doc.rust-lang.org/std/primitive/index.html
+/// [serde attributes]: https://serde.rs/attributes.html
 ///
 /// [^actix]: Feature **actix_extras** need to be enabled
 ///

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1327,7 +1327,7 @@ where
     fn deref(&self) -> &Self::Target {
         match self {
             Self::Owned(vec) => vec.as_slice(),
-            Self::Borrowed(slice) => *slice,
+            Self::Borrowed(slice) => slice,
         }
     }
 }

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -14,10 +14,7 @@ use syn::{
     feature = "axum_extras"
 ))]
 use crate::ext::{ArgumentIn, ValueArgument};
-use crate::{
-    component::into_params::FieldParamContainerAttributes, parse_utils, AnyValue, Deprecated,
-    Required, Type,
-};
+use crate::{parse_utils, AnyValue, Deprecated, Required, Type};
 
 use super::property::Property;
 
@@ -343,15 +340,6 @@ pub struct ParameterExt {
     pub explode: Option<bool>,
     pub allow_reserved: Option<bool>,
     pub(crate) example: Option<AnyValue>,
-}
-
-impl From<&'_ FieldParamContainerAttributes<'_>> for ParameterExt {
-    fn from(attributes: &FieldParamContainerAttributes) -> Self {
-        Self {
-            style: attributes.style,
-            ..ParameterExt::default()
-        }
-    }
 }
 
 impl ParameterExt {

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -533,6 +533,7 @@ fn derive_path_params_intoparams() {
 
     let parameters = operation.get("parameters").unwrap();
 
+    dbg!(&parameters);
     assert_json_eq!(
         parameters,
         json!([

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -816,6 +816,70 @@ fn derive_path_params_custom_rename_all_serde_will_override() {
 }
 
 #[test]
+fn derive_path_parameters_container_level_default() {
+    #[derive(serde::Deserialize, IntoParams, Default)]
+    #[into_params(parameter_in = Query)]
+    #[serde(default)]
+    #[allow(dead_code)]
+    struct MyParams {
+        vec_default: Vec<String>,
+        string: String,
+    }
+
+    #[utoipa::path(
+        get,
+        path = "/list/{id}",
+        responses(
+            (status = 200, description = "success response")
+        ),
+        params(
+            MyParams,
+        )
+    )]
+    #[allow(unused)]
+    fn list(id: i64) -> String {
+        "".to_string()
+    }
+
+    #[derive(utoipa::OpenApi, Default)]
+    #[openapi(paths(list))]
+    struct ApiDoc;
+
+    let operation: Value = test_api_fn_doc! {
+        list,
+        operation: get,
+        path: "/list/{id}"
+    };
+
+    let parameters = operation.get("parameters").unwrap();
+
+    assert_json_eq!(
+        parameters,
+        json!([
+            {
+                "in": "query",
+                "name": "vec_default",
+                "required": false,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+            },
+            {
+                "in": "query",
+                "name": "string",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+            }
+        ])
+    )
+}
+
+#[test]
 fn derive_path_params_intoparams() {
     #[derive(serde::Deserialize, ToSchema)]
     #[schema(default = "foo1", example = "foo1")]

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -705,6 +705,116 @@ fn derive_path_params_with_serde_and_custom_rename() {
         ])
     )
 }
+
+#[test]
+fn derive_path_params_custom_rename_all() {
+    #[derive(serde::Deserialize, IntoParams)]
+    #[into_params(rename_all = "camelCase", parameter_in = Query)]
+    #[allow(dead_code)]
+    struct MyParams {
+        vec_default: Option<Vec<String>>,
+    }
+
+    #[utoipa::path(
+        get,
+        path = "/list/{id}",
+        responses(
+            (status = 200, description = "success response")
+        ),
+        params(
+            MyParams,
+        )
+    )]
+    #[allow(unused)]
+    fn list(id: i64) -> String {
+        "".to_string()
+    }
+
+    #[derive(utoipa::OpenApi, Default)]
+    #[openapi(paths(list))]
+    struct ApiDoc;
+
+    let operation: Value = test_api_fn_doc! {
+        list,
+        operation: get,
+        path: "/list/{id}"
+    };
+
+    let parameters = operation.get("parameters").unwrap();
+
+    assert_json_eq!(
+        parameters,
+        json!([
+            {
+                "in": "query",
+                "name": "vecDefault",
+                "required": false,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+            },
+        ])
+    )
+}
+
+#[test]
+fn derive_path_params_custom_rename_all_serde_will_override() {
+    #[derive(serde::Deserialize, IntoParams)]
+    #[into_params(rename_all = "camelCase", parameter_in = Query)]
+    #[serde(rename_all = "UPPERCASE")]
+    #[allow(dead_code)]
+    struct MyParams {
+        vec_default: Option<Vec<String>>,
+    }
+
+    #[utoipa::path(
+        get,
+        path = "/list/{id}",
+        responses(
+            (status = 200, description = "success response")
+        ),
+        params(
+            MyParams,
+        )
+    )]
+    #[allow(unused)]
+    fn list(id: i64) -> String {
+        "".to_string()
+    }
+
+    #[derive(utoipa::OpenApi, Default)]
+    #[openapi(paths(list))]
+    struct ApiDoc;
+
+    let operation: Value = test_api_fn_doc! {
+        list,
+        operation: get,
+        path: "/list/{id}"
+    };
+
+    let parameters = operation.get("parameters").unwrap();
+
+    assert_json_eq!(
+        parameters,
+        json!([
+            {
+                "in": "query",
+                "name": "VEC_DEFAULT",
+                "required": false,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+            },
+        ])
+    )
+}
+
 #[test]
 fn derive_path_params_intoparams() {
     #[derive(serde::Deserialize, ToSchema)]

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -467,6 +467,245 @@ fn derive_path_params_map() {
 }
 
 #[test]
+fn derive_required_path_params() {
+    #[derive(serde::Deserialize, IntoParams)]
+    #[into_params(parameter_in = Query)]
+    #[allow(dead_code)]
+    struct MyParams {
+        #[serde(default)]
+        vec_default: Option<Vec<String>>,
+
+        #[serde(default)]
+        string_default: Option<String>,
+
+        #[serde(default)]
+        vec_default_required: Vec<String>,
+
+        #[serde(default)]
+        string_default_required: String,
+
+        vec_option: Option<Vec<String>>,
+
+        string_option: Option<String>,
+
+        vec: Vec<String>,
+
+        string: String,
+    }
+
+    #[utoipa::path(
+        get,
+        path = "/list/{id}",
+        responses(
+            (status = 200, description = "success response")
+        ),
+        params(
+            MyParams,
+        )
+    )]
+    #[allow(unused)]
+    fn list(id: i64) -> String {
+        "".to_string()
+    }
+
+    #[derive(utoipa::OpenApi, Default)]
+    #[openapi(paths(list))]
+    struct ApiDoc;
+
+    let operation: Value = test_api_fn_doc! {
+        list,
+        operation: get,
+        path: "/list/{id}"
+    };
+
+    let parameters = operation.get("parameters").unwrap();
+
+    assert_json_eq!(
+        parameters,
+        json!([
+            {
+                "in": "query",
+                "name": "vec_default",
+                "required": false,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+            },
+            {
+                "in": "query",
+                "name": "string_default",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "in": "query",
+                "name": "vec_default_required",
+                "required": false,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+            },
+            {
+                "in": "query",
+                "name": "string_default_required",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+            },
+            {
+                "in": "query",
+                "name": "vec_option",
+                "required": false,
+                "schema": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array",
+                },
+            },
+            {
+                "in": "query",
+                "name": "string_option",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "in": "query",
+                "name": "vec",
+                "required": true,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            {
+                "in": "query",
+                "name": "string",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            }
+        ])
+    )
+}
+
+#[test]
+fn derive_path_params_with_serde_and_custom_rename() {
+    #[derive(serde::Deserialize, IntoParams)]
+    #[into_params(parameter_in = Query)]
+    #[serde(rename_all = "camelCase")]
+    #[allow(dead_code)]
+    struct MyParams {
+        vec_default: Option<Vec<String>>,
+
+        #[serde(default, rename = "STRING")]
+        string_default: Option<String>,
+
+        #[serde(default, rename = "VEC")]
+        #[param(rename = "vec2")]
+        vec_default_required: Vec<String>,
+
+        #[serde(default)]
+        #[param(rename = "string_r2")]
+        string_default_required: String,
+
+        string: String,
+    }
+
+    #[utoipa::path(
+        get,
+        path = "/list/{id}",
+        responses(
+            (status = 200, description = "success response")
+        ),
+        params(
+            MyParams,
+        )
+    )]
+    #[allow(unused)]
+    fn list(id: i64) -> String {
+        "".to_string()
+    }
+
+    #[derive(utoipa::OpenApi, Default)]
+    #[openapi(paths(list))]
+    struct ApiDoc;
+
+    let operation: Value = test_api_fn_doc! {
+        list,
+        operation: get,
+        path: "/list/{id}"
+    };
+
+    let parameters = operation.get("parameters").unwrap();
+
+    assert_json_eq!(
+        parameters,
+        json!([
+            {
+                "in": "query",
+                "name": "vecDefault",
+                "required": false,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+            },
+            {
+                "in": "query",
+                "name": "STRING",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "in": "query",
+                "name": "VEC",
+                "required": false,
+                "schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+            },
+            {
+                "in": "query",
+                "name": "string_r2",
+                "required": false,
+                "schema": {
+                    "type": "string"
+                },
+            },
+            {
+                "in": "query",
+                "name": "string",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            }
+        ])
+    )
+}
+#[test]
 fn derive_path_params_intoparams() {
     #[derive(serde::Deserialize, ToSchema)]
     #[schema(default = "foo1", example = "foo1")]
@@ -533,7 +772,6 @@ fn derive_path_params_intoparams() {
 
     let parameters = operation.get("parameters").unwrap();
 
-    dbg!(&parameters);
     assert_json_eq!(
         parameters,
         json!([


### PR DESCRIPTION
Refactor IntoParams field attribute parsing functionality to use the new Feature based parsing. Add new features for `Rename`, `RenameAll`, `Style`, `AllowReserved` and `Explode`.

Add support for serde `default`, `rename` and `rename_all` attributes for container and field level similar to `ToSchema` implementation.

Resolves #309, fixes #313