### PR TITLE
Use OUT_DIR in build.rs

### DIFF
--- a/utoipa-swagger-ui/build.rs
+++ b/utoipa-swagger-ui/build.rs
@@ -1,6 +1,6 @@
 use std::{
     cmp::Ordering,
-    env::{self, VarError},
+    env,
     fs::{self, File},
     io,
     path::PathBuf,
@@ -18,17 +18,7 @@ fn main() {
         SWAGGER_UI_DIST_ZIP
     );
 
-    let target_dir = env::var("CARGO_TARGET_DIR")
-        .or_else(|_| env::var("CARGO_BUILD_TARGET_DIR"))
-        .or_else(|_| -> Result<String, VarError> {
-            let manifest_dir = env::var("CARGO_MANIFEST_DIR")?;
-            if manifest_dir.contains("/package") {
-                Ok("target".to_string())
-            } else {
-                Ok("../target".to_string())
-            }
-        })
-        .unwrap();
+    let target_dir = env::var("OUT_DIR").unwrap();
     println!("cargo:rustc-env=UTOIPA_SWAGGER_DIR={}", &target_dir);
 
     let swagger_ui_zip = File::open(


### PR DESCRIPTION
From the docs [0]: "Build scripts may save any output files or intermediate artifacts in the directory specified in the OUT_DIR environment variable. Scripts should not modify any files outside of that directory."

[0] https://doc.rust-lang.org/cargo/reference/build-scripts.html#outputs-of-the-build-script

---

I've discovered this issue when I tried to build a crate depending on utoipa using Nix. In this case the current "fallback" directory ("../target") is not writable and executing `build.rs` fails.