### PR TITLE
feat: make schema_type field pub on Object struct

### DIFF
--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -524,7 +524,7 @@ builder! {
         /// Type of [`Object`] e.g. [`SchemaType::Object`] for `object` and [`SchemaType::String`] for
         /// `string` types.
         #[serde(rename = "type")]
-        schema_type: SchemaType,
+        pub schema_type: SchemaType,
 
         /// Changes the [`Object`] title.
         #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
I've been playing around with generating a client for the frontend for code that uses Utopia; however, I have to use a fork since the `schema_type` property isn't public.

Would you consider making this field public? I think it could be useful for others as well. 