### PR TITLE
Add missing features to `IntoParams`

### DIFF
--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, mem};
+use std::borrow::Cow;
 
 use proc_macro2::{Ident, TokenStream};
 use proc_macro_error::{abort, ResultExt};
@@ -1166,8 +1166,8 @@ impl ToTokens for SchemaProperty<'_> {
                             tokens.extend(quote! { .deprecated(Some(#deprecated)) });
                         }
 
-                        if let Some(attributes) = self.features {
-                            tokens.extend(attributes.to_token_stream())
+                        if let Some(features) = self.features {
+                            tokens.extend(features.to_token_stream())
                         }
                     }
                     ValueType::Object => {
@@ -1202,30 +1202,12 @@ impl ToTokens for SchemaProperty<'_> {
 
 trait SchemaFeatureExt {
     fn split_for_title(self) -> (Vec<Feature>, Vec<Feature>);
-
-    fn extract_vec_xml_feature(&mut self, type_tree: &TypeTree) -> Option<Feature>;
 }
 
 impl SchemaFeatureExt for Vec<Feature> {
     fn split_for_title(self) -> (Vec<Feature>, Vec<Feature>) {
         self.into_iter()
             .partition(|feature| matches!(feature, Feature::Title(_)))
-    }
-
-    fn extract_vec_xml_feature(&mut self, type_tree: &TypeTree) -> Option<Feature> {
-        self.iter_mut().find_map(|feature| match feature {
-            Feature::XmlAttr(xml_feature) => {
-                let (vec_xml, value_xml) = xml_feature.split_for_vec(type_tree);
-
-                // replace the original xml attribute with splitted value xml
-                if let Some(mut xml) = value_xml {
-                    mem::swap(xml_feature, &mut xml)
-                }
-
-                vec_xml.map(Feature::XmlAttr)
-            }
-            _ => None,
-        })
     }
 }
 

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1159,6 +1159,14 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///    _`Object`_ will be rendered as generic OpenAPI object.
 /// * `inline` If set, the schema for this field's type needs to be a [`ToSchema`][to_schema], and
 ///   the schema definition will be inlined.
+/// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json]
+/// * `format = ...` May either be variant of the [`KnownFormat`][known_format] enum, or otherwise
+///   an open value as a string. By default the format is derived from the type of the property
+///   according OpenApi spec.
+/// * `write_only` Defines property is only used in **write** operations *POST,PUT,PATCH* but not in *GET*
+/// * `read_only` Defines property is only used in **read** operations *GET* but not in *POST,PUT,PATCH*
+/// * `xml(...)` Can be used to define [`Xml`][xml] object properties applicable to named fields.
+/// * `nullable` Defines property is nullable (note this is different to non-required).
 /// * `rename = ...` Can be provided to alternatively to the serde's `rename` attribute. Effectively provides same functionality.
 ///
 /// **Note!** `#[into_params(...)]` is only supported on unnamed struct types to declare names for the arguments.
@@ -1335,6 +1343,8 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// ```
 ///
 /// [to_schema]: trait.ToSchema.html
+/// [known_format]: openapi/schema/enum.KnownFormat.html
+/// [xml]: openapi/xml/struct.Xml.html
 /// [into_params]: trait.IntoParams.html
 /// [path_params]: attr.path.html#params-attributes
 /// [struct]: https://doc.rust-lang.org/std/keyword.struct.html

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -538,6 +538,77 @@ fn derive_path_params_with_examples() {
 }
 
 #[test]
+fn derive_path_query_params_with_schema_features() {
+    let operation = api_fn_doc_with_params! {get: "/foo" =>
+        #[into_params(parameter_in = Query)]
+        struct MyParams {
+            #[serde(default)]
+            #[param(write_only, read_only, default = "value", nullable, xml(name = "xml_value"))]
+            value: String,
+            #[param(value_type = String, format = Binary)]
+            int: i64,
+        }
+    };
+    let parameters = operation.get("parameters").unwrap();
+
+    assert_json_eq! {
+        parameters,
+        json!{[
+            {
+            "in": "query",
+            "name": "value",
+            "required": false,
+            "schema": {
+                "default": "value",
+                "type": "string",
+                "readOnly": true,
+                "writeOnly": true,
+                "nullable": true,
+                "xml": {
+                    "name": "xml_value"
+                }
+            }
+          },
+          {
+            "in": "query",
+            "name": "int",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "binary"
+            }
+          }
+        ]}
+    }
+}
+
+#[test]
+fn derive_path_params_always_required() {
+    let operation = api_fn_doc_with_params! {get: "/foo" =>
+        #[into_params(parameter_in = Path)]
+        struct MyParams {
+            #[serde(default)]
+            value: String,
+        }
+    };
+    let parameters = operation.get("parameters").unwrap();
+
+    assert_json_eq! {
+        parameters,
+        json!{[
+            {
+            "in": "path",
+            "name": "value",
+            "required": true,
+            "schema": {
+                "type": "string",
+            }
+          }
+        ]}
+    }
+}
+
+#[test]
 fn derive_required_path_params() {
     let operation = api_fn_doc_with_params! {get: "/list/{id}" =>
         #[into_params(parameter_in = Query)]


### PR DESCRIPTION
Add missing features to `IntoParams` that exists in `ToSchema` named fields to unify `IntoParams` and `ToSchema`. Missing features are `Inline`, `Format`, `Default`, `WriteOnly`, `ReadOnly` and `Nullable`.

Resolves #284