### PR TITLE
Feat/serde enum representation

### DIFF
--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -734,10 +734,7 @@ fn regular_enum_to_tokens<T: self::enum_variant::Variant>(
                     .map(|variant| (Cow::Borrowed(tag.as_str()), variant)),
             )
             .to_token_stream(),
-            // FIXME: Correctly support Untagged repr
-            //SerdeEnumRepr::Untagged => Enum::new(enum_values).to_token_stream(),
             SerdeEnumRepr::Untagged => UntaggedEnum.to_token_stream(),
-            // FIXME: Correctly support AdjacentlyTagged repr
             SerdeEnumRepr::AdjacentlyTagged { tag, content } => {
                 AdjacentlyTaggedEnum::new(enum_values.into_iter().map(|variant| {
                     (
@@ -1162,10 +1159,10 @@ impl ComplexEnum<'_> {
                 } else {
                     abort!(
                         variant,
-                        "Unnamed (tuple) enum variants are unsupported for internally tagged enums using the `tag = ` serde attribute";
+                        "Unnamed (tuple) enum variants are unsupported for adjacently tagged enums using the `tag = <tag>, content = <content>` serde attribute";
 
                         help = "Try using a different serde enum representation";
-                        note = "See more about enum limitations here: `https://serde.rs/enum-representations.html#internally-tagged`"
+                        note = "See more about enum limitations here: `https://serde.rs/enum-representations.html#adjacently-tagged`"
                     );
                 }
             }

--- a/utoipa-gen/src/component/schema/enum_variant.rs
+++ b/utoipa-gen/src/component/schema/enum_variant.rs
@@ -211,6 +211,14 @@ impl<'t, V: Variant> FromIterator<(Cow<'t, str>, V)> for TaggedEnum<V> {
     }
 }
 
+pub struct UntaggedEnum;
+
+impl ToTokens for UntaggedEnum {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.extend(quote!(utoipa::openapi::ObjectBuilder::new().nullable(true)));
+    }
+}
+
 /// Used to create complex enums with varying Object types.
 ///
 /// Will create `oneOf` object with discriminator field for referenced schemas.

--- a/utoipa-gen/src/component/schema/enum_variant.rs
+++ b/utoipa-gen/src/component/schema/enum_variant.rs
@@ -219,6 +219,75 @@ impl ToTokens for UntaggedEnum {
     }
 }
 
