### PR TITLE
Add derive info support for derive OpenApi

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1145,7 +1145,13 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   Tag can be used to define extra information for the api to produce richer documentation.
 /// * `external_docs(...)` Can be used to reference external resource to the OpenAPI doc for extended documentation.
 ///   External docs can be in [`OpenApi`][openapi_struct] or in [`Tag`][tags] level.
-/// * `servers(...)` Define [`servers`][servers] as derive argumenst to the _`OpenApi`_.
+/// * `servers(...)` Define [`servers`][servers] as derive argumenst to the _`OpenApi`_. Servers
+///   are completely optional and thus can be omitted from the declaration.
+/// * `info(...)` Declare [`Info`][info] attribute values used to override the default values
+///   generated from Cargo environment variables. **Note!** Defined attributes will override the
+///   whole attribute from generated values of Cargo environment variables. E.g. defining
+///   `contact(name = ...)` will ultimately override whole contact of info and not just partially
+///   the name.
 ///
 /// OpenApi derive macro will also derive [`Info`][info] for OpenApi specification using Cargo
 /// environment variables.
@@ -1155,6 +1161,37 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// * env `CARGO_PKG_DESCRIPTION` map info `description`
 /// * env `CARGO_PKG_AUTHORS` map to contact `name` and `email` **only first author will be used**
 /// * env `CARGO_PKG_LICENSE` map to info `license`
+///
+/// # `info(...)` attribute syntax
+/// * `title = ...` Define title of the API. It can be literal string.
+/// * `description = ...` Define description of the API. Markdown can be used for rich text
+///   representation. It can be literal string or [`include_str!`] statement.
+/// * `contanct(...)` Used to override the whole contanct generated from environment variables.
+///     * `name = ...` Define identifying name of contact person / organization. It Can be a literal string.
+///     * `email = ...` Define email address of the contact person / organization. It can be a literal string.
+///     * `url = ...` Define URL pointing to the contact information. It must be in URL formatted string.
+/// * `license(...)` Used to override the whole license generated from environment variables.
+///     * `name = ...` License name of the API. It can be a literal string.
+///     * `url = ...` Define optional URL of the license. It must be URL formatted string.
+///
+/// # `servers(...)` attribute syntax
+/// * `url = ...` Define the url for server. It can be literal string.
+/// * `description = ...` Define description for the server. It can be literal string.
+/// * `variables(...)` Can be used to define variables for the url.
+///     * `name = ...` Is the first argument withing parentheses. It should be ident, an unquoted
+///       string
+///     * `default = ...` Defines a default value for the variable if nothing else will be
+///       provided. If _`enum_values`_ is defined the _`default`_ must be found within the enum
+///       options. It can be a literal string.
+///     * `description = ...` Define the description for the variable. It can be a literal string.
+///     * `enum_values(...)` Define list of possible values for the variable. Values must be
+///       literal strings.
+///
+///  _**Example server variable definition.**_
+///  ```text
+/// (username = (default = "demo", description = "Default username for API")),
+/// (port = (enum_values("8080", "5000", "4545")))
+/// ```
 ///
 /// # Examples
 ///
@@ -1221,6 +1258,19 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// )]
 /// struct ApiDoc;
 ///```
+///
+/// _**Define info attribute values used to override auto generated ones from Cargo environment
+/// variables.**_
+/// ```compile_fail
+/// # use utoipa::OpenApi;
+/// #[derive(OpenApi)]
+/// #[openapi(info(
+///     title = "title override",
+///     description = include_str!("./path/to/content"), // fail compile cause no such file
+///     contact(name = "Test")
+/// ))]
+/// struct ApiDoc;
+/// ```
 ///
 /// [openapi]: trait.OpenApi.html
 /// [openapi_struct]: openapi/struct.OpenApi.html

--- a/utoipa-gen/src/openapi/info.rs
+++ b/utoipa-gen/src/openapi/info.rs
@@ -1,24 +1,334 @@
-use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
+use std::borrow::Cow;
+use std::io;
 
-pub(crate) fn impl_info() -> TokenStream2 {
-    let name = std::env::var("CARGO_PKG_NAME").unwrap_or_default();
-    let version = std::env::var("CARGO_PKG_VERSION").unwrap_or_default();
-    let description = std::env::var("CARGO_PKG_DESCRIPTION").unwrap_or_default();
-    let authors = std::env::var("CARGO_PKG_AUTHORS").unwrap_or_default();
-    let license = std::env::var("CARGO_PKG_LICENSE").unwrap_or_default();
+use proc_macro2::{Group, Ident, TokenStream as TokenStream2};
+use quote::{quote, ToTokens};
+use syn::parse::Parse;
+use syn::token::Comma;
+use syn::{parenthesized, Error, LitStr, Token};
 
-    let contact = get_contact(&authors);
+use crate::parse_utils;
 
-    quote! {
-        utoipa::openapi::InfoBuilder::new()
-            .title(#name)
-            .version(#version)
-            .description(Some(#description))
-            .license(Some(utoipa::openapi::License::new(#license)))
-            .contact(Some(#contact))
-            .build()
+#[derive(Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub(super) enum Str {
+    String(String),
+    IncludeStr(TokenStream2),
+}
+
+impl Parse for Str {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        if input.peek(LitStr) {
+            Ok(Self::String(input.parse::<LitStr>()?.value()))
+        } else {
+            let include_str = input.parse::<Ident>()?;
+            let bang = input.parse::<Option<Token![!]>>()?;
+            if include_str != "include_str" || bang.is_none() {
+                return Err(Error::new(
+                    include_str.span(),
+                    "unexpected token, expected either literal string or include_str!(...)",
+                ));
+            }
+            Ok(Self::IncludeStr(input.parse::<Group>()?.stream()))
+        }
     }
+}
+
+impl ToTokens for Str {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        match self {
+            Self::String(str) => str.to_tokens(tokens),
+            Self::IncludeStr(include_str) => tokens.extend(quote! { include_str!(#include_str) }),
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub(super) struct Info<'i> {
+    title: Option<String>,
+    version: Option<String>,
+    description: Option<Str>,
+    license: Option<License<'i>>,
+    contact: Option<Contact<'i>>,
+}
+
+impl Info<'_> {
+    /// Construct new [`Info`] from _`cargo`_ env variables such as
+    /// * `CARGO_PGK_NAME`
+    /// * `CARGO_PGK_VERSION`
+    /// * `CARGO_PGK_DESCRIPTION`
+    /// * `CARGO_PGK_AUTHORS`
+    /// * `CARGO_PGK_LICENSE`
+    fn from_env() -> Self {
+        let name = std::env::var("CARGO_PKG_NAME").ok();
+        let version = std::env::var("CARGO_PKG_VERSION").ok();
+        let description = std::env::var("CARGO_PKG_DESCRIPTION").ok().map(Str::String);
+        let contact = std::env::var("CARGO_PKG_AUTHORS")
+            .ok()
+            .and_then(|authors| Contact::try_from(authors).ok());
+        let license = std::env::var("CARGO_PKG_LICENSE").ok().map(License::from);
+
+        Info {
+            title: name,
+            version,
+            description,
+            contact,
+            license,
+        }
+    }
+}
+
+impl Parse for Info<'_> {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut info = Info::default();
+
+        while !input.is_empty() {
+            let ident = input.parse::<Ident>()?;
+            let attribute_name = &*ident.to_string();
+
+            match attribute_name {
+                "title" => {
+                    info.title =
+                        Some(parse_utils::parse_next(input, || input.parse::<LitStr>())?.value())
+                }
+                "version" => {
+                    info.version =
+                        Some(parse_utils::parse_next(input, || input.parse::<LitStr>())?.value())
+                }
+                "description" => {
+                    info.description =
+                        Some(parse_utils::parse_next(input, || input.parse::<Str>())?)
+                }
+                "licence" => {
+                    let licence_stream;
+                    parenthesized!(licence_stream in input);
+                    info.license = Some(licence_stream.parse()?)
+                }
+                "contact" => {
+                    let contact_stream;
+                    parenthesized!(contact_stream in input);
+                    info.contact = Some(contact_stream.parse()?)
+                }
+                _ => {
+                    return Err(Error::new(ident.span(), &format!("unexpected attribute: {attribute_name}, expected one of: title, version, description, licence, contact")));
+                }
+            }
+            if !input.is_empty() {
+                input.parse::<Comma>()?;
+            }
+        }
+
+        Ok(info)
+    }
+}
+
+impl ToTokens for Info<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let title = self.title.as_ref().map(|title| quote! { .title(#title) });
+        let version = self
+            .version
+            .as_ref()
+            .map(|version| quote! { .version(#version) });
+        let description = self
+            .description
+            .as_ref()
+            .map(|description| quote! { .description(Some(#description)) });
+        let license = self
+            .license
+            .as_ref()
+            .map(|license| quote! { .license(Some(#license)) });
+        let contact = self
+            .contact
+            .as_ref()
+            .map(|contact| quote! { .contact(Some(#contact)) });
+
+        tokens.extend(quote! {
+            utoipa::openapi::InfoBuilder::new()
+                #title
+                #version
+                #description
+                #license
+                #contact
+        })
+    }
+}
+
+#[derive(Default, Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub(super) struct License<'l> {
+    name: Cow<'l, str>,
+    url: Option<Cow<'l, str>>,
+}
+
+impl Parse for License<'_> {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut license = License::default();
+
+        while !input.is_empty() {
+            let ident = input.parse::<Ident>()?;
+            let attribute_name = &*ident.to_string();
+
+            match attribute_name {
+                "name" => {
+                    license.name = Cow::Owned(
+                        parse_utils::parse_next(input, || input.parse::<LitStr>())?.value(),
+                    )
+                }
+                "url" => {
+                    license.url = Some(Cow::Owned(
+                        parse_utils::parse_next(input, || input.parse::<LitStr>())?.value(),
+                    ))
+                }
+                _ => {
+                    return Err(Error::new(
+                        ident.span(),
+                        &format!(
+                            "unexpected attribute: {attribute_name}, expected one of: name, url"
+                        ),
+                    ));
+                }
+            }
+            if !input.is_empty() {
+                input.parse::<Comma>()?;
+            }
+        }
+
+        Ok(license)
+    }
+}
+
+impl ToTokens for License<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let name = &self.name;
+        let url = self.url.as_ref().map(|url| quote! { .url(Some(#url))});
+
+        tokens.extend(quote! {
+            utoipa::openapi::info::LicenseBuilder::new()
+                .name(#name)
+                #url
+                .build()
+        })
+    }
+}
+
+impl From<String> for License<'_> {
+    fn from(string: String) -> Self {
+        License {
+            name: Cow::Owned(string),
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Default, Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub(super) struct Contact<'c> {
+    name: Option<Cow<'c, str>>,
+    email: Option<Cow<'c, str>>,
+    url: Option<Cow<'c, str>>,
+}
+
+impl Parse for Contact<'_> {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut contact = Contact::default();
+
+        while !input.is_empty() {
+            let ident = input.parse::<Ident>()?;
+            let attribute_name = &*ident.to_string();
+
+            match attribute_name {
+                "name" => {
+                    contact.name = Some(Cow::Owned(
+                        parse_utils::parse_next(input, || input.parse::<LitStr>())?.value(),
+                    ))
+                }
+                "email" => {
+                    contact.email = Some(Cow::Owned(
+                        parse_utils::parse_next(input, || input.parse::<LitStr>())?.value(),
+                    ))
+                }
+                "url" => {
+                    contact.url = Some(Cow::Owned(
+                        parse_utils::parse_next(input, || input.parse::<LitStr>())?.value(),
+                    ))
+                }
+                _ => {
+                    return Err(Error::new(
+                        ident.span(),
+                        &format!("unexpected attribute: {attribute_name}, expected one of: name, email, url"),
+                    ));
+                }
+            }
+            if !input.is_empty() {
+                input.parse::<Comma>()?;
+            }
+        }
+
+        Ok(contact)
+    }
+}
+
+impl ToTokens for Contact<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        let name = self.name.as_ref().map(|name| quote! { .name(Some(#name)) });
+        let email = self
+            .email
+            .as_ref()
+            .map(|email| quote! { .email(Some(#email)) });
+        let url = self.url.as_ref().map(|url| quote! { .url(Some(#url)) });
+
+        tokens.extend(quote! {
+            utoipa::openapi::info::ContactBuilder::new()
+                #name
+                #email
+                #url
+                .build()
+        })
+    }
+}
+
+impl TryFrom<String> for Contact<'_> {
+    type Error = io::Error;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        if let Some((name, email)) = get_parsed_author(value.split(':').into_iter().next()) {
+            Ok(Contact {
+                name: Some(Cow::Owned(name.to_string())),
+                email: Some(Cow::Owned(email.to_string())),
+                ..Default::default()
+            })
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                format!("invalid contact: {value}"),
+            ))
+        }
+    }
+}
+
+pub(super) fn impl_info(parsed: Option<Info>) -> Info {
+    let mut info = Info::from_env();
+
+    if let Some(parsed) = parsed {
+        if parsed.title.is_some() {
+            info.title = parsed.title;
+        }
+
+        if parsed.description.is_some() {
+            info.description = parsed.description;
+        }
+
+        if parsed.license.is_some() {
+            info.license = parsed.license;
+        }
+
+        if parsed.contact.is_some() {
+            info.contact = parsed.contact;
+        }
+    }
+
+    info
 }
 
 fn get_parsed_author(author: Option<&str>) -> Option<(&str, &str)> {
@@ -33,26 +343,6 @@ fn get_parsed_author(author: Option<&str>) -> Option<(&str, &str)> {
 
         (name.trim_end(), email)
     })
-}
-
-fn get_contact(authors: &str) -> TokenStream2 {
-    if let Some((name, email)) = get_parsed_author(authors.split(':').into_iter().next()) {
-        let email_tokens = if email.is_empty() {
-            None
-        } else {
-            Some(quote! { .email(Some(#email)) })
-        };
-        quote! {
-            utoipa::openapi::ContactBuilder::new()
-                .name(Some(#name))
-                #email_tokens
-                .build()
-        }
-    } else {
-        quote! {
-            utoipa::openapi::Contact::default()
-        }
-    }
 }
 
 #[cfg(test)]

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -187,3 +187,65 @@ fn derive_openapi_with_servers() {
         ])
     )
 }
+
+#[test]
+fn derive_openapi_with_custom_info() {
+    #[derive(OpenApi)]
+    #[openapi(info(
+        title = "title override",
+        description = "description override",
+        contact(name = "Test")
+    ))]
+    struct ApiDoc;
+
+    let value = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let info = value.pointer("/info");
+
+    assert_json_eq!(
+        info,
+        json!(
+        {
+            "title": "title override",
+            "description": "description override",
+            "license": {
+                "name": "MIT OR Apache-2.0",
+            },
+            "version": "2.4.2",
+            "contact": {
+                "name": "Test"
+            }
+        }
+        )
+    )
+}
+
+#[test]
+fn derive_openapi_with_include_str_description() {
+    #[derive(OpenApi)]
+    #[openapi(info(
+        title = "title override",
+        description = include_str!("./testdata/openapi-derive-info-description"),
+        contact(name = "Test")
+    ))]
+    struct ApiDoc;
+
+    let value = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let info = value.pointer("/info");
+
+    assert_json_eq!(
+        info,
+        json!(
+        {
+            "title": "title override",
+            "description": "this is include description\n",
+            "license": {
+                "name": "MIT OR Apache-2.0",
+            },
+            "version": "2.4.2",
+            "contact": {
+                "name": "Test"
+            }
+        }
+        )
+    )
+}

--- a/utoipa-gen/tests/testdata/openapi-derive-info-description
+++ b/utoipa-gen/tests/testdata/openapi-derive-info-description
@@ -1,0 +1,1 @@
+this is include description

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -219,8 +219,8 @@ impl OpenApi {
 
 impl OpenApiBuilder {
     /// Add [`Info`] metadata of the API.
-    pub fn info(mut self, info: Info) -> Self {
-        set_value!(self info info)
+    pub fn info<I: Into<Info>>(mut self, info: I) -> Self {
+        set_value!(self info info.into())
     }
 
     /// Add iterator of [`Server`]s to configure target servers.

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -41,7 +41,7 @@ impl Paths {
 
     /// Return _`Option`_ of reference to [`PathItem`] by given relative path _`P`_ if one exists
     /// in [`Paths::paths`] map. Otherwise will return `None`.
-    /// 
+    ///
     /// # Examples
     ///
     /// _**Get user path item.**_


### PR DESCRIPTION
Add derive info support for #[derive(OpenApi)] macro. Prior to this PR info was solely auto generated on compile time from cargo env variables what describes the package details such as CARGO_PKG_NAME or by implementing it manually via OpenApi types or `Modify` trait. This PR will add another alternative to that by allowing users to define info attributes on `#[openapi(...info(...)... )]` macro attribute.

These `info` attributes will override the content of what is generated automatically from the env variables allowing further customization only to information that needs it.

Supported info attribute syntax:
```rust
 #[derive(OpenApi)]
 #[openapi(info(
     title = "title override",
     description = "description override",
     contact(name = "Test")
 ))]
 struct ApiDoc;

 #[derive(OpenApi)]
 #[openapi(info(
     title = "title override",
     description = include_str!("./testdata/openapi-derive-info-description"),
     contact(name = "Test")
 ))]
 struct ApiDoc;
```
If contanct generated from the env variables contains `email` and `name` and it is replaced with into `contact(name = ...)` the whole contact will be replaced with the one from derive attributes, not just the `name`. `description` field supports alternatively to string value `inlcude_str!(...)` statement.