### PR TITLE
Add example attributes for request body

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -603,6 +603,14 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///   [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and
 ///   _`application/json`_ for struct and complex enum types.
 ///
+/// * `example = ...` Can be _`json!(...)`_. _`json!(...)`_ should be something that
+///   _`serde_json::json!`_ can parse as a _`serde_json::Value`_.
+///
+/// * `examples(...)` Define mulitple examples for single request body. This attribute is mutually
+///   exclusive to the _`example`_ attribute and if both are defined this will override the _`example`_.
+///   This has same syntax as _`examples(...)`_ in [Response Attributes](#response-attributes)
+///   _examples(...)_
+///
 /// **Request body supports following formats:**
 ///
 /// ```text

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -26,6 +26,7 @@ use self::parameter::ValueParameter;
 ))]
 use crate::ext::{IntoParamsType, ValueArgument};
 
+pub mod example;
 pub mod parameter;
 mod property;
 mod request_body;

--- a/utoipa-gen/src/path/example.rs
+++ b/utoipa-gen/src/path/example.rs
@@ -1,0 +1,106 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::token::Comma;
+use syn::{parenthesized, Error, LitStr, Token};
+
+use crate::{parse_utils, AnyValue};
+
+// (name = (summary = "...", description = "...", value = "..", external_value = "..."))
+#[derive(Default)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub(super) struct Example {
+    pub(super) name: String,
+    pub(super) summary: Option<String>,
+    pub(super) description: Option<String>,
+    pub(super) value: Option<AnyValue>,
+    pub(super) external_value: Option<String>,
+}
+
+impl Parse for Example {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let example_stream;
+        parenthesized!(example_stream in input);
+        let mut example = Example {
+            name: example_stream.parse::<LitStr>()?.value(),
+            ..Default::default()
+        };
+        example_stream.parse::<Token![=]>()?;
+
+        let content;
+        parenthesized!(content in example_stream);
+
+        while !content.is_empty() {
+            let ident = content.parse::<Ident>()?;
+            let attribute_name = &*ident.to_string();
+            match attribute_name {
+                "summary" => {
+                    example.summary = Some(
+                        parse_utils::parse_next(&content, || content.parse::<LitStr>())?
+                            .value(),
+                    )
+                }
+                "description" => {
+                    example.description = Some(
+                        parse_utils::parse_next(&content, || content.parse::<LitStr>())?
+                            .value(),
+                    )
+                }
+                "value" => {
+                    example.value = Some(parse_utils::parse_next(&content, || {
+                        AnyValue::parse_json(&content)
+                    })?)
+                }
+                "external_value" => {
+                    example.external_value = Some(
+                        parse_utils::parse_next(&content, || content.parse::<LitStr>())?
+                            .value(),
+                    )
+                }
+                _ => {
+                    return Err(
+                        Error::new(
+                            ident.span(),
+                            &format!("unexpected attribute: {attribute_name}, expected one of: summary, description, value, external_value")
+                        )
+                    )
+                }
+            }
+
+            if !content.is_empty() {
+                content.parse::<Comma>()?;
+            }
+        }
+
+        Ok(example)
+    }
+}
+
+impl ToTokens for Example {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let summary = self
+            .summary
+            .as_ref()
+            .map(|summary| quote!(.summary(#summary)));
+        let description = self
+            .description
+            .as_ref()
+            .map(|description| quote!(.description(#description)));
+        let value = self
+            .value
+            .as_ref()
+            .map(|value| quote!(.value(Some(#value))));
+        let external_value = self
+            .external_value
+            .as_ref()
+            .map(|external_value| quote!(.external_value(#external_value)));
+
+        tokens.extend(quote! {
+            utoipa::openapi::example::ExampleBuilder::new()
+                #summary
+                #description
+                #value
+                #external_value
+        })
+    }
+}

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -1,9 +1,12 @@
 use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
 use syn::{parenthesized, parse::Parse, token::Paren, Error, Token};
 
-use crate::{parse_utils, Required, Type};
+use crate::{parse_utils, AnyValue, Array, Required, Type};
 
+use super::example::Example;
 use super::property::Property;
 use super::TypeExt;
 
@@ -50,12 +53,14 @@ pub struct RequestBodyAttr<'r> {
     content: Option<Type<'r>>,
     content_type: Option<String>,
     description: Option<String>,
+    example: Option<AnyValue>,
+    examples: Option<Punctuated<Example, Comma>>,
 }
 
 impl Parse for RequestBodyAttr<'_> {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         const EXPECTED_ATTRIBUTE_MESSAGE: &str =
-            "unexpected attribute, expected any of: content, content_type, description";
+            "unexpected attribute, expected any of: content, content_type, description, examples";
         let lookahead = input.lookahead1();
 
         if lookahead.peek(Paren) {
@@ -91,6 +96,15 @@ impl Parse for RequestBodyAttr<'_> {
                         request_body_attr.description =
                             Some(parse_utils::parse_next_literal_str(&group)?)
                     }
+                    "example" => {
+                        request_body_attr.example = Some(parse_utils::parse_next(&group, || {
+                            AnyValue::parse_json(&group)
+                        })?)
+                    }
+                    "examples" => {
+                        request_body_attr.examples =
+                            Some(parse_utils::parse_punctuated_within_parenthesis(&group)?)
+                    }
                     _ => return Err(Error::new(ident.span(), EXPECTED_ATTRIBUTE_MESSAGE)),
                 }
 
@@ -110,8 +124,7 @@ impl Parse for RequestBodyAttr<'_> {
                         format!("unexpected token, expected type such as String, {}", error),
                     )
                 })?),
-                content_type: None,
-                description: None,
+                ..Default::default()
             })
         } else {
             Err(lookahead.error())
@@ -127,11 +140,31 @@ impl ToTokens for RequestBodyAttr<'_> {
                 .content_type
                 .as_deref()
                 .unwrap_or_else(|| body_type.get_default_content_type());
-            let required: Required = (!body_type.is_option).into();
+            let mut content =
+                quote! { utoipa::openapi::content::ContentBuilder::new().schema(#property) };
 
+            if let Some(ref example) = self.example {
+                content.extend(quote! {
+                    .example(Some(#example))
+                })
+            }
+            if let Some(ref examples) = self.examples {
+                let examples = examples
+                    .iter()
+                    .map(|example| {
+                        let name = &example.name;
+                        quote!((#name, #example))
+                    })
+                    .collect::<Array<TokenStream2>>();
+                content.extend(quote!(
+                    .examples_from_iter(#examples)
+                ))
+            }
+
+            let required: Required = (!body_type.is_option).into();
             tokens.extend(quote! {
                 utoipa::openapi::request_body::RequestBodyBuilder::new()
-                    .content(#content_type, utoipa::openapi::Content::new(#property))
+                    .content(#content_type, #content.build())
                     .required(Some(#required))
             });
         }

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -13,7 +13,7 @@ use syn::{
 
 use crate::{parse_utils, AnyValue, Array, Type};
 
-use super::{property::Property, status::STATUS_CODES, TypeExt};
+use super::{example::Example, property::Property, status::STATUS_CODES, TypeExt};
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum Response<'r> {
@@ -395,105 +395,6 @@ impl Parse for Content<'_> {
         }
 
         Ok(Content(content_type.value(), body, example, examples))
-    }
-}
-
-// (name = (summary = "...", description = "...", value = "..", external_value = "..."))
-#[derive(Default)]
-#[cfg_attr(feature = "debug", derive(Debug))]
-struct Example {
-    name: String,
-    summary: Option<String>,
-    description: Option<String>,
-    value: Option<AnyValue>,
-    external_value: Option<String>,
-}
-
-impl Parse for Example {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let example_stream;
-        parenthesized!(example_stream in input);
-        let mut example = Example {
-            name: example_stream.parse::<LitStr>()?.value(),
-            ..Default::default()
-        };
-        example_stream.parse::<Token![=]>()?;
-
-        let content;
-        parenthesized!(content in example_stream);
-
-        while !content.is_empty() {
-            let ident = content.parse::<Ident>()?;
-            let attribute_name = &*ident.to_string();
-            match attribute_name {
-                "summary" => {
-                    example.summary = Some(
-                        parse_utils::parse_next(&content, || content.parse::<LitStr>())?
-                            .value(),
-                    )
-                }
-                "description" => {
-                    example.description = Some(
-                        parse_utils::parse_next(&content, || content.parse::<LitStr>())?
-                            .value(),
-                    )
-                }
-                "value" => {
-                    example.value = Some(parse_utils::parse_next(&content, || {
-                        AnyValue::parse_json(&content)
-                    })?)
-                }
-                "external_value" => {
-                    example.external_value = Some(
-                        parse_utils::parse_next(&content, || content.parse::<LitStr>())?
-                            .value(),
-                    )
-                }
-                _ => {
-                    return Err(
-                        Error::new(
-                            ident.span(),
-                            &format!("unexpected attribute: {attribute_name}, expected one of: summary, description, value, external_value")
-                        )
-                    )
-                }
-            }
-
-            if !content.is_empty() {
-                content.parse::<Comma>()?;
-            }
-        }
-
-        Ok(example)
-    }
-}
-
-impl ToTokens for Example {
-    fn to_tokens(&self, tokens: &mut TokenStream2) {
-        let summary = self
-            .summary
-            .as_ref()
-            .map(|summary| quote!(.summary(#summary)));
-        let description = self
-            .description
-            .as_ref()
-            .map(|description| quote!(.description(#description)));
-        let value = self
-            .value
-            .as_ref()
-            .map(|value| quote!(.value(Some(#value))));
-        let external_value = self
-            .external_value
-            .as_ref()
-            .map(|external_value| quote!(.external_value(#external_value)));
-
-        tokens.extend(quote! {
-            utoipa::openapi::example::ExampleBuilder::new()
-                #summary
-                #description
-                #value
-                #external_value
-        })
     }
 }
 


### PR DESCRIPTION
Add `example` and `examples(...)` attribute for derive request body on `#[utoipa::path(...)]` attribute.
```rust
 // request body with example
 #[utoipa::path(get, path = "/item", request_body(content = Value, example = json!({"value": "this is value"})))]

 // request body with exmaples
 request_body(content = Value,
     examples(
         ("Value1" = (value = json!({"value": "this is value"}) ) ),
         ("Value2" = (value = json!({"value": "this is value2"}) ) )
     )
 )
```