### PR TITLE
Add support for `schema_with` custon fn reference

### DIFF
--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -222,7 +222,7 @@ impl NamedStructSchema<'_> {
     fn field_as_schema_property<R>(
         &self,
         field: &Field,
-        yield_: impl FnOnce(SchemaProperty<'_>, Option<Cow<'_, str>>) -> R,
+        yield_: impl FnOnce(Property<'_>, Option<Cow<'_, str>>) -> R,
     ) -> R {
         let type_tree = &mut TypeTree::from_type(&field.ty);
 
@@ -257,15 +257,20 @@ impl NamedStructSchema<'_> {
             .as_ref()
             .map(|value_type| value_type.as_type_tree());
         let comments = CommentAttributes::from_attributes(&field.attrs);
+        let with_schema = pop_feature!(field_features => Feature::SchemaWith(_));
 
         yield_(
-            SchemaProperty::new(
-                override_type_tree.as_ref().unwrap_or(type_tree),
-                Some(&comments),
-                field_features.as_ref(),
-                deprecated.as_ref(),
-                self.struct_name.as_ref(),
-            ),
+            if let Some(with_schema) = with_schema {
+                Property::WithSchema(with_schema)
+            } else {
+                Property::Schema(SchemaProperty::new(
+                    override_type_tree.as_ref().unwrap_or(type_tree),
+                    Some(&comments),
+                    field_features.as_ref(),
+                    deprecated.as_ref(),
+                    self.struct_name.as_ref(),
+                ))
+            },
             rename_field,
         )
     }
@@ -296,7 +301,7 @@ impl ToTokens for NamedStructSchema<'_> {
                         field_name = &field_name[2..];
                     }
 
-                    self.field_as_schema_property(field, |schema_property, rename| {
+                    self.field_as_schema_property(field, |property, rename| {
                         let rename_to = field_rule
                             .as_ref()
                             .and_then(|field_rule| field_rule.rename.as_deref().map(Cow::Borrowed))
@@ -314,15 +319,20 @@ impl ToTokens for NamedStructSchema<'_> {
                             .unwrap_or(Cow::Borrowed(field_name));
 
                         object_tokens.extend(quote! {
-                            .property(#name, #schema_property)
+                            .property(#name, #property)
                         });
 
-                        if !schema_property.is_option()
-                            && !super::is_default(&container_rules.as_ref(), &field_rule.as_ref())
-                        {
-                            object_tokens.extend(quote! {
-                                .required(#name)
-                            })
+                        if let Property::Schema(schema_property) = property {
+                            if !schema_property.is_option()
+                                && !super::is_default(
+                                    &container_rules.as_ref(),
+                                    &field_rule.as_ref(),
+                                )
+                            {
+                                object_tokens.extend(quote! {
+                                    .required(#name)
+                                })
+                            }
                         }
 
                         object_tokens
@@ -1030,6 +1040,20 @@ impl ToTokens for ComplexEnum<'_> {
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(PartialEq)]
 struct TypeTuple<'a, T>(T, &'a Ident);
+
+enum Property<'a> {
+    Schema(SchemaProperty<'a>),
+    WithSchema(Feature),
+}
+
+impl ToTokens for Property<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match self {
+            Self::Schema(schema) => schema.to_tokens(tokens),
+            Self::WithSchema(with_schema) => with_schema.to_tokens(tokens),
+        }
+    }
+}
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 struct SchemaProperty<'a> {

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1041,6 +1041,7 @@ impl ToTokens for ComplexEnum<'_> {
 #[derive(PartialEq)]
 struct TypeTuple<'a, T>(T, &'a Ident);
 
+#[cfg_attr(feature = "debug", derive(Debug))]
 enum Property<'a> {
     Schema(SchemaProperty<'a>),
     WithSchema(Feature),

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -8,7 +8,7 @@ use crate::component::features::{
     impl_into_inner, parse_features, Default, Example, ExclusiveMaximum, ExclusiveMinimum, Feature,
     Format, Inline, MaxItems, MaxLength, MaxProperties, Maximum, MinItems, MinLength,
     MinProperties, Minimum, MultipleOf, Nullable, Pattern, ReadOnly, Rename, RenameAll, Title,
-    ValueType, WriteOnly, XmlAttr,
+    ValueType, SchemaWith, WriteOnly, XmlAttr,
 };
 
 #[cfg_attr(feature = "debug", derive(Debug))]
@@ -99,7 +99,8 @@ impl Parse for NamedFieldFeatures {
             MinLength,
             Pattern,
             MaxItems,
-            MinItems
+            MinItems,
+            SchemaWith
         )))
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -141,6 +141,9 @@ use ext::ArgumentResolver;
 ///   be non-negative integer.
 /// * `min_items = ...` Can be used to define minimum items allowed for `array` fields. Value must
 ///   be non-negative integer.
+/// * `with_schema = ...` Use _`schema`_ created by provided function reference insted of the
+///   default derived _`schema`_. The function must match to `fn() -> Into<RefOr<Schema>>`. It does
+///   not accept arguments and must return anything that can be convered into `RefOr<Schema>`.
 ///
 /// [^json2]: Values are converted to string if **json** feature is not enabled.
 ///
@@ -501,6 +504,26 @@ use ext::ArgumentResolver;
 ///     items: Vec<String>,
 /// }
 /// ````
+///
+/// _**Use `schema_with` to manually implement schema for a field**_
+/// ```rust
+/// # use utoipa::openapi::schema::{Object, ObjectBuilder};
+/// fn custom_type() -> Object {
+///     ObjectBuilder::new()
+///         .schema_type(utoipa::openapi::SchemaType::String)
+///         .format(Some(utoipa::openapi::SchemaFormat::Custom(
+///             "email".to_string(),
+///         )))
+///         .description(Some("this is the description"))
+///         .build()
+/// }
+///
+/// #[derive(utoipa::ToSchema)]
+/// struct Value {
+///     #[schema(schema_with = custom_type)]
+///     id: String,
+/// }
+/// ```
 ///
 /// More examples for _`value_type`_ in [`IntoParams` derive docs][into_params].
 ///
@@ -1280,6 +1303,9 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///   be non-negative integer.
 /// * `min_items = ...` Can be used to define minimum items allowed for `array` fields. Value must
 ///   be non-negative integer.
+/// * `with_schema = ...` Use _`schema`_ created by provided function reference insted of the
+///   default derived _`schema`_. The function must match to `fn() -> Into<RefOr<Schema>>`. It does
+///   not accept arguments and must return anything that can be convered into `RefOr<Schema>`.
 ///
 /// **Note!** `#[into_params(...)]` is only supported on unnamed struct types to declare names for the arguments.
 ///
@@ -1466,6 +1492,27 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///     items: Vec<String>,
 /// }
 /// ````
+///
+/// _**Use `schema_with` to manually implement schema for a field**_
+/// ```rust
+/// # use utoipa::openapi::schema::{Object, ObjectBuilder};
+/// fn custom_type() -> Object {
+///     ObjectBuilder::new()
+///         .schema_type(utoipa::openapi::SchemaType::String)
+///         .format(Some(utoipa::openapi::SchemaFormat::Custom(
+///             "email".to_string(),
+///         )))
+///         .description(Some("this is the description"))
+///         .build()
+/// }
+///
+/// #[derive(utoipa::IntoParams)]
+/// #[into_params(parameter_in = Query)]
+/// struct Query {
+///     #[param(schema_with = custom_type)]
+///     email: String,
+/// }
+/// ```
 ///
 /// [to_schema]: trait.ToSchema.html
 /// [known_format]: openapi/schema/enum.KnownFormat.html

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -141,7 +141,7 @@ use ext::ArgumentResolver;
 ///   be non-negative integer.
 /// * `min_items = ...` Can be used to define minimum items allowed for `array` fields. Value must
 ///   be non-negative integer.
-/// * `with_schema = ...` Use _`schema`_ created by provided function reference insted of the
+/// * `with_schema = ...` Use _`schema`_ created by provided function reference instead of the
 ///   default derived _`schema`_. The function must match to `fn() -> Into<RefOr<Schema>>`. It does
 ///   not accept arguments and must return anything that can be convered into `RefOr<Schema>`.
 ///
@@ -1303,7 +1303,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///   be non-negative integer.
 /// * `min_items = ...` Can be used to define minimum items allowed for `array` fields. Value must
 ///   be non-negative integer.
-/// * `with_schema = ...` Use _`schema`_ created by provided function reference insted of the
+/// * `with_schema = ...` Use _`schema`_ created by provided function reference instead of the
 ///   default derived _`schema`_. The function must match to `fn() -> Into<RefOr<Schema>>`. It does
 ///   not accept arguments and must return anything that can be convered into `RefOr<Schema>`.
 ///

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -6,6 +6,7 @@ use chrono::{Date, DateTime, Duration, Utc};
 
 use serde::Serialize;
 use serde_json::{json, Value};
+use utoipa::openapi::{Object, ObjectBuilder};
 use utoipa::{OpenApi, ToSchema};
 
 mod common;
@@ -2937,4 +2938,37 @@ fn derive_schema_multiple_serde_definitions() {
             "type": "object",
         })
     );
+}
+
+#[test]
+fn derive_schema_with_custom_field_with_schema() {
+    fn custom_type() -> Object {
+        ObjectBuilder::new()
+            .schema_type(utoipa::openapi::SchemaType::String)
+            .format(Some(utoipa::openapi::SchemaFormat::Custom(
+                "email".to_string(),
+            )))
+            .description(Some("this is the description"))
+            .build()
+    }
+    let value = api_doc! {
+        struct Value {
+            #[schema(schema_with = custom_type)]
+            id: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "id": {
+                    "description": "this is the description",
+                    "type": "string",
+                    "format": "email"
+                }
+            },
+            "type": "object"
+        })
+    )
 }


### PR DESCRIPTION
Add support for `schema_with` custom fn reference that can be used alternatively via builders to alter the compile time schema if schema attributes are not enough nor does not fit to the purpose.

Implement `schema_with` for `ToSchema` and `IntoParmas` named struct fields.

Supported syntax:
```rust
fn custom_type() -> Object {
    ObjectBuilder::new()
        .schema_type(utoipa::openapi::SchemaType::String)
        .format(Some(utoipa::openapi::SchemaFormat::Custom(
            "email".to_string(),
        )))
        .description(Some("this is email"))
        .build()
}

#[derive(ToSchema)]
struct Value {
    #[schema(with_schema = custom_type)]
    email: String,
}

#[derive(IntoParams)]
struct Query {
    #[param(with_schema = custom_type)]
    email: String,
}
```

Resolves #195 