### PR TITLE
Add support for self referencing schema

### DIFF
--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -242,7 +242,7 @@ impl ToTokens for OpenApi {
 
         let components_builder_stream = attributes.components.to_token_stream();
 
-        let components = if !components_builder_stream.to_token_stream().is_empty() {
+        let components = if !components_builder_stream.is_empty() {
             Some(quote! { .components(Some(#components_builder_stream)) })
         } else {
             None

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -2747,3 +2747,85 @@ fn derive_struct_field_with_example() {
         })
     )
 }
+
+#[test]
+fn derive_struct_with_self_reference() {
+    let value = api_doc! {
+        struct Item {
+            id: String,
+            previous: Box<Self>,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "id": {
+                    "type": "string",
+                },
+                "previous": {
+                    "$ref": "#/components/schemas/Item",
+                },
+            },
+            "type": "object",
+            "required": ["id", "previous"]
+        })
+    )
+}
+
+#[test]
+fn derive_unnamed_struct_with_self_reference() {
+    let value = api_doc! {
+        struct Item(Box<Item>);
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "$ref": "#/components/schemas/Item"
+        })
+    )
+}
+
+#[test]
+fn derive_enum_with_self_reference() {
+    let value = api_doc! {
+        enum EnumValue {
+            Item(Box<Self>),
+            Item2 {
+                value: Box<Self>
+            }
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "properties": {
+                        "Item": {
+                            "$ref": "#/components/schemas/EnumValue"
+                        }
+                    },
+                    "type": "object",
+                },
+                {
+                    "properties": {
+                        "Item2": {
+                            "properties": {
+                                "value": {
+                                    "$ref": "#/components/schemas/EnumValue"
+                                }
+                            },
+                            "required": ["value"],
+                            "type": "object",
+                        }
+                    },
+                    "type": "object",
+                }
+            ]
+        })
+    )
+}

--- a/utoipa-swagger-ui/src/actix.rs
+++ b/utoipa-swagger-ui/src/actix.rs
@@ -47,7 +47,7 @@ fn register_api_doc_url_resource(url: &str, api: OpenApi, config: &mut actix_web
 }
 
 async fn serve_swagger_ui(path: web::Path<String>, data: web::Data<Config<'_>>) -> HttpResponse {
-    match super::serve(&*path.into_inner(), data.into_inner()) {
+    match super::serve(&path.into_inner(), data.into_inner()) {
         Ok(swagger_file) => swagger_file
             .map(|file| {
                 HttpResponse::Ok()

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -299,7 +299,7 @@ pub trait OpenApi {
 /// # }
 /// #
 /// impl utoipa::ToSchema for Pet {
-///     fn schema() -> utoipa::openapi::schema::Schema {
+///     fn schema() -> utoipa::openapi::schema::RefOr<utoipa::openapi::schema::Schema> {
 ///         use utoipa::openapi::ToArray;
 ///         utoipa::openapi::ObjectBuilder::new()
 ///             .property(
@@ -328,7 +328,7 @@ pub trait OpenApi {
 /// }
 /// ```
 pub trait ToSchema {
-    fn schema() -> openapi::schema::Schema;
+    fn schema() -> openapi::schema::RefOr<openapi::schema::Schema>;
 
     fn aliases() -> Vec<(&'static str, openapi::schema::Schema)> {
         Vec::new()


### PR DESCRIPTION
Previously field with type `Box<Self>` within a `ToSchema` struct or enum did not create correct OpenAPI schema but mistakenly created a reference to unknown type `#/components/schemas/Self`.

This commit fixes this issue and now correct type will be created when `Self` keyword is being used withing `ToSchema` structs or enums. E.g. now `struct Item(Box<Self>);` will create a reference like `#/components/schemas/Item`.

This commit also makes a breaking change to `ToSchema` trait where previously it was not possible to add a Reference directly to OpenAPI components schemas map even this is allowed by OpenAPI spec. This is commit will change the `ToSchema` return type to `RefOr<Schema>` to allow returning references directly.

Resolves #179 