### PR TITLE
Add `merge` functionality for `OpenApi`

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -63,8 +63,8 @@ use ext::ArgumentResolver;
 /// `#[deprecated  = "There is better way to do this"]` the reason would not render in OpenAPI spec.
 ///
 /// # Struct Optional Configuration Options for `#[schema(...)]`
-/// * `example = ...` Can be either _`json!(...)`_ or literal string that can be parsed to json. _`json!`_
-///   should be something that _`serde_json::json!`_ can parse as a _`serde_json::Value`_. [^json]
+/// * `example = ...` Can be _`json!(...)`_. _`json!(...)`_ should be something that
+///   _`serde_json::json!`_ can parse as a _`serde_json::Value`_.
 /// * `xml(...)` Can be used to define [`Xml`][xml] object properties applicable to Structs.
 /// * `title = ...` Literal string value. Can be used to define title for struct in OpenAPI
 ///   document. Some OpenAPI code generation libraries also use this field as a name for the
@@ -72,12 +72,10 @@ use ext::ArgumentResolver;
 /// * `rename_all = ...` Supports same syntax as _serde_ _`rename_all`_ attribute. Will rename all fields
 ///   of the structs accordingly. If both _serde_ `rename_all` and _schema_ _`rename_all`_ are defined
 ///   __serde__ will take precedence.
-///  
-/// [^json]: **json** feature need to be enabled for _`json!(...)`_ type to work.
 ///
 /// # Enum Optional Configuration Options for `#[schema(...)]`
-/// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
-/// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
+/// * `example = ...` Can be method reference or _`json!(...)`_.
+/// * `default = ...` Can be method reference or _`json!(...)`_.
 /// * `title = ...` Literal string value. Can be used to define title for enum in OpenAPI
 ///   document. Some OpenAPI code generation libraries also use this field as a name for the
 ///   enum. __Note!__  ___Complex enum (enum with other than unit variants) does not support title!___
@@ -94,8 +92,8 @@ use ext::ArgumentResolver;
 /// _`rename`_ and _schema_ _`rename`_ are defined __serde__ will take prededence.
 ///
 /// # Unnamed Field Struct Optional Configuration Options for `#[schema(...)]`
-/// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
-/// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
+/// * `example = ...` Can be method reference or _`json!(...)`_.
+/// * `default = ...` Can be method reference or _`json!(...)`_.
 /// * `format = ...` May either be variant of the [`KnownFormat`][known_format] enum, or otherwise
 ///   an open value as a string. By default the format is derived from the type of the property
 ///   according OpenApi spec.
@@ -109,8 +107,8 @@ use ext::ArgumentResolver;
 ///   struct.
 ///
 /// # Named Fields Optional Configuration Options for `#[schema(...)]`
-/// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
-/// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json2]
+/// * `example = ...` Can be method reference or _`json!(...)`_.
+/// * `default = ...` Can be method reference or _`json!(...)`_.
 /// * `format = ...` May either be variant of the [`KnownFormat`][known_format] enum, or otherwise
 ///   an open value as a string. By default the format is derived from the type of the property
 ///   according OpenApi spec.
@@ -144,8 +142,6 @@ use ext::ArgumentResolver;
 /// * `with_schema = ...` Use _`schema`_ created by provided function reference instead of the
 ///   default derived _`schema`_. The function must match to `fn() -> Into<RefOr<Schema>>`. It does
 ///   not accept arguments and must return anything that can be convered into `RefOr<Schema>`.
-///
-/// [^json2]: Values are converted to string if **json** feature is not enabled.
 ///
 /// # Xml attribute Configuration Options
 ///
@@ -626,8 +622,8 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///  _`json`_ and _`xml`_ formats. **The order** of the content types define the default example show first in
 ///  the Swagger UI. Swagger UI wil use the first _`content_type`_ value as a default example.
 /// * `headers(...)` Slice of response headers that are returned back to a caller.
