### PR TITLE
Add support for multiple serde definitions

### DIFF
--- a/utoipa-gen/src/component/serde.rs
+++ b/utoipa-gen/src/component/serde.rs
@@ -116,22 +116,55 @@ impl SerdeContainer {
 pub fn parse_value(attributes: &[Attribute]) -> Option<SerdeValue> {
     attributes
         .iter()
-        .find(|attribute| attribute.path.is_ident("serde"))
+        .filter(|attribute| attribute.path.is_ident("serde"))
         .map(|serde_attribute| {
             serde_attribute
                 .parse_args_with(SerdeValue::parse)
                 .unwrap_or_abort()
+        })
+        .fold(Some(SerdeValue::default()), |acc, value| {
+            acc.map(|mut acc| {
+                if value.skip {
+                    acc.skip = value.skip;
+                }
+                if value.rename.is_some() {
+                    acc.rename = value.rename;
+                }
+                if value.flatten {
+                    acc.flatten = value.flatten;
+                }
+                if value.default {
+                    acc.default = value.default;
+                }
+
+                acc
+            })
         })
 }
 
 pub fn parse_container(attributes: &[Attribute]) -> Option<SerdeContainer> {
     attributes
         .iter()
-        .find(|attribute| attribute.path.is_ident("serde"))
+        .filter(|attribute| attribute.path.is_ident("serde"))
         .map(|serde_attribute| {
             serde_attribute
                 .parse_args_with(SerdeContainer::parse)
                 .unwrap_or_abort()
+        })
+        .fold(Some(SerdeContainer::default()), |acc, value| {
+            acc.map(|mut acc| {
+                if value.default {
+                    acc.default = value.default;
+                }
+                if !value.tag.is_empty() {
+                    acc.tag = value.tag;
+                }
+                if value.rename_all.is_some() {
+                    acc.rename_all = value.rename_all;
+                }
+
+                acc
+            })
         })
 }
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -2914,3 +2914,27 @@ fn derive_schema_with_slice_and_array() {
         })
     )
 }
+
+#[test]
+fn derive_schema_multiple_serde_definitions() {
+    let value = api_doc! {
+        #[derive(serde::Deserialize)]
+        struct Value {
+            #[serde(default)]
+            #[serde(rename = "ID")]
+            id: String
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "ID": {
+                    "type": "string",
+                }
+            },
+            "type": "object",
+        })
+    );
+}


### PR DESCRIPTION
This PR add support for multiple `serde` definitions over `ToSchema` and `IntoParams` types. Previously only the first `serde` attribute was taken in account when resolving serde attributes for struct fields and enum variants.

Resolves #353 