### PR TITLE
Add auto detect application/octet-stream type

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -600,7 +600,8 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// * `content_type = "..."` Can be used to override the default behavior of auto resolving the content type
 ///   from the `content` attribute. If defined the value should be valid content type such as
 ///   _`application/json`_. By default the content type is _`text/plain`_ for
-///   [primitive Rust types][primitive] and _`application/json`_ for struct and complex enum types.
+///   [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and
+///   _`application/json`_ for struct and complex enum types.
 ///
 /// **Request body supports following formats:**
 ///
@@ -629,7 +630,8 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// * `content_type = "..." | content_type = [...]` Can be used to override the default behavior of auto resolving the content type
 ///   from the `body` attribute. If defined the value should be valid content type such as
 ///   _`application/json`_. By default the content type is _`text/plain`_ for
-///   [primitive Rust types][primitive] and _`application/json`_ for struct and complex enum types.
+///   [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and
+///   _`application/json`_ for struct and complex enum types.
 ///   Content type can also be slice of **content_type** values if the endpoint support returning multiple
 ///  response content types. E.g _`["application/json", "text/xml"]`_ would indicate that endpoint can return both
 ///  _`json`_ and _`xml`_ formats. **The order** of the content types define the default example show first in

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -571,14 +571,16 @@ impl ToTokens for Operation<'_> {
     }
 }
 
-trait ContentTypeResolver {
-    fn resolve_content_type<'a>(
-        &self,
-        content_type: Option<&'a String>,
-        schema_type: &SchemaType<'a>,
-    ) -> &'a str {
-        if let Some(content_type) = content_type {
-            content_type
+trait TypeExt {
+    /// Resolve default content type based on curren [`Type`].
+    fn get_default_content_type(&self) -> &str;
+}
+
+impl TypeExt for crate::Type<'_> {
+    fn get_default_content_type(&self) -> &'static str {
+        let schema_type = SchemaType(&self.ty);
+        if self.is_array && schema_type.is_byte() {
+            "application/octet-stream"
         } else if schema_type.is_primitive() {
             "text/plain"
         } else {

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -11,9 +11,9 @@ use syn::{
     Error, ExprPath, LitInt, LitStr, Token,
 };
 
-use crate::{parse_utils, schema_type::SchemaType, AnyValue, Array, Type};
+use crate::{parse_utils, AnyValue, Array, Type};
 
-use super::{property::Property, status::STATUS_CODES, ContentTypeResolver};
+use super::{property::Property, status::STATUS_CODES, TypeExt};
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum Response<'r> {
@@ -234,8 +234,7 @@ impl ToTokens for ResponseTuple<'_> {
                             })
                         })
                     } else {
-                        let schema_type = SchemaType(response_type.ty.as_ref());
-                        let default_type = self.resolve_content_type(None, &schema_type);
+                        let default_type = response_type.get_default_content_type();
                         tokens.extend(quote! {
                             .content(#default_type, #content.build())
                         });
@@ -398,8 +397,6 @@ impl Parse for Content<'_> {
         Ok(Content(content_type.value(), body, example, examples))
     }
 }
-
-impl ContentTypeResolver for ResponseTuple<'_> {}
 
 // (name = (summary = "...", description = "...", value = "..", external_value = "..."))
 #[derive(Default)]

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -106,6 +106,10 @@ impl SchemaType<'_> {
     pub fn is_string(&self) -> bool {
         matches!(&*self.last_segment_to_string(), "str" | "String")
     }
+
+    pub fn is_byte(&self) -> bool {
+        matches!(&*self.last_segment_to_string(), "u8")
+    }
 }
 
 #[inline]
@@ -163,7 +167,7 @@ impl ToTokens for SchemaType<'_> {
             #[cfg(feature = "chrono")]
             "DateTime" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
             #[cfg(feature = "chrono")]
-            "NaiveDate" => tokens.extend(quote!( utoipa::openapi::SchemaType::String)),
+            "NaiveDate" => tokens.extend(quote!(utoipa::openapi::SchemaType::String)),
             #[cfg(any(feature = "chrono", feature = "time"))]
             "Date" | "Duration" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
             #[cfg(feature = "decimal")]

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -244,6 +244,10 @@ response_no_body_with_complex_header_with_description => headers: (
     "responses.200.headers.random-digits.schema.type" = r###""array""###, "random-digits header type"
     "responses.200.headers.random-digits.schema.items.type" = r###""integer""###, "random-digits header items type"
     "responses.200.headers.random-digits.schema.items.format" = r###""int64""###, "random-digits header items format"
+binary_octet_stream => body: [u8], assert:
+    "responses.200.content.application~1octet-stream.schema.type" = r#""string""#, "Response content type"
+    "responses.200.content.application~1octet-stream.schema.format" = r#""binary""#, "Response content format"
+    "responses.200.headers" = r###"null"###, "Response headers"
 }
 
 test_fn! {


### PR DESCRIPTION
Prior to this PR defining application/octet-stream needed a manual step to define custom binary type with correct format and schema type. This commit will add support to automatically detect
application/octet-stream type from `[u8]` response body or request body.

Resolves #197 