-/// * `example = ...` Can be either `json!(...)` or literal str that can be parsed to json. `json!`
-///   should be something that `serde_json::json!` can parse as a `serde_json::Value`. [^json]
+/// * `example = ...` Can be _`json!(...)`_. _`json!(...)`_ should be something that
+///   _`serde_json::json!`_ can parse as a _`serde_json::Value`_.
 /// * `response = ...` Type what implements [`ToResponse`][to_response_trait] trait. This can alternatively be used to
 ///    define response attributes. _`response`_ attribute cannot co-exist with other than _`status`_ attribute.
 /// * `content((...), (...))` Can be used to define multiple return types for single response status. Supported format for single
@@ -732,7 +728,7 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// * `style = ...` Defines how parameters are serialized by [`ParameterStyle`][style]. Default values are based on _`in`_ attribute.
 /// * `explode` Defines whether new _`parameter=value`_ is created for each parameter withing _`object`_ or _`array`_.
 /// * `allow_reserved` Defines whether reserved characters _`:/?#[]@!$&'()*+,;=`_ is allowed within value.
-/// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json]. Given example
+/// * `example = ...` Can method reference or _`json!(...)`_. Given example
 ///   will override any example in underlying parameter type.
 ///
 /// **For example:**
@@ -1061,8 +1057,6 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// [into_params_derive]: derive.IntoParams.html
 /// [to_response_trait]: trait.ToResponse.html
 ///
-/// [^json]: **json** feature need to be enabled for `json!(...)` type to work.
-///
 /// [^actix_extras]: **actix_extras** feature need to be enabled and **actix-web** framework must be declared in your `Cargo.toml`.
 pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
     let path_attribute = syn::parse_macro_input!(attr as PathAttr);
@@ -1292,7 +1286,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// * `style = ...` Defines how the parameter is serialized by [`ParameterStyle`][style]. Default values are based on _`parameter_in`_ attribute.
 /// * `explode` Defines whether new _`parameter=value`_ pair is created for each parameter withing _`object`_ or _`array`_.
 /// * `allow_reserved` Defines whether reserved characters _`:/?#[]@!$&'()*+,;=`_ is allowed within value.
-/// * `example = ...` Can be literal value, method reference or _`json!(...)`_. [^json] Given example
+/// * `example = ...` Can be method reference or _`json!(...)`_. Given example
 ///   will override any example in underlying parameter type.
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
 ///   This is useful in cases where the default type does not correspond to the actual type e.g. when
@@ -1301,7 +1295,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///    _`Object`_ will be rendered as generic OpenAPI object.
 /// * `inline` If set, the schema for this field's type needs to be a [`ToSchema`][to_schema], and
 ///   the schema definition will be inlined.
-/// * `default = ...` Can be literal value, method reference or _`json!(...)`_. [^json]
+/// * `default = ...` Can be method reference or _`json!(...)`_.
 /// * `format = ...` May either be variant of the [`KnownFormat`][known_format] enum, or otherwise
 ///   an open value as a string. By default the format is derived from the type of the property
 ///   according OpenApi spec.
@@ -1546,8 +1540,6 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// [serde attributes]: https://serde.rs/attributes.html
 ///
 /// [^actix]: Feature **actix_extras** need to be enabled
-///
-/// [^json]: **json** feature need to be enabled for `json!(...)` type to work.
 pub fn into_params(input: TokenStream) -> TokenStream {
     let DeriveInput {
         attrs,

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -44,4 +44,4 @@ indexmap = { version = "1", features = ["serde"] }
 assert-json-diff = "2"
 
 [package.metadata.docs.rs]
-features = ["actix_extras", "openapi_extensions"]
+features = ["actix_extras", "openapi_extensions", "yaml"]

--- a/utoipa/src/openapi/content.rs
+++ b/utoipa/src/openapi/content.rs
@@ -13,7 +13,7 @@ builder! {
 
 
     /// Content holds request body content or response content.
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[non_exhaustive]
     pub struct Content {

--- a/utoipa/src/openapi/encoding.rs
+++ b/utoipa/src/openapi/encoding.rs
@@ -11,7 +11,7 @@ builder! {
 
     /// A single encoding definition applied to a single schema [`Object
     /// property`](crate::openapi::schema::Object::properties).
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     #[non_exhaustive]

--- a/utoipa/src/openapi/external_docs.rs
+++ b/utoipa/src/openapi/external_docs.rs
@@ -10,7 +10,7 @@ builder! {
 
     /// Reference of external resource allowing extended documentation.
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct ExternalDocs {

--- a/utoipa/src/openapi/header.rs
+++ b/utoipa/src/openapi/header.rs
@@ -13,7 +13,7 @@ builder! {
     ///
     /// [header]: https://spec.openapis.org/oas/latest.html#header-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Clone)]
+    #[derive(Serialize, Deserialize, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct Header {
         /// Schema of header type.

--- a/utoipa/src/openapi/info.rs
+++ b/utoipa/src/openapi/info.rs
@@ -35,7 +35,7 @@ builder! {
     ///
     /// [info]: <https://spec.openapis.org/oas/latest.html#info-object>
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Info {
@@ -133,7 +133,7 @@ builder! {
     ///
     /// [contact]: <https://spec.openapis.org/oas/latest.html#contact-object>
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Contact {
@@ -182,7 +182,7 @@ builder! {
     ///
     /// [license]: <https://spec.openapis.org/oas/latest.html#license-object>
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct License {

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -24,7 +24,7 @@ builder! {
     ///
     /// [paths]: https://spec.openapis.org/oas/latest.html#paths-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct Paths {
         /// Map of relative paths with [`PathItem`]s holding [`Operation`]s matching
@@ -39,16 +39,34 @@ impl Paths {
         Default::default()
     }
 
-    /// Return [`Option<&PathItem>`] by given relative path if one exists
+    /// Return _`Option`_ of reference to [`PathItem`] by given relative path _`P`_ if one exists
     /// in [`Paths::paths`] map. Otherwise will return `None`.
+    /// 
+    /// # Examples
+    ///
+    /// _**Get user path item.**_
+    /// ```rust
+    /// # use utoipa::openapi::path::{Paths, PathItemType};
+    /// # let paths = Paths::new();
+    /// let path_item = paths.get_path_item("/api/v1/user");
+    /// ```
     pub fn get_path_item<P: AsRef<str>>(&self, path: P) -> Option<&PathItem> {
         self.paths.get(path.as_ref())
     }
 
-    /// Return [`Option<&Operation>`] from map of paths or `None` if not found.
+    /// Return _`Option`_ of reference to [`Operation`] from map of paths or `None` if not found.
     ///
-    /// * First will try to find [`PathItem`] by given relative path.
+    /// * First will try to find [`PathItem`] by given relative path _`P`_ e.g. `"/api/v1/user"`.
     /// * Then tries to find [`Operation`] from [`PathItem`]'s operations by given [`PathItemType`].
+    ///
+    /// # Examples
+    ///
+    /// _**Get user operation from paths.**_
+    /// ```rust
+    /// # use utoipa::openapi::path::{Paths, PathItemType};
+    /// # let paths = Paths::new();
+    /// let operation = paths.get_path_operation("/api/v1/user", PathItemType::Get);
+    /// ```
     pub fn get_path_operation<P: AsRef<str>>(
         &self,
         path: P,
@@ -83,7 +101,7 @@ builder! {
     ///
     /// [path_item]: https://spec.openapis.org/oas/latest.html#path-item-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct PathItem {
@@ -194,7 +212,7 @@ builder! {
     ///
     /// [operation]: https://spec.openapis.org/oas/latest.html#operation-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Operation {
@@ -421,7 +439,7 @@ builder! {
     ///
     /// [parameter]: https://spec.openapis.org/oas/latest.html#parameter-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Parameter {
@@ -577,7 +595,7 @@ impl Default for ParameterIn {
 }
 
 /// Defines how [`Parameter`] should be serialized.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub enum ParameterStyle {

--- a/utoipa/src/openapi/request_body.rs
+++ b/utoipa/src/openapi/request_body.rs
@@ -14,7 +14,7 @@ builder! {
     ///
     /// [request_body]: https://spec.openapis.org/oas/latest.html#request-body-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct RequestBody {

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -21,7 +21,7 @@ builder! {
     ///
     /// [responses]: https://spec.openapis.org/oas/latest.html#responses-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Responses {
@@ -100,7 +100,7 @@ builder! {
     ///
     /// [response]: https://spec.openapis.org/oas/latest.html#response-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Response {

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -40,7 +40,7 @@ builder! {
     ///
     /// [components]: https://spec.openapis.org/oas/latest.html#components-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Components {
@@ -209,7 +209,7 @@ impl ComponentsBuilder {
 ///
 /// [schemas]: https://spec.openapis.org/oas/latest.html#schema-object
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum Schema {
@@ -242,7 +242,7 @@ impl Default for Schema {
 /// [`OneOf`] composite object.
 ///
 /// [discriminator]: https://spec.openapis.org/oas/latest.html#discriminator-object
-#[derive(Serialize, Deserialize, Clone, Default)]
+#[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Discriminator {
@@ -277,7 +277,7 @@ builder! {
     /// See [`Schema::OneOf`] for more details.
     ///
     /// [oneof]: https://spec.openapis.org/oas/latest.html#components-object
-    #[derive(Serialize, Deserialize, Clone, Default)]
+    #[derive(Serialize, Deserialize, Clone, Default, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct OneOf {
         /// Components of _OneOf_ component.
@@ -397,7 +397,7 @@ builder! {
     /// See [`Schema::AllOf`] for more details.
     ///
     /// [allof]: https://spec.openapis.org/oas/latest.html#components-object
-    #[derive(Serialize, Deserialize, Clone, Default)]
+    #[derive(Serialize, Deserialize, Clone, Default, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct AllOf {
         /// Components of _AllOf_ component.
@@ -517,7 +517,7 @@ builder! {
     ///
     /// [schema]: https://spec.openapis.org/oas/latest.html#schema-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Object {
@@ -829,7 +829,7 @@ impl From<ObjectBuilder> for RefOr<Schema> {
 ///
 /// [reference]: https://spec.openapis.org/oas/latest.html#reference-object
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Default, Clone)]
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Ref {
     /// Reference location of the actual component.
@@ -871,7 +871,7 @@ impl From<Ref> for RefOr<Schema> {
 ///
 /// Typically used in combination with [`Components`] and is an union type between [`Ref`] and any
 /// other given type such as [`Schema`] or [`Response`].
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[serde(untagged)]
 pub enum RefOr<T> {
@@ -912,7 +912,7 @@ builder! {
     ///
     /// See [`Schema::Array`] for more details.
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Clone)]
+    #[derive(Serialize, Deserialize, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Array {
@@ -1039,7 +1039,7 @@ where
 }
 
 /// Represents data type of [`Schema`].
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[serde(rename_all = "lowercase")]
 pub enum SchemaType {
@@ -1072,7 +1072,7 @@ impl Default for SchemaType {
 /// supported by the UI it may default back to [`SchemaType`] alone.
 /// Format is an open value, so you can use any formats, even not those defined by the
 /// OpenAPI Specification.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[serde(rename_all = "lowercase", untagged)]
 pub enum SchemaFormat {
@@ -1080,7 +1080,7 @@ pub enum SchemaFormat {
     Custom(String),
 }
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[serde(rename_all = "lowercase")]
 pub enum KnownFormat {

--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -24,7 +24,7 @@ use super::builder;
 /// [path]: ../../attr.path.html
 /// [openapi]: ../../derive.OpenApi.html
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 pub struct SecurityRequirement {
     #[serde(flatten)]
     value: BTreeMap<String, Vec<String>>,
@@ -97,7 +97,7 @@ impl SecurityRequirement {
 ///     HttpBuilder::new().scheme(HttpAuthScheme::Bearer).bearer_format("JWT").build()
 /// );
 /// ```
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(tag = "type", rename_all = "camelCase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum SecurityScheme {
@@ -121,7 +121,7 @@ pub enum SecurityScheme {
 }
 
 /// Api key authentication [`SecurityScheme`].
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(tag = "in", rename_all = "lowercase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum ApiKey {
@@ -135,7 +135,7 @@ pub enum ApiKey {
 
 /// Value object for [`ApiKey`].
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct ApiKeyValue {
     /// Name of the [`ApiKey`] parameter.
@@ -187,7 +187,7 @@ builder! {
     ///
     /// Methods can be chained to configure _bearer_format_ or to add _description_.
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Clone, Default)]
+    #[derive(Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
     #[serde(rename_all = "camelCase")]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct Http {
@@ -296,7 +296,7 @@ impl Default for HttpAuthScheme {
 
 /// Open id connect [`SecurityScheme`]
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct OpenIdConnect {
@@ -343,7 +343,7 @@ impl OpenIdConnect {
 
 /// OAuth2 [`Flow`] configuration for [`SecurityScheme`].
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct OAuth2 {
     /// Map of supported OAuth2 flows.
@@ -442,7 +442,7 @@ impl OAuth2 {
 ///
 ///
 /// See more details at <https://spec.openapis.org/oas/latest.html#oauth-flows-object>.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(untagged)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum Flow {
@@ -471,7 +471,7 @@ impl Flow {
 
 /// Implicit [`Flow`] configuration for [`OAuth2`].
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Implicit {
@@ -554,7 +554,7 @@ impl Implicit {
 
 /// Authorization code [`Flow`] configuration for [`OAuth2`].
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct AuthorizationCode {
@@ -649,7 +649,7 @@ impl AuthorizationCode {
 
 /// Password [`Flow`] configuration for [`OAuth2`].
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Password {
@@ -731,7 +731,7 @@ impl Password {
 
 /// Client credentials [`Flow`] configuration for [`OAuth2`].
 #[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct ClientCredentials {
@@ -842,7 +842,7 @@ impl ClientCredentials {
 ///     ("read:items", "read my items")
 /// ]);
 /// ```
-#[derive(Default, Serialize, Deserialize, Clone)]
+#[derive(Default, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Scopes {
     scopes: BTreeMap<String, String>,

--- a/utoipa/src/openapi/server.rs
+++ b/utoipa/src/openapi/server.rs
@@ -58,7 +58,7 @@ builder! {
     ///
     /// [openapi]: ../struct.OpenApi.html
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Server {
@@ -153,7 +153,7 @@ builder! {
     ///
     /// [server_variable]: https://spec.openapis.org/oas/latest.html#server-variable-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct ServerVariable {
         /// Default value used to substitute parameter if no other value is being provided.

--- a/utoipa/src/openapi/tag.rs
+++ b/utoipa/src/openapi/tag.rs
@@ -14,7 +14,7 @@ builder! {
     ///
     /// [tag]: https://spec.openapis.org/oas/latest.html#tag-object
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Tag {

--- a/utoipa/src/openapi/xml.rs
+++ b/utoipa/src/openapi/xml.rs
@@ -28,7 +28,7 @@ builder! {
     /// [schema_object]: https://spec.openapis.org/oas/latest.html#schema-object
     /// [schema]: ../schema/index.html
     #[non_exhaustive]
-    #[derive(Serialize, Deserialize, Default, Clone)]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct Xml {
         /// Used to replace the name of attribute or type used in schema property.


### PR DESCRIPTION
Add `merge` function to `OpenApi`. This will perform shallow comparison for paths, schemas, responses and security schemes. This means that only name for components and path for paths is used for comparison. Tags, security requirements and servers will be compared against the whole object. Only not matching elements will be merged from `OpenApi` argument to the self.

This is useful for larger APIs allowing users to easily split the OpenAPI definition to multiple smaller OpenAPI specs and then only merging them in root level to a single OpenAPI specification. This is good for encapsulation and enables users not to make all module internals public to the root module.

Also improve generally the documentation and implement `PartialEq` and `Eq` for openapi types for easier comparison.

Resolves #396 