+pub struct AdjacentlyTaggedEnum<T: Variant> {
+    items: TokenStream,
+    len: usize,
+    _p: PhantomData<T>,
+}
+
+impl<V: Variant> AdjacentlyTaggedEnum<V> {
+    pub fn new<'t, I: IntoIterator<Item = (Cow<'t, str>, Cow<'t, str>, V)>>(items: I) -> Self {
+        items.into_iter().collect()
+    }
+}
+
+impl<T> ToTokens for AdjacentlyTaggedEnum<T>
+where
+    T: Variant,
+{
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let len = &self.len;
+        let items = &self.items;
+
+        tokens.extend(quote! {
+            Into::<utoipa::openapi::schema::OneOfBuilder>::into(utoipa::openapi::OneOf::with_capacity(#len))
+                #items
+        })
+    }
+}
+
+impl<'t, V: Variant> FromIterator<(Cow<'t, str>, Cow<'t, str>, V)> for AdjacentlyTaggedEnum<V> {
+    fn from_iter<T: IntoIterator<Item = (Cow<'t, str>, Cow<'t, str>, V)>>(iter: T) -> Self {
+        let mut len = 0;
+
+        let items = iter
+            .into_iter()
+            .enumerate()
+            .map(|(index, (tag, content, variant))| {
+                len = index + 1;
+
+                let (schema_type, enum_type) = variant.get_type();
+                let item = variant.to_tokens();
+                quote! {
+                    .item(
+                        utoipa::openapi::schema::ObjectBuilder::new()
+                            .property(
+                                #tag,
+                                utoipa::openapi::schema::ObjectBuilder::new()
+                                    .schema_type(utoipa::openapi::schema::SchemaType::String)
+                                    .enum_values::<[#enum_type; 1], #enum_type>(Some([#content]))
+                            )
+                            .required(#tag)
+                            .property(
+                                #content,
+                                utoipa::openapi::schema::ObjectBuilder::new()
+                                    .schema_type(#schema_type)
+                                    .enum_values::<[#enum_type; 1], #enum_type>(Some([#item]))
+                            )
+                            .required(#content)
+                    )
+                }
+            })
+            .collect::<TokenStream>();
+
+        Self {
+            items,
+            len,
+            _p: PhantomData,
+        }
+    }
+}
+
 /// Used to create complex enums with varying Object types.
 ///
 /// Will create `oneOf` object with discriminator field for referenced schemas.

--- a/utoipa-gen/src/component/serde.rs
+++ b/utoipa-gen/src/component/serde.rs
@@ -57,18 +57,49 @@ impl SerdeValue {
     }
 }
 
+/// The [Serde Enum representation](https://serde.rs/enum-representations.html) being used
+/// The default case (when no serde attributes are present) is `ExternallyTagged`.
+#[derive(Clone, Debug)]
+pub enum SerdeEnumRepr {
+    ExternallyTagged,
+    InternallyTagged {
+        tag: String,
+    },
+    AdjacentlyTagged {
+        tag: String,
+        content: String,
+    },
+    Untagged,
+    /// This is a variant that can never happen because `serde` will not accept it.
+    /// With the current implementation it is necessary to have it as an intermediate state when parsing the
+    /// attributes
+    UnfinishedAdjacentlyTagged {
+        content: String,
+    },
+}
+
+impl Default for SerdeEnumRepr {
+    fn default() -> SerdeEnumRepr {
+        SerdeEnumRepr::ExternallyTagged
+    }
+}
+
 /// Attributes defined within a `#[serde(...)]` container attribute.
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct SerdeContainer {
     pub rename_all: Option<RenameRule>,
-    pub tag: String,
+    pub enum_repr: SerdeEnumRepr,
     pub default: bool,
 }
 
 impl SerdeContainer {
-    /// Parse a single serde attribute, currently `rename_all = ...`, `tag = ...` and
-    /// `defaut = ...` attributes are supported.
+    /// Parse a single serde attribute, currently supported attributes are:
+    ///     * `rename_all = ...`
+    ///     * `tag = ...`
+    ///     * `content = ...`
+    ///     * `untagged = ...`
+    ///     * `default = ...`
     fn parse_attribute(&mut self, ident: Ident, next: Cursor) -> syn::Result<()> {
         match ident.to_string().as_str() {
             "rename_all" => {
@@ -78,12 +109,50 @@ impl SerdeContainer {
                             .parse::<RenameRule>()
                             .map_err(|error| Error::new(span, error.to_string()))?,
                     );
-                };
+                }
             }
             "tag" => {
                 if let Some((literal, _span)) = parse_next_lit_str(next) {
-                    self.tag = literal
+                    self.enum_repr = match &self.enum_repr {
+                        SerdeEnumRepr::ExternallyTagged => {
+                            SerdeEnumRepr::InternallyTagged { tag: literal }
+                        }
+                        SerdeEnumRepr::UnfinishedAdjacentlyTagged { content } => {
+                            SerdeEnumRepr::AdjacentlyTagged {
+                                tag: literal,
+                                content: content.clone(),
+                            }
+                        }
+                        SerdeEnumRepr::InternallyTagged { .. }
+                        | SerdeEnumRepr::AdjacentlyTagged { .. } => {
+                            panic!("Duplicate serde tag argument")
+                        }
+                        SerdeEnumRepr::Untagged => panic!("Untagged enum cannot have tag"),
+                    };
                 }
+            }
+            "content" => {
+                if let Some((literal, _span)) = parse_next_lit_str(next) {
+                    self.enum_repr = match &self.enum_repr {
+                        SerdeEnumRepr::InternallyTagged { tag } => {
+                            SerdeEnumRepr::AdjacentlyTagged {
+                                tag: tag.clone(),
+                                content: literal,
+                            }
+                        }
+                        SerdeEnumRepr::ExternallyTagged => {
+                            SerdeEnumRepr::UnfinishedAdjacentlyTagged { content: literal }
+                        }
+                        SerdeEnumRepr::AdjacentlyTagged { .. }
+                        | SerdeEnumRepr::UnfinishedAdjacentlyTagged { .. } => {
+                            panic!("Duplicate serde content argument")
+                        }
+                        SerdeEnumRepr::Untagged => panic!("Untagged enum cannot have content"),
+                    };
+                }
+            }
+            "untagged" => {
+                self.enum_repr = SerdeEnumRepr::Untagged;
             }
             "default" => {
                 self.default = true;
@@ -156,8 +225,14 @@ pub fn parse_container(attributes: &[Attribute]) -> Option<SerdeContainer> {
                 if value.default {
                     acc.default = value.default;
                 }
-                if !value.tag.is_empty() {
-                    acc.tag = value.tag;
+                match value.enum_repr {
+                    SerdeEnumRepr::ExternallyTagged => {},
+                    SerdeEnumRepr::Untagged
+                    | SerdeEnumRepr::InternallyTagged { .. }
+                    | SerdeEnumRepr::AdjacentlyTagged { .. }
+                    | SerdeEnumRepr::UnfinishedAdjacentlyTagged { .. } => {
+                        acc.enum_repr = value.enum_repr;
+                    },
                 }
                 if value.rename_all.is_some() {
                     acc.rename_all = value.rename_all;

--- a/utoipa-gen/src/component/serde.rs
+++ b/utoipa-gen/src/component/serde.rs
@@ -226,13 +226,13 @@ pub fn parse_container(attributes: &[Attribute]) -> Option<SerdeContainer> {
                     acc.default = value.default;
                 }
                 match value.enum_repr {
-                    SerdeEnumRepr::ExternallyTagged => {},
+                    SerdeEnumRepr::ExternallyTagged => {}
                     SerdeEnumRepr::Untagged
                     | SerdeEnumRepr::InternallyTagged { .. }
                     | SerdeEnumRepr::AdjacentlyTagged { .. }
                     | SerdeEnumRepr::UnfinishedAdjacentlyTagged { .. } => {
                         acc.enum_repr = value.enum_repr;
-                    },
+                    }
                 }
                 if value.rename_all.is_some() {
                     acc.rename_all = value.rename_all;

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -160,12 +160,17 @@ use self::path::response::DeriveResponse;
 /// generated OpenAPI doc. For example if _`#[serde(skip)]`_ is defined the attribute will not show up in the OpenAPI spec at all since it will not never
 /// be serialized anyway. Similarly the _`rename`_ and _`rename_all`_ will reflect to the generated OpenAPI doc.
 ///
-/// * `rename_all = "..."` Supported in container level.
-/// * `rename = "..."` Supported **only** in field or variant level.
-/// * `skip = "..."` Supported  **only** in field or variant level.
-/// * `tag = "..."` Supported in container level. `tag` attribute also works as a [discriminator field][discriminator] for an enum.
-/// * `default` Supported in container level and field level according to [serde attributes].
-/// * `flatten` Supported in field level.
+/// * `rename_all = "..."` Supported at the container level.
+/// * `rename = "..."` Supported **only** at the field or variant level.
+/// * `skip = "..."` Supported  **only** at the field or variant level.
+/// * `tag = "..."` Supported at the container level. `tag` attribute works as a [discriminator field][discriminator] for an enum.
+/// * `content = "..."` Supported at the container level, allows [adjacently-tagged enums](https://serde.rs/enum-representations.html#adjacently-tagged).
+///   This attribute requires that a `tag` is present, otherwise serde will trigger a compile-time
+///   failure.
+/// * `untagged` Supported at the container level. Allows [untagged
+/// enum representation](https://serde.rs/enum-representations.html#untagged).
+/// * `default` Supported at the container level and field level according to [serde attributes].
+/// * `flatten` Supported at the field level.
 ///
 /// Other _`serde`_ attributes works as is but does not have any effect on the generated OpenAPI doc.
 ///
@@ -921,7 +926,7 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// # rocket_extras feature support for rocket
 ///
 /// **rocket_extras** feature enahances path operation parameter support. It gives **utoipa** ability to parse `path`, `path parameters`
-/// and `query parameters` based on arguments given to **rocket**  proc macros such as _**`#[get(...)]`**_.  
+/// and `query parameters` based on arguments given to **rocket**  proc macros such as _**`#[get(...)]`**_.
 ///
 /// 1. It is able to parse parameter types for [primitive types][primitive], [`String`], [`Vec`], [`Option`] or [`std::path::PathBuf`]
 ///    type.
@@ -1523,13 +1528,13 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// # Partial `#[serde(...)]` attributes support
 ///
 /// IntoParams derive has partial support for [serde attributes]. These supported attributes will reflect to the
-/// generated OpenAPI doc. For example the _`rename`_ and _`rename_all`_ will reflect to the generated OpenAPI doc.
+/// generated OpenAPI doc. The following attributes are currently supported :
 ///
-/// * `rename_all = "..."` Supported in container level.
-/// * `rename = "..."` Supported **only** in field.
-/// * `default` Supported in container level and field level according to [serde attributes].
+/// * `rename_all = "..."` Supported at the container level.
+/// * `rename = "..."` Supported **only** at the field level.
+/// * `default` Supported at the container level and field level according to [serde attributes].
 ///
-/// Other _`serde`_ attributes works as is but does not have any effect on the generated OpenAPI doc.
+/// Other _`serde`_ attributes will impact the serialization but will not be reflected on the generated OpenAPI doc.
 ///
 /// # Examples
 ///

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1795,6 +1795,57 @@ fn derive_complex_enum_with_ref_serde_untagged_named_fields() {
 }
 
 #[test]
+fn derive_complex_enum_with_ref_serde_untagged_named_fields_rename_all() {
+    #[derive(Serialize, ToSchema)]
+    struct Bar {
+        name: String,
+        age: u32,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(untagged)]
+        enum Foo {
+            #[serde(rename_all = "camelCase")]
+            One { some_number: i32 },
+            #[serde(rename_all = "camelCase")]
+            Two { some_bar: Bar },
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "properties": {
+                      "someNumber": {
+                        "format": "int32",
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "someNumber"
+                    ],
+                    "type": "object"
+                },
+                {
+                    "properties": {
+                      "someBar": {
+                        "$ref": "#/components/schemas/Bar"
+                      }
+                    },
+                    "required": [
+                      "someBar"
+                    ],
+                    "type": "object"
+                }
+            ]
+        })
+    );
+}
+
+#[test]
 fn derive_complex_enum_serde_adjacently_tagged() {
     let value: Value = api_doc! {
         #[derive(Serialize)]
@@ -1986,6 +2037,90 @@ fn derive_complex_enum_with_ref_serde_adjacently_tagged_named_fields() {
                             },
                             "required": [
                                 "bar",
+                            ],
+                        },
+                    },
+                    "required": [
+                      "tag",
+                      "content",
+                    ],
+                },
+            ],
+            "discriminator": {
+                "propertyName": "tag",
+            },
+        })
+    );
+}
+
+#[test]
+fn derive_complex_enum_with_ref_serde_adjacently_tagged_named_fields_rename_all() {
+    #[derive(Serialize, ToSchema)]
+    struct Bar {
+        name: String,
+        age: u32,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "tag", content = "content")]
+        enum Foo {
+            #[serde(rename_all = "camelCase")]
+            One { some_number: i32 },
+            #[serde(rename_all = "camelCase")]
+            Two { some_bar: Bar },
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "One",
+                            ],
+                        },
+                        "content": {
+                            "type": "object",
+                            "properties": {
+                                "someNumber": {
+                                    "format": "int32",
+                                    "type": "integer",
+                                },
+                            },
+                            "required": [
+                                "someNumber",
+                            ],
+                        },
+                    },
+                    "required": [
+                      "tag",
+                      "content"
+                    ],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "Two",
+                            ],
+                        },
+                        "content": {
+                            "type": "object",
+                            "properties": {
+                                "someBar": {
+                                    "$ref": "#/components/schemas/Bar",
+                                },
+                            },
+                            "required": [
+                                "someBar",
                             ],
                         },
                     },

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1795,6 +1795,214 @@ fn derive_complex_enum_with_ref_serde_untagged_named_fields() {
 }
 
 #[test]
