### PR TITLE
Add support for derive validation attributes

### DIFF
--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -5,8 +5,10 @@ use syn::{
 };
 
 use crate::component::features::{
-    impl_into_inner, parse_features, Default, Example, Feature, Format, Inline, Nullable, ReadOnly,
-    Rename, RenameAll, Title, ValueType, WriteOnly, XmlAttr,
+    impl_into_inner, parse_features, Default, Example, ExclusiveMaximum, ExclusiveMinimum, Feature,
+    Format, Inline, MaxItems, MaxLength, MaxProperties, Maximum, MinItems, MinLength,
+    MinProperties, Minimum, MultipleOf, Nullable, Pattern, ReadOnly, Rename, RenameAll, Title,
+    ValueType, WriteOnly, XmlAttr,
 };
 
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -18,7 +20,9 @@ impl Parse for NamedFieldStructFeatures {
             input as Example,
             XmlAttr,
             Title,
-            RenameAll
+            RenameAll,
+            MaxProperties,
+            MinProperties
         )))
     }
 }
@@ -85,7 +89,17 @@ impl Parse for NamedFieldFeatures {
             XmlAttr,
             Inline,
             Nullable,
-            Rename
+            Rename,
+            MultipleOf,
+            Maximum,
+            Minimum,
+            ExclusiveMaximum,
+            ExclusiveMinimum,
+            MaxLength,
+            MinLength,
+            Pattern,
+            MaxItems,
+            MinItems
         )))
     }
 }

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -7,6 +7,15 @@ use syn::{parse::Parse, Error, Ident, LitStr, Path};
 pub struct SchemaType<'a>(pub &'a syn::Path);
 
 impl SchemaType<'_> {
+    fn last_segment_to_string(&self) -> String {
+        self.0
+            .segments
+            .last()
+            .expect("Expected at least one segment is_integer")
+            .ident
+            .to_string()
+    }
+
     /// Check whether type is known to be primitive in wich case returns true.
     pub fn is_primitive(&self) -> bool {
         let SchemaType(path) = self;
@@ -67,6 +76,35 @@ impl SchemaType<'_> {
 
             primitive
         }
+    }
+
+    pub fn is_integer(&self) -> bool {
+        matches!(
+            &*self.last_segment_to_string(),
+            "i8" | "i16"
+                | "i32"
+                | "i64"
+                | "i128"
+                | "isize"
+                | "u8"
+                | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "usize"
+        )
+    }
+
+    pub fn is_number(&self) -> bool {
+        match &*self.last_segment_to_string() {
+            "f32" | "f64" => true,
+            _ if self.is_integer() => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_string(&self) -> bool {
+        matches!(&*self.last_segment_to_string(), "str" | "String")
     }
 }
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -2828,3 +2828,54 @@ fn derive_enum_with_self_reference() {
         })
     )
 }
+
+#[test]
+fn derive_struct_with_validation_fields() {
+    let value = api_doc! {
+        struct Item {
+            #[schema(maximum = 10, minimum = 5, multiple_of = 2.5)]
+            id: i32,
+
+            #[schema(max_length = 10, min_length = 5, pattern = "[a-z]*")]
+            value: String,
+
+            #[schema(max_items = 5, min_items = 1)]
+            items: Vec<String>,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "id": {
+                    "format": "int32",
+                    "type": "integer",
+                    "maximum": 10.0,
+                    "minimum": 5.0,
+                    "multipleOf": 2.5,
+                },
+                "value": {
+                    "type": "string",
+                    "maxLength": 10,
+                    "minLength": 5,
+                    "pattern": "[a-z]*"
+                },
+                "items": {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                    },
+                    "maxItems": 5,
+                    "minItems": 1,
+                }
+            },
+            "type": "object",
+            "required": [
+                "id",
+                "value",
+                "items"
+            ]
+        })
+    );
+}

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -585,27 +585,27 @@ builder! {
         /// Must be a number strictly greater than `0`. Numeric value is considered valid if value
         /// diveded by the _`multiple_of`_ value results an integer.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub multiple_of: Option<usize>,
+        pub multiple_of: Option<f64>,
 
         /// Specify inclusive upper limit for the [`Object`]'s value. Number is considered valid if
         /// it is equal or less than the _`maximum`_.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub maximum: Option<usize>,
+        pub maximum: Option<f64>,
 
         /// Specify inclusive lower limit for the [`Object`]'s value. Number value is considered
         /// valid if it is equal or greater than the _`minimum`_.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub minimum: Option<usize>,
+        pub minimum: Option<f64>,
 
         /// Specify exclusive upper limit for the [`Object`]'s value. Number value is considered
         /// valid if it is strictly less than _`esclusive_maximum`_.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub exclusive_maximum: Option<usize>,
+        pub exclusive_maximum: Option<f64>,
 
         /// Specify esclusive lower limit for the [`Object`]'s value. Number value is considered
         /// valid if it is strictly above the _`exclusive_minimum`_.
         #[serde(skip_serializing_if = "Option::is_none")]
-        pub exclusive_minimum: Option<usize>,
+        pub exclusive_minimum: Option<f64>,
 
         /// Specify maximum lenght for `string` values. _`max_length`_ cannot be a negative integer
         /// value. Value is considered valid if content lenght is equal or less than the _`max_lenght`_.
@@ -764,27 +764,27 @@ impl ObjectBuilder {
     }
 
     /// Set or change _`multiple_of`_ validation flag for `number` and `integer` type values.
-    pub fn multiple_of(mut self, multiple_of: Option<usize>) -> Self {
+    pub fn multiple_of(mut self, multiple_of: Option<f64>) -> Self {
         set_value!(self multiple_of multiple_of)
     }
 
     /// Set or change inclusive maximum value for `number` and `integer` values.
-    pub fn maximum(mut self, maximum: Option<usize>) -> Self {
+    pub fn maximum(mut self, maximum: Option<f64>) -> Self {
         set_value!(self maximum maximum)
     }
 
     /// Set or change inclusive minimum value for `number` and `integer` values.
-    pub fn minimum(mut self, minimum: Option<usize>) -> Self {
+    pub fn minimum(mut self, minimum: Option<f64>) -> Self {
         set_value!(self minimum minimum)
     }
 
     /// Set or change exclusive maximum value for `number` and `integer` values.
-    pub fn exclusive_maximum(mut self, exclusive_maximum: Option<usize>) -> Self {
+    pub fn exclusive_maximum(mut self, exclusive_maximum: Option<f64>) -> Self {
         set_value!(self exclusive_maximum exclusive_maximum)
     }
 
     /// Set or change exclusive minimum value for `number` and `integer` values.
-    pub fn exclusive_minimum(mut self, exclusive_minimum: Option<usize>) -> Self {
+    pub fn exclusive_minimum(mut self, exclusive_minimum: Option<f64>) -> Self {
         set_value!(self exclusive_minimum exclusive_minimum)
     }
 


### PR DESCRIPTION
Add support for derive validation attributes to `ToSchema`.

**Newly supported derive attributes:**

* maximum
* minimum
* multiple_of
* max_length
* min_length
* pattern
* max_items
* min_items

Resolves #328 