### PR TITLE
Add external ref(...) attribute

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -588,16 +588,21 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// # Request Body Attributes
 ///
 /// **Simple format definition by `request_body = ...`**
-/// * `request_body = Type` or `request_body = inline(Type)`. The given _`Type`_ can be any
-///   Rust type that is JSON parseable. It can be Option, Vec or Map etc. With _`inline(...)`_
-///   the schema will be inlined instead of a referenced which is the default for
-///   [`ToSchema`][to_schema] types.
+/// * _`request_body = Type`_, _`request_body = inline(Type)`_ or _`request_body = ref("...")`_.
+///   The given _`Type`_ can be any Rust type that is JSON parseable. It can be Option, Vec or Map etc.
+///   With _`inline(...)`_ the schema will be inlined instead of a referenced which is the default for
+///   [`ToSchema`][to_schema] types. _`ref("./external.json")`_ can be used to reference external
+///   json file for body schema. **Note!** Utoipa does **not** guarantee that free form _`ref`_ is accessbile via
+///   OpenAPI doc or Swagger UI, users are eligible to make these guarantees.
 ///
 /// **Advanced format definition by `request_body(...)`**
-/// * `content = ...` Can be `content = Type` or `content = inline(Type)`. The given _`Type`_ can be any
-///   Rust type that is JSON parseable. It can be Option, Vec or Map etc. With _`inline(...)`_
-///   the schema will be inlined instead of a referenced which is the default for
-///   [`ToSchema`][to_schema] types.
+/// * `content = ...` Can be _`content = Type`_, _`content = inline(Type)`_ or _`content = ref("...")`_. The
+///   given _`Type`_ can be any Rust type that is JSON parseable. It can be Option, Vec
+///   or Map etc. With _`inline(...)`_ the schema will be inlined instead of a referenced
+///   which is the default for [`ToSchema`][to_schema] types. _`ref("./external.json")`_
+///   can be used to reference external json file for body schema. **Note!** Utoipa does **not** guarantee
+///   that free form _`ref`_ is accessbile via OpenAPI doc or Swagger UI, users are eligible
+///   to make these guarantees.
 ///
 /// * `description = "..."` Define the description for the request body object as str.
 ///
@@ -631,10 +636,13 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// * `description = "..."` Define description for the response as str.
 ///
 /// * `body = ...` Optional response body object type. When left empty response does not expect to send any
-///   response body. Can be `body = Type` or `body = inline(Type)`. The given _`Type`_ can be any
-///   Rust type that is JSON parseable. It can be Option, Vec or Map etc. With _`inline(...)`_
-///   the schema will be inlined instead of a referenced which is the default for
-///   [`ToSchema`][to_schema] types.
+///   response body. Can be _`body = Type`_, _`body = inline(Type)`_, or _`body = ref("...")`_.
+///   The given _`Type`_ can be any Rust type that is JSON parseable. It can be Option, Vec or Map etc.
+///   With _`inline(...)`_ the schema will be inlined instead of a referenced which is the default for
+///   [`ToSchema`][to_schema] types. _`ref("./external.json")`_
+///   can be used to reference external json file for body schema. **Note!** Utoipa does **not** guarantee
+///   that free form _`ref`_ is accessbile via OpenAPI doc or Swagger UI, users are eligible
+///   to make these guarantees.
 ///
 /// * `content_type = "..." | content_type = [...]` Can be used to override the default behavior of auto resolving the content type
 ///   from the `body` attribute. If defined the value should be valid content type such as

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -16,7 +16,7 @@ use syn::{
 use crate::ext::{ArgumentIn, ValueArgument};
 use crate::{component::TypeTree, parse_utils, AnyValue, Deprecated, Required};
 
-use super::{media_type::MediaTypeSchema, InlineableType, PathTypeTree};
+use super::{media_type::MediaTypeSchema, InlineType, PathTypeTree};
 
 /// Parameter of request suchs as in path, header, query or cookie
 ///
@@ -104,7 +104,7 @@ pub struct ValueParameter<'a> {
     parameter_ext: Option<ParameterExt>,
 
     /// Type only when value parameter is parsed
-    parsed_type: Option<InlineableType>,
+    parsed_type: Option<InlineType>,
 }
 
 impl<'p> ValueParameter<'p> {

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -552,3 +552,40 @@ fn derive_path_with_mutliple_resposnes_with_multiple_examples() {
         })
     )
 }
+
+#[test]
+fn path_response_with_external_ref() {
+    #[utoipa::path(
+        get,
+        path = "/foo", 
+        responses(
+            (status = 200, body = ref("./MyUser.json"))
+        )
+    )]
+    #[allow(unused)]
+    fn get_item() {}
+
+    #[derive(utoipa::OpenApi)]
+    #[openapi(paths(get_item))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let resopnses = doc.pointer("/paths/~1foo/get/responses").unwrap();
+
+    assert_json_eq!(
+        resopnses,
+        json!({
+            "200": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref":
+                                "./MyUser.json",
+                        },
+                    },
+                },
+                "description": "",
+            },
+        })
+    )
+}

--- a/utoipa-gen/tests/request_body_derive_test.rs
+++ b/utoipa-gen/tests/request_body_derive_test.rs
@@ -540,3 +540,30 @@ fn request_body_with_binary() {
         })
     )
 }
+
+#[test]
+fn request_body_with_external_ref() {
+    #[utoipa::path(get, path = "/item", request_body(content = ref("./MyUser.json")))]
+    #[allow(dead_code)]
+    fn get_item() {}
+
+    #[derive(utoipa::OpenApi)]
+    #[openapi(paths(get_item))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+
+    let content = doc
+        .pointer("/paths/~1item/get/requestBody/content")
+        .unwrap();
+    assert_json_eq!(
+        content,
+        json!(
+            {"application/json": {
+                "schema": {
+                    "$ref": "./MyUser.json"
+                }
+            }
+        })
+    )
+}


### PR DESCRIPTION
Add external ref(...) attribute for response body and reqeust body. This allows to use external json file schema for request body or reponse body.

This PR will not add any support for giving guarantees of accessibility of the externally referenced json value. Those guaratees are deemed to be done by the user.

This commit will add support for following syntax.
```rust
 // external ref on request body
 #[utoipa::path(get, path = "/item", request_body(content = ref("./MyUser.json")))]
 #[allow(dead_code)]
 fn get_item() {}

 // external ref on response body
 #[utoipa::path(
     get,
     path = "/foo",
     responses(
         (status = 200, body = ref("./MyUser.json"))
     )
 )]
 #[allow(unused)]
 fn get_item() {}
```

Resolves #242 