+fn derive_complex_enum_serde_adjacently_tagged() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "tag", content = "content")]
+        enum Foo {
+            Bar(i32),
+            Baz(String),
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "Bar",
+                            ],
+                        },
+                        "content": {
+                            "format": "int32",
+                            "type": "integer",
+                        },
+                    },
+                    "required": [
+                        "tag",
+                        "content"
+                    ],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "Baz",
+                            ]
+                        },
+                        "content": {
+                            "type": "string",
+                        },
+                    },
+                    "required": [
+                        "tag",
+                        "content"
+                    ],
+                },
+            ],
+            "discriminator": {
+                "propertyName": "tag",
+            },
+        })
+    );
+}
+
+#[test]
+fn derive_complex_enum_with_ref_serde_adjacently_tagged() {
+    #[derive(Serialize)]
+    struct Foo {
+        name: String,
+        age: u32,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "tag", content = "content")]
+        enum Bar {
+            Baz(i32),
+            FooBar(Foo),
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "Baz",
+                            ],
+                        },
+                        "content": {
+                            "type": "integer",
+                            "format": "int32",
+                        },
+                    },
+                    "required": [
+                        "tag",
+                        "content"
+                    ],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "FooBar",
+                            ],
+                        },
+                        "content": {
+                            "$ref": "#/components/schemas/Foo"
+                        },
+                    },
+                    "required": [
+                        "tag",
+                        "content"
+                    ],
+                },
+            ],
+            "discriminator": {
+                "propertyName": "tag",
+            },
+        })
+    );
+}
+
+#[test]
+fn derive_complex_enum_with_ref_serde_adjacently_tagged_named_fields() {
+    #[derive(Serialize, ToSchema)]
+    struct Bar {
+        name: String,
+        age: u32,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "tag", content = "content")]
+        enum Foo {
+            One { n: i32 },
+            Two { bar: Bar },
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "One",
+                            ],
+                        },
+                        "content": {
+                            "type": "object",
+                            "properties": {
+                                "n": {
+                                    "format": "int32",
+                                    "type": "integer",
+                                },
+                            },
+                            "required": [
+                                "n",
+                            ],
+                        },
+                    },
+                    "required": [
+                      "tag",
+                      "content"
+                    ],
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "tag": {
+                            "type": "string",
+                            "enum": [
+                                "Two",
+                            ],
+                        },
+                        "content": {
+                            "type": "object",
+                            "properties": {
+                                "bar": {
+                                    "$ref": "#/components/schemas/Bar",
+                                },
+                            },
+                            "required": [
+                                "bar",
+                            ],
+                        },
+                    },
+                    "required": [
+                      "tag",
+                      "content",
+                    ],
+                },
+            ],
+            "discriminator": {
+                "propertyName": "tag",
+            },
+        })
+    );
+}
+
+#[test]
 fn derive_complex_enum_serde_tag_title() {
     #[derive(Serialize)]
     struct Foo(String);


### PR DESCRIPTION
This brings support for all kinds of [serde enum reprensentations](https://serde.rs/enum-representations.html).

Unit tests included, on top of which we tried generating Typescript bindings using openapi-generator (typescript-axios generator, not because of `Axios` but because the generated types are simple to understand). They do indeed look good, so we're confident that this works mostly like it should.

Maybe some missing docs? Could be done in a separate PR? If you feel like it, please provide examples of what needs an update.

Fixes #320 
Fixes #219 