### PR TITLE
Add support for unit structs

### DIFF
--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -2972,3 +2972,20 @@ fn derive_schema_with_custom_field_with_schema() {
         })
     )
 }
+
+#[test]
+fn derive_unit_struct_schema() {
+    let value = api_doc! {
+        struct UnitValue;
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "type": "object",
+            "nullable": true,
+            "default": null,
+            "example": null
+        })
+    )
+}


### PR DESCRIPTION
This PR will add support for unit type structs to be declared with `#[derive(ToSchema)]`. Previously only struct either with named fiels or unnamed fields and enums where supported.

According serde serialization unit type struct will be serialized as `null` but the support for utoipa `ToSchema` was lacking in this aspect.

Add suport for the definition:
```rust
#[derive(ToSchema)]
struct UnitValue;

// .... results following specification:

utoipa::openapi::schema::ObjectBuilder::new()
    .nullable(true)
    .default(Some(serde_json::Value::Null))
    .example(Some(serde_json::Value::Null))
```
Above definition will get serialized as `null`.

Resolves #332 