### PR TITLE
Enhance repeated attributes support

### DIFF
--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -1470,3 +1470,45 @@ macro_rules! impl_into_inner {
 }
 
 pub(crate) use impl_into_inner;
+
+pub trait Merge<T>: IntoInner<Vec<Feature>> {
+    fn merge(self, from: T) -> Self;
+}
+
+macro_rules! impl_merge {
+    ( $($ident:ident),* ) => {
+        $(
+            impl AsMut<Vec<Feature>> for $ident {
+                fn as_mut(&mut self) -> &mut Vec<Feature> {
+                    &mut self.0
+                }
+            }
+
+            impl crate::component::features::Merge<$ident> for $ident {
+                fn merge(mut self, from: $ident) -> Self {
+                    let a = self.as_mut();
+                    let mut b = from.into_inner();
+
+                    a.append(&mut b);
+
+                    self
+                }
+            }
+        )*
+    };
+}
+
+pub(crate) use impl_merge;
+
+impl IntoInner<Vec<Feature>> for Vec<Feature> {
+    fn into_inner(self) -> Vec<Feature> {
+        self
+    }
+}
+
+impl Merge<Vec<Feature>> for Vec<Feature> {
+    fn merge(mut self, mut from: Vec<Feature>) -> Self {
+        self.append(&mut from);
+        self
+    }
+}

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -34,11 +34,43 @@ pub struct OpenApiAttr<'o> {
     servers: Punctuated<Server, Comma>,
 }
 
+impl<'o> OpenApiAttr<'o> {
+    fn merge(mut self, other: OpenApiAttr<'o>) -> Self {
+        if other.info.is_some() {
+            self.info = other.info;
+        }
+        if !other.paths.is_empty() {
+            self.paths = other.paths;
+        }
+        if !other.components.schemas.is_empty() {
+            self.components.schemas = other.components.schemas;
+        }
+        if !other.components.responses.is_empty() {
+            self.components.responses = other.components.responses;
+        }
+        if other.security.is_some() {
+            self.security = other.security;
+        }
+        if other.tags.is_some() {
+            self.tags = other.tags;
+        }
+        if other.external_docs.is_some() {
+            self.external_docs = other.external_docs;
+        }
+        if !other.servers.is_empty() {
+            self.servers = other.servers;
+        }
+
+        self
+    }
+}
+
 pub fn parse_openapi_attrs(attrs: &[Attribute]) -> Option<OpenApiAttr> {
     attrs
         .iter()
-        .find(|attribute| attribute.path.is_ident("openapi"))
+        .filter(|attribute| attribute.path.is_ident("openapi"))
         .map(|attribute| attribute.parse_args::<OpenApiAttr>().unwrap_or_abort())
+        .reduce(|acc, item| acc.merge(item))
 }
 
 impl Parse for OpenApiAttr<'_> {


### PR DESCRIPTION
Add repeated attribute support for `params(...)`, `into_params(...)` and `openapi(...)` derive attributes. This functionality is effectively same as in `ToSchema` `schema` attribute.

The latest defined attribute takes preference. For `openapi` attribute values the merge is shallow and also latest defined attribute will take preference without considering inner attributes within `openapi` attribute.