### PR TITLE
Fix primitive type generic aliases

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -256,8 +256,26 @@ impl<'t> TypeTree<'t> {
         }
     }
 
-    fn update_path(&mut self, ident: &'_ Ident) {
-        self.path = Some(Cow::Owned(Path::from(ident.clone())))
+    /// Update current [`TypeTree`] from given `ident`.
+    /// 
+    /// It will update everything else except `children` for the `TypeTree`. This means that the
+    /// `TypeTree` will not be changed and will be travelsed as before update.
+    fn update(&mut self, ident: Ident) {
+        let new_path = Path::from(ident);
+
+        let segments = &new_path.segments;
+        let last_segment = segments.last().expect("TypeTree::update path should have at least one segment");
+
+        let generic_type = Self::get_generic_type(last_segment);
+        let value_type = if SchemaType(&new_path).is_primitive() {
+            ValueType::Primitive
+        } else {
+            ValueType::Object
+        };
+
+        self.value_type = value_type;
+        self.generic_type = generic_type;
+        self.path = Some(Cow::Owned(new_path));
     }
 
     /// `Object` virtual type is used when generic object is required in OpenAPI spec. Typically used

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -114,11 +114,7 @@ impl ToTokens for Schema<'_> {
                         #vis type #name = #ty #alias_type_generics;
                     }
                 })
-                .fold(quote! {}, |mut tokens, alias| {
-                    tokens.extend(alias);
-
-                    tokens
-                })
+                .collect::<TokenStream>()
         });
 
         tokens.extend(quote! {
@@ -255,8 +251,15 @@ impl NamedStructSchema<'_> {
                 .enumerate()
                 .for_each(|(index, generic)| {
                     if let Some(generic_type) = type_tree.find_mut_by_ident(&generic.ident) {
-                        generic_type
-                            .update_path(&alias.generics.type_params().nth(index).unwrap().ident);
+                        generic_type.update(
+                            alias
+                                .generics
+                                .type_params()
+                                .nth(index)
+                                .unwrap()
+                                .ident
+                                .clone(),
+                        );
                     };
                 })
         }


### PR DESCRIPTION
Fix primitive type generic aliases for `ToSchema`. Prior to this PR aliases mistakenly did not update `ValueType` for alias resulting incorrect OpenAPI spec definition. This PR fixes this with allowing following syntax:
```rust
 #[derive(ToSchema)]
 #[aliases(BarString = Bar<String>, BarInt = Bar<i32>)]
 struct Bar<R> {
     bar: R,
 }
```

Fixes #351 