### PR TITLE
Update axum to 0.6 RC

### DIFF
--- a/examples/todo-axum/Cargo.toml
+++ b/examples/todo-axum/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.5"
+axum = "0.6.0-rc.2"
 hyper = { version = "0.14", features = ["full"] }
 tokio = { version = "1.17", features = ["full"] }
 tower = "0.4"

--- a/examples/todo-axum/src/main.rs
+++ b/examples/todo-axum/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Error> {
 
     let store = Arc::new(Store::default());
     let app = Router::new()
-        .merge(SwaggerUi::new("/swagger-ui/*tail").url("/api-doc/openapi.json", ApiDoc::openapi()))
+        .merge(SwaggerUi::new("/swagger-ui/").url("/api-doc/openapi.json", ApiDoc::openapi()))
         .route(
             "/todo",
             routing::get(todo::list_todos).post(todo::create_todo),

--- a/examples/todo-axum/src/main.rs
+++ b/examples/todo-axum/src/main.rs
@@ -173,8 +173,8 @@ mod todo {
         )
     )]
     pub(super) async fn create_todo(
-        Json(todo): Json<Todo>,
         Extension(store): Extension<Arc<Store>>,
+        Json(todo): Json<Todo>,
     ) -> impl IntoResponse {
         let mut todos = store.lock().await;
 

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -26,7 +26,7 @@ utoipa = { path = "../utoipa", default-features = false }
 serde_json = "1"
 serde = "1"
 actix-web = { version = "4", features = ["macros"], default-features = false }
-axum = "0.5"
+axum = "0.6.0-rc.2"
 paste = "1"
 rocket = "0.5.0-rc.1"
 smallvec = { version = "1.9.0", features = ["serde"] }

--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -21,7 +21,7 @@ rust-embed = { version = "6.3", features = ["interpolate-folder-path"] }
 mime_guess = { version = "2.0" }
 actix-web =  { version = "4", features = [ "macros" ], optional = true, default-features = false }
 rocket = { version = "0.5.0-rc.1", features = ["json"], optional = true }
-axum = { version = "0.5", optional = true }
+axum = { version = "0.6.0-rc.2", optional = true }
 utoipa = { version = "2", path = "../utoipa", default-features = false, features = [] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }

--- a/utoipa-swagger-ui/README.md
+++ b/utoipa-swagger-ui/README.md
@@ -78,7 +78,7 @@ Setup Router to serve Swagger UI with **`axum`** framework. See full implementat
 Swagger UI with axum from [examples](https://github.com/juhaku/utoipa/tree/master/examples/todo-axum).
 ```rust
 let app = Router::new()
-    .merge(SwaggerUi::new("/swagger-ui/*tail")
+    .merge(SwaggerUi::new("/swagger-ui/")
         .url("/api-doc/openapi.json", ApiDoc::openapi()));
 ```
 

--- a/utoipa-swagger-ui/src/axum.rs
+++ b/utoipa-swagger-ui/src/axum.rs
@@ -50,7 +50,7 @@ async fn serve_swagger_ui(
     Path(tail): Path<String>,
     Extension(state): Extension<Arc<Config<'static>>>,
 ) -> impl IntoResponse {
-    match super::serve(&tail[1..], state) {
+    match super::serve(&tail, state) {
         Ok(file) => file
             .map(|file| {
                 (

--- a/utoipa-swagger-ui/src/axum.rs
+++ b/utoipa-swagger-ui/src/axum.rs
@@ -9,7 +9,7 @@ use axum::{
 
 use crate::{Config, SwaggerUi, Url};
 
-impl<B> From<SwaggerUi> for Router<B>
+impl<B> From<SwaggerUi> for Router<(), B>
 where
     B: HttpBody + Send + 'static,
 {
@@ -17,7 +17,7 @@ where
         let urls_capacity = swagger_ui.urls.len();
 
         let (router, urls) = swagger_ui.urls.into_iter().fold(
-            (Router::<B>::new(), Vec::<Url>::with_capacity(urls_capacity)),
+            (Router::<(), B>::new(), Vec::<Url>::with_capacity(urls_capacity)),
             |(router, mut urls), url| {
                 let (url, openapi) = url;
                 (

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -103,7 +103,7 @@
 //!#     B: HttpBody + Send + 'static,
 //!# {
 //! let app = Router::<(), B>::new()
-//!     .merge(SwaggerUi::new("/swagger-ui/*tail")
+//!     .merge(SwaggerUi::new("/swagger-ui/")
 //!         .url("/api-doc/openapi.json", ApiDoc::openapi()));
 //!# }
 //! ```

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -102,7 +102,7 @@
 //!# where
 //!#     B: HttpBody + Send + 'static,
 //!# {
-//! let app = Router::<B>::new()
+//! let app = Router::<(), B>::new()
 //!     .merge(SwaggerUi::new("/swagger-ui/*tail")
 //!         .url("/api-doc/openapi.json", ApiDoc::openapi()));
 //!# }


### PR DESCRIPTION
Probably best not to merge this until 0.6 is a stable release, but review would be appreciated

## BREAKING

Because of this change in axum 0.6:

> breaking: The request /foo/ no longer matches /foo/*rest. If you want
to match /foo/ you have to add a route specifically for that ([#1086](https://github.com/tokio-rs/axum/pull/1086))

... that means that we have to manually specify a second route without `*tail` at the end. So I decided the most reasonable thing would be to make the user remove the `*tail` from the URL in `SwaggerUi::new()`. Then we can just register the two routes easily by appending `*tail` to the end of the second one.