### PR TITLE
Add support for repeated `schema(...)` definition

### DIFF
--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3055,3 +3055,29 @@ fn derive_unit_struct_schema() {
         })
     )
 }
+
+#[test]
+fn derive_schema_with_multiple_schema_attributes() {
+    let value = api_doc! {
+        struct UserName {
+            #[schema(min_length = 5)]
+            #[schema(max_length = 10)]
+            name: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "minLength": 5,
+                    "maxLength": 10,
+                }
+            },
+            "required": ["name"]
+        })
+    )
+}


### PR DESCRIPTION
Add support for `ToSchema` types to have repeated definition of `schema(...)` attribute. Prior to this PR only the first `#[schema(...)]` attribute was taken in account in parsing the attributes for variant / field / type. This commit will add support for repeated definition of the attribute.
```rust
 #[derive(ToSchema)]
 struct UserName {
     #[schema(min_length = 5)]
     #[schema(max_length = 10)]
     name: String,
 }
```