### PR TITLE
Fix broken swagger-ui on axum 

### DIFF
--- a/examples/todo-axum/src/main.rs
+++ b/examples/todo-axum/src/main.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<(), Error> {
 
     let store = Arc::new(Store::default());
     let app = Router::new()
-        .merge(SwaggerUi::new("/swagger-ui/*tail").url("/api-doc/openapi.json", ApiDoc::openapi()))
+        .merge(SwaggerUi::new("/swagger-ui").url("/api-doc/openapi.json", ApiDoc::openapi()))
         .route(
             "/todo",
             routing::get(todo::list_todos).post(todo::create_todo),

--- a/utoipa-swagger-ui/README.md
+++ b/utoipa-swagger-ui/README.md
@@ -78,7 +78,7 @@ Setup Router to serve Swagger UI with **`axum`** framework. See full implementat
 Swagger UI with axum from [examples](https://github.com/juhaku/utoipa/tree/master/examples/todo-axum).
 ```rust
 let app = Router::new()
-    .merge(SwaggerUi::new("/swagger-ui/*tail")
+    .merge(SwaggerUi::new("/swagger-ui")
         .url("/api-doc/openapi.json", ApiDoc::openapi()));
 ```
 

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -104,7 +104,7 @@
 //!#     S: Clone + Send + Sync + 'static,
 //!# {
 //! let app = Router::<S, B>::new()
-//!     .merge(SwaggerUi::new("/swagger-ui/*tail")
+//!     .merge(SwaggerUi::new("/swagger-ui")
 //!         .url("/api-doc/openapi.json", ApiDoc::openapi()));
 //!# }
 //! ```


### PR DESCRIPTION
The new trailing slash handling of axum broke the swagger ui page.

This PR fixes it by introducing handlers for `<doc page>/` and `<doc page>/*tail` and introducing a redirect from `<doc page>` to `<doc page>/`

I'm unsure if this is the best way though as I don't have much experience with axum.