### PR TITLE
Chore refine description attribute

### DIFF
--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -297,12 +297,10 @@ impl ToTokens for Param<'_> {
         if let Some(deprecated) = super::get_deprecated(&field.attrs) {
             tokens.extend(quote! { .deprecated(Some(#deprecated)) });
         }
-        let attributes = CommentAttributes::from_attributes(&field.attrs);
-        if !attributes.is_empty() {
-            let comment = attributes.join("\n");
-            tokens.extend(quote! {
-                .description(Some(#comment))
-            })
+
+        let description = CommentAttributes::from_attributes(&field.attrs).as_formatted_string();
+        if !description.is_empty() {
+            tokens.extend(quote! { .description(Some(#description))})
         }
 
         let component = value_type

--- a/utoipa-gen/src/doc_comment.rs
+++ b/utoipa-gen/src/doc_comment.rs
@@ -55,6 +55,11 @@ impl CommentAttributes {
             _ => abort_call_site!("Exected only Meta::NameValue type"),
         }
     }
+
+    /// Returns found `doc comments` as formatted `String` joining them all with `\n` _(new line)_.
+    pub(crate) fn as_formatted_string(&self) -> String {
+        self.join("\n")
+    }
 }
 
 impl Deref for CommentAttributes {

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -555,15 +555,13 @@ impl ToTokens for Operation<'_> {
         }
 
         if let Some(description) = self.description {
-            let description = description
-                .iter()
-                .map(|comment| format!("{}\n", comment))
-                .collect::<Vec<String>>()
-                .join("");
+            let description = description.join("\n");
 
-            tokens.extend(quote! {
-                .description(Some(#description))
-            })
+            if !description.is_empty() {
+                tokens.extend(quote! {
+                    .description(Some(#description))
+                })
+            }
         }
 
         self.parameters

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -125,7 +125,7 @@ fn derive_path_with_all_info_success() {
     common::assert_json_array_len(operation.pointer("/parameters").unwrap(), 1);
     assert_value! {operation=>
        "deprecated" = r#"true"#, "Api fn deprecated status"
-       "description" = r#""This is test operation description\n\nAdditional info in long description\n""#, "Api fn description"
+       "description" = r#""This is test operation description\n\nAdditional info in long description""#, "Api fn description"
        "summary" = r#""This is test operation description""#, "Api fn summary"
        "operationId" = r#""foo_bar_id""#, "Api fn operation_id"
        "tags.[0]" = r#""custom_tag""#, "Api fn tag"
@@ -154,7 +154,6 @@ fn derive_path_with_defaults_success() {
 
     assert_value! {operation=>
        "deprecated" = r#"false"#, "Api fn deprecated status"
-       "description" = r#""""#, "Api fn description"
        "operationId" = r#""test_operation3""#, "Api fn operation_id"
        "tags.[0]" = r#""derive_path_with_defaults""#, "Api fn tag"
        "parameters" = r#"null"#, "Api parameters"
@@ -191,7 +190,7 @@ fn derive_path_with_extra_attributes_without_nested_module() {
     common::assert_json_array_len(operation.pointer("/parameters").unwrap(), 2);
     assert_value! {operation=>
         "deprecated" = r#"false"#, "Api operation deprecated"
-        "description" = r#""This is test operation\n\nThis is long description for test operation\n""#, "Api operation description"
+        "description" = r#""This is test operation\n\nThis is long description for test operation""#, "Api operation description"
         "operationId" = r#""get_foos_by_id_since""#, "Api operation operation_id"
         "summary" = r#""This is test operation""#, "Api operation summary"
         "tags.[0]" = r#""crate""#, "Api operation tag"

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -277,7 +277,6 @@ fn derive_response_body_inline_schema_component() {
         doc,
         json!({
             "deprecated": false,
-            "description": "",
             "operationId": "get_foo",
             "responses": {
                 "200": {


### PR DESCRIPTION
Unify the description attribute definition across `ToSchema` and `#[utoipa::path(...)]` attribute macro.