### PR TITLE
Add Example type to OpenApi types

### DIFF
--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -119,7 +119,7 @@ impl ToTokens for Schema<'_> {
 
         tokens.extend(quote! {
             impl #impl_generics utoipa::ToSchema for #ident #ty_generics #where_clause {
-                fn schema() -> utoipa::openapi::schema::RefOr<utoipa::openapi::schema::Schema> {
+                fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
                     #variant.into()
                 }
 

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -4,7 +4,7 @@ use assert_json_diff::assert_json_eq;
 use paste::paste;
 use serde_json::{json, Value};
 use std::collections::HashMap;
-use utoipa::openapi::schema::RefOr;
+use utoipa::openapi::RefOr;
 use utoipa::openapi::{Object, ObjectBuilder};
 use utoipa::{
     openapi::{Response, ResponseBuilder, ResponsesBuilder},

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -215,7 +215,6 @@ pub mod openapi;
 
 use std::collections::BTreeMap;
 
-use crate::openapi::schema::RefOr;
 use openapi::Response;
 pub use utoipa_gen::*;
 
@@ -297,7 +296,7 @@ pub trait OpenApi {
 /// # }
 /// #
 /// impl utoipa::ToSchema for Pet {
-///     fn schema() -> utoipa::openapi::schema::RefOr<utoipa::openapi::schema::Schema> {
+///     fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
 ///         use utoipa::openapi::ToArray;
 ///         utoipa::openapi::ObjectBuilder::new()
 ///             .property(
@@ -326,7 +325,7 @@ pub trait OpenApi {
 /// }
 /// ```
 pub trait ToSchema {
-    fn schema() -> openapi::schema::RefOr<openapi::schema::Schema>;
+    fn schema() -> openapi::RefOr<openapi::schema::Schema>;
 
     fn aliases() -> Vec<(&'static str, openapi::schema::Schema)> {
         Vec::new()
@@ -564,7 +563,7 @@ pub trait IntoParams {
 /// ```
 /// use std::collections::BTreeMap;
 /// use utoipa::{
-///     openapi::{Response, ResponseBuilder, ResponsesBuilder, schema::RefOr},
+///     openapi::{Response, ResponseBuilder, ResponsesBuilder, RefOr},
 ///     IntoResponses,
 /// };
 ///
@@ -585,7 +584,7 @@ pub trait IntoParams {
 /// ```
 pub trait IntoResponses {
     /// Returns an ordered map of response codes to responses.
-    fn responses() -> BTreeMap<String, RefOr<Response>>;
+    fn responses() -> BTreeMap<String, openapi::RefOr<Response>>;
 }
 
 /// This trait is implemented to document a type which represents a single response which can be

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -20,6 +20,7 @@ pub use self::{
 };
 
 pub mod content;
+pub mod example;
 pub mod encoding;
 pub mod external_docs;
 pub mod header;
@@ -376,6 +377,18 @@ impl Default for Required {
     fn default() -> Self {
         Required::False
     }
+}
+
+/// A [`Ref`] or some other type `T`.
+///
+/// Typically used in combination with [`Components`] and is an union type between [`Ref`] and any
+/// other given type such as [`Schema`] or [`Response`].
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[serde(untagged)]
+pub enum RefOr<T> {
+    Ref(Ref),
+    T(T),
 }
 
 macro_rules! build_fn {

--- a/utoipa/src/openapi/content.rs
+++ b/utoipa/src/openapi/content.rs
@@ -6,7 +6,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::builder;
-use super::{encoding::Encoding, schema::RefOr, set_value, Schema};
+use super::example::Example;
+use super::{encoding::Encoding, set_value, RefOr, Schema};
 
 builder! {
     ContentBuilder;
@@ -24,6 +25,12 @@ builder! {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub example: Option<Value>,
 
+        /// Examples of the request body or response body. [`Content::examples`] should match to
+        /// media type and specified schema if present. [`Content::examples`] and
+        /// [`Content::example`] are mutually exclusive. If both are defined `examples` will
+        /// override value in `example`.
+        #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+        pub examples: BTreeMap<String, Example>,
 
         /// A map between a property name and its encoding information.
         ///
@@ -56,6 +63,26 @@ impl ContentBuilder {
     /// Add example of schema.
     pub fn example(mut self, example: Option<Value>) -> Self {
         set_value!(self example example)
+    }
+
+    /// Add iterator of _`(N, V)`_ where `N` is name of example and `V` is [`Example`][example] to
+    /// [`Content`] of a request body or response body.
+    ///
+    /// [`Content::examples`] and [`Content::example`] are mutually exclusive. If both are defined
+    /// `examples` will override value in `example`.
+    ///
+    /// [example]: ../example/Example.html
+    pub fn examples_from_iter<E: IntoIterator<Item = (N, V)>, N: Into<String>, V: Into<Example>>(
+        mut self,
+        examples: E,
+    ) -> Self {
+        self.examples.extend(
+            examples
+                .into_iter()
+                .map(|(name, example)| (name.into(), example.into())),
+        );
+
+        self
     }
 
     /// Add an encoding.

--- a/utoipa/src/openapi/example.rs
+++ b/utoipa/src/openapi/example.rs
@@ -1,0 +1,95 @@
+//! Implements [OpenAPI Example Object][example] can be used to define examples for [`Response`][response]s and
+//! [`RequestBody`][request_body]s.
+//!
+//! [example]: https://spec.openapis.org/oas/latest.html#example-object
+//! [response]: response/struct.Response.html
+//! [request_body]: request_body/struct.RequestBody.html
+use serde::{Deserialize, Serialize};
+
+use super::{builder, set_value};
+
+builder! {
+    /// # Examples
+    ///
+    /// _**Construct a new [`Example`] via builder**_
+    /// ```rust
+    /// # use utoipa::openapi::example::ExampleBuilder;
+    /// let example = ExampleBuilder::new()
+    ///     .summary("Example string response")
+    ///     .value(Some(serde_json::json!("Example value")))
+    ///     .build();
+    /// ```
+    ExampleBuilder;
+
+    /// Implements [OpenAPI Example Object][example].
+    ///
+    /// Example is used on path operations to describe possible response bodies.
+    ///
+    /// [example]: https://spec.openapis.org/oas/latest.html#example-object
+    #[non_exhaustive]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    #[serde(rename_all = "camelCase")]
+    pub struct Example {
+        /// Short description for the [`Example`].
+        #[serde(skip_serializing_if = "String::is_empty")]
+        pub summary: String,
+
+        /// Long description for the [`Example`]. Value supports markdown syntax for rich text
+        /// representation.
+        #[serde(skip_serializing_if = "String::is_empty")]
+        pub description: String,
+
+        /// Embedded literal example value. [`Example::value`] and [`Example::external_value`] are
+        /// mutually exclusive.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub value: Option<serde_json::Value>,
+
+        /// An URI that points to a literal example value. [`Example::external_value`] provides the
+        /// capability to references an example that cannot be easily included in JSON or YAML.
+        /// [`Example::value`] and [`Example::external_value`] are mutually exclusive.
+        #[serde(skip_serializing_if = "String::is_empty")]
+        pub external_value: String,
+    }
+}
+
+impl Example {
+    /// Construct a new empty [`Example`]. This is effectively same as calling
+    /// [`Example::default`].
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl ExampleBuilder {
+    /// Add or change a short description for the [`Example`]. Setting this to empty `String`
+    /// will make it not render in the generated OpenAPI document.
+    pub fn summary<S: Into<String>>(mut self, summary: S) -> Self {
+        set_value!(self summary summary.into())
+    }
+
+    /// Add or change a long description for the [`Example`]. Markdown syntax is supported for rich
+    /// text representation.
+    ///
+    /// Setting this to empty `String` will make it not render in the generated
+    /// OpenAPI document.
+    pub fn description<D: Into<String>>(mut self, description: D) -> Self {
+        set_value!(self description description.into())
+    }
+
+    /// Add or change embedded literal example value. [`Example::value`] and [`Example::external_value`]
+    /// are mutually exclusive.
+    pub fn value(mut self, value: Option<serde_json::Value>) -> Self {
+        set_value!(self value value)
+    }
+
+    /// Add or change an URI that points to a literal example value. [`Example::external_value`]
+    /// provides the capability to references an example that cannot be easily included
+    /// in JSON or YAML. [`Example::value`] and [`Example::external_value`] are mutually exclusive.
+    ///
+    /// Setting this to an empty String will make the field not to render in the generated OpenAPI
+    /// document.
+    pub fn external_value<E: Into<String>>(mut self, external_value: E) -> Self {
+        set_value!(self external_value external_value.into())
+    }
+}

--- a/utoipa/src/openapi/header.rs
+++ b/utoipa/src/openapi/header.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{builder, schema::RefOr, set_value, Object, Schema, SchemaType};
+use super::{builder, RefOr, set_value, Object, Schema, SchemaType};
 
 builder! {
     HeaderBuilder;

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -10,7 +10,7 @@ use super::{
     builder,
     request_body::RequestBody,
     response::{Response, Responses},
-    schema::RefOr,
+    RefOr,
     set_value, Deprecated, ExternalDocs, Required, Schema, SecurityRequirement, Server,
 };
 

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -6,8 +6,7 @@ use std::collections::BTreeMap;
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 
-use crate::openapi::schema::RefOr;
-use crate::openapi::Ref;
+use crate::openapi::{Ref, RefOr};
 use crate::IntoResponses;
 
 use super::{builder, header::Header, set_value, Content};

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::RefOr;
 use super::{builder, security::SecurityScheme, set_value, xml::Xml, Deprecated, Response};
 use crate::ToResponse;
 
@@ -865,18 +866,6 @@ impl From<Ref> for RefOr<Schema> {
     fn from(r: Ref) -> Self {
         Self::Ref(r)
     }
-}
-
-/// A [`Ref`] or some other type `T`.
-///
-/// Typically used in combination with [`Components`] and is an union type between [`Ref`] and any
-/// other given type such as [`Schema`] or [`Response`].
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "debug", derive(Debug))]
-#[serde(untagged)]
-pub enum RefOr<T> {
-    Ref(Ref),
-    T(T),
 }
 
 impl<T> From<T> for RefOr<T> {


### PR DESCRIPTION
Add Example type to OpenApi types. This will be used to define multiple example values for response body or request body.

Move `RefOf` type to openapi module. Since it it is common to multiple OpenApi types not just belonging only to schema.

#317