### PR TITLE
Add `ToResponse` derive implementation

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -43,6 +43,8 @@ use crate::path::{Path, PathAttr};
 ))]
 use ext::ArgumentResolver;
 
+use self::path::response::DeriveResponse;
+
 #[proc_macro_error]
 #[proc_macro_derive(ToSchema, attributes(schema, aliases))]
 /// ToSchema derive macro.
@@ -1693,6 +1695,28 @@ pub fn into_params(input: TokenStream) -> TokenStream {
     };
 
     into_params.to_token_stream().into()
+}
+
+#[proc_macro_error]
+#[proc_macro_derive(ToResponse, attributes(response))]
+/// Derive response macro attribute
+pub fn to_response(input: TokenStream) -> TokenStream {
+    let DeriveInput {
+        attrs,
+        ident,
+        generics,
+        data,
+        ..
+    } = syn::parse_macro_input!(input);
+
+    let response = DeriveResponse {
+        attributes: attrs,
+        ident,
+        generics,
+        data,
+    };
+
+    response.to_token_stream().into()
 }
 
 /// Tokenizes slice or Vec of tokenizable items as array either with reference (`&[...]`)

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1698,7 +1698,7 @@ pub fn into_params(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_error]
-#[proc_macro_derive(ToResponse, attributes(response))]
+#[proc_macro_derive(ToResponse, attributes(response, content))]
 /// Derive response macro attribute
 pub fn to_response(input: TokenStream) -> TokenStream {
     let DeriveInput {

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -34,7 +34,7 @@ pub mod example;
 mod media_type;
 pub mod parameter;
 mod request_body;
-mod response;
+pub mod response;
 mod status;
 
 pub(crate) const PATH_STRUCT_PREFIX: &str = "__path_";

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -1,7 +1,7 @@
 use assert_json_diff::assert_json_eq;
 use serde_json::{json, Value};
 use utoipa::{
-    openapi::{Response, ResponseBuilder},
+    openapi::{RefOr, Response, ResponseBuilder},
     OpenApi, ToResponse,
 };
 
@@ -114,10 +114,10 @@ fn derive_openapi_with_responses() {
     struct MyResponse;
 
     impl ToResponse for MyResponse {
-        fn response() -> (String, Response) {
+        fn response() -> (String, RefOr<Response>) {
             (
                 "MyResponse".to_string(),
-                ResponseBuilder::new().description("Ok").build(),
+                ResponseBuilder::new().description("Ok").build().into(),
             )
         }
     }

--- a/utoipa-gen/tests/response_derive_test.rs
+++ b/utoipa-gen/tests/response_derive_test.rs
@@ -243,3 +243,63 @@ fn derive_response_multiple_examples() {
         })
     )
 }
+
+#[test]
+fn derive_response_with_enum_contents() {
+    #[allow(unused)]
+    struct Admin {
+        name: String,
+    }
+    #[allow(unused)]
+    struct Moderator {
+        name: String,
+    }
+    #[derive(ToSchema, ToResponse)]
+    #[allow(unused)]
+    enum Person {
+        #[response(examples(
+                ("Person1" = (value = json!({"name": "name1"}))),
+                ("Person2" = (value = json!({"name": "name2"})))
+        ))]
+        Admin(#[content("application/json/1")] Admin),
+        #[response(example = json!({"name": "name3"}))]
+        Moderator(#[content("application/json/2")] Moderator),
+    }
+    let (name, v) = <Person as utoipa::ToResponse>::response();
+    let value = serde_json::to_value(v).unwrap();
+
+    assert_eq!("Person", name);
+    assert_json_eq!(
+        value,
+        json!({
+            "content": {
+                "application/json/1": {
+                    "examples": {
+                        "Person1": {
+                            "value": {
+                                "name": "name1"
+                            }
+                        },
+                        "Person2": {
+                            "value": {
+                                "name": "name2"
+                            }
+                        }
+                    },
+                    "schema": {
+                        "$ref": "#/components/schemas/Admin"
+                    }
+                },
+                "application/json/2": {
+                    "example": {
+                        "name": "name3"
+                    },
+                    "schema": {
+                        "$ref": "#/components/schemas/Moderator"
+                    }
+                }
+            },
+            "description": ""
+        })
+    )
+}

--- a/utoipa-gen/tests/response_derive_test.rs
+++ b/utoipa-gen/tests/response_derive_test.rs
@@ -1,0 +1,245 @@
+use assert_json_diff::assert_json_eq;
+use serde_json::json;
+use utoipa::ToSchema;
+use utoipa_gen::ToResponse;
+
+#[test]
+fn derive_name_struct_response() {
+    #[derive(ToResponse)]
+    #[allow(unused)]
+    struct Person {
+        name: String,
+    }
+    let (name, v) = <Person as utoipa::ToResponse>::response();
+    let value = serde_json::to_value(v).unwrap();
+
+    assert_eq!("Person", name);
+    assert_json_eq!(
+        value,
+        json!({
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "$ref": "#/components/schemas/Person"
+                    }
+                }
+            },
+            "description": ""
+        })
+    )
+}
+
+#[test]
+fn derive_unnamed_struct_response() {
+    #[derive(ToResponse)]
+    #[allow(unused)]
+    struct Person(Vec<String>);
+
+    let (name, v) = <Person as utoipa::ToResponse>::response();
+    let value = serde_json::to_value(v).unwrap();
+
+    assert_eq!("Person", name);
+    assert_json_eq!(
+        value,
+        json!({
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                }
+            },
+            "description": ""
+        })
+    )
+}
+
+#[test]
+fn derive_enum_response() {
+    #[derive(ToResponse)]
+    #[allow(unused)]
+    enum PersonType {
+        Value(String),
+        Foobar,
+    }
+    let (name, v) = <PersonType as utoipa::ToResponse>::response();
+    let value = serde_json::to_value(v).unwrap();
+
+    assert_eq!("PersonType", name);
+    assert_json_eq!(
+        value,
+        json!({
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "$ref": "#/components/schemas/PersonType"
+                    }
+                }
+            },
+            "description": ""
+        })
+    )
+}
+
+#[test]
+fn derive_struct_response_with_description() {
+    /// This is description
+    ///
+    /// It will also be used in `ToSchema` if present
+    #[derive(ToResponse)]
+    #[allow(unused)]
+    struct Person {
+        name: String,
+    }
+    let (name, v) = <Person as utoipa::ToResponse>::response();
+    let value = serde_json::to_value(v).unwrap();
+
+    assert_eq!("Person", name);
+    assert_json_eq!(
+        value,
+        json!({
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "$ref": "#/components/schemas/Person"
+                    }
+                }
+            },
+            "description": "This is description\n\nIt will also be used in `ToSchema` if present"
+        })
+    )
+}
+
+#[test]
+fn derive_response_with_attributes() {
+    /// This is description
+    ///
+    /// It will also be used in `ToSchema` if present
+    #[derive(ToSchema, ToResponse)]
+    #[response(
+        description = "Override description for response",
+        content_type = "text/xml"
+    )]
+    #[response(
+        example = json!({"name": "the name"}),
+        headers(
+            ("csrf-token", description = "response csrf token"),
+            ("random-id" = i32)
+        )
+    )]
+    #[allow(unused)]
+    struct Person {
+        name: String,
+    }
+    let (name, v) = <Person as utoipa::ToResponse>::response();
+    let value = serde_json::to_value(v).unwrap();
+
+    assert_eq!("Person", name);
+    assert_json_eq!(
+        value,
+        json!({
+            "content": {
+                "text/xml": {
+                    "example": {
+                        "name": "the name"
+                    },
+                    "schema": {
+                        "$ref": "#/components/schemas/Person"
+                    }
+                }
+            },
+            "description": "Override description for response",
+            "headers": {
+                "csrf-token": {
+                    "description": "response csrf token",
+                    "schema": {
+                        "type": "string"
+                    }
+                },
+                "random-id": {
+                    "schema": {
+                        "type": "integer",
+                        "format": "int32"
+                    }
+                }
+            }
+        })
+    )
+}
+
+#[test]
+fn derive_response_with_mutliple_content_types() {
+    #[derive(ToSchema, ToResponse)]
+    #[response(content_type = ["application/json", "text/xml"] )]
+    #[allow(unused)]
+    struct Person {
+        name: String,
+    }
+    let (name, v) = <Person as utoipa::ToResponse>::response();
+    let value = serde_json::to_value(v).unwrap();
+
+    assert_eq!("Person", name);
+    assert_json_eq!(
+        value,
+        json!({
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "$ref": "#/components/schemas/Person"
+                    }
+                },
+                "text/xml": {
+                    "schema": {
+                        "$ref": "#/components/schemas/Person"
+                    }
+                }
+            },
+            "description": ""
+        })
+    )
+}
+
+#[test]
+fn derive_response_multiple_examples() {
+    #[derive(ToSchema, ToResponse)]
+    #[response(examples(
+            ("Person1" = (value = json!({"name": "name1"}))),
+            ("Person2" = (value = json!({"name": "name2"})))
+    ))]
+    #[allow(unused)]
+    struct Person {
+        name: String,
+    }
+    let (name, v) = <Person as utoipa::ToResponse>::response();
+    let value = serde_json::to_value(v).unwrap();
+
+    assert_eq!("Person", name);
+    assert_json_eq!(
+        value,
+        json!({
+            "content": {
+                "application/json": {
+                    "examples": {
+                        "Person1": {
+                            "value": {
+                                "name": "name1"
+                            }
+                        },
+                        "Person2": {
+                            "value": {
+                                "name": "name2"
+                            }
+                        }
+                    },
+                    "schema": {
+                        "$ref": "#/components/schemas/Person"
+                    }
+                },
+            },
+            "description": ""
+        })
+    )
+}

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -590,6 +590,8 @@ pub trait IntoResponses {
 /// This trait is implemented to document a type which represents a single response which can be
 /// referenced or reused as a component in multiple operations.
 ///
+/// _`ToResponse`_ trait can also be derived with [`#[derive(ToResponse)]`][derive].
+///
 /// # Examples
 ///
 /// ```
@@ -609,6 +611,8 @@ pub trait IntoResponses {
 ///     }
 /// }
 /// ```
+///
+/// [derive]: derive.ToResponse.html
 pub trait ToResponse {
     /// Returns a map of response component name (to be referenced) to a response.
     fn response() -> (String, openapi::RefOr<openapi::response::Response>);

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -594,14 +594,14 @@ pub trait IntoResponses {
 ///
 /// ```
 /// use utoipa::{
-///     openapi::{Response, ResponseBuilder},
+///     openapi::{RefOr, Response, ResponseBuilder},
 ///     ToResponse,
 /// };
 ///
 /// struct MyResponse;
 ///
 /// impl ToResponse for MyResponse {
-///     fn response() -> (String, utoipa::openapi::RefOr<Response>) {
+///     fn response() -> (String, RefOr<Response>) {
 ///         (
 ///             "MyResponse".to_string(),
 ///             ResponseBuilder::new().description("My Response").build().into(),

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -216,7 +216,6 @@ pub mod openapi;
 
 use std::collections::BTreeMap;
 
-use openapi::Response;
 pub use utoipa_gen::*;
 
 /// Trait for implementing OpenAPI specification in Rust.
@@ -585,7 +584,7 @@ pub trait IntoParams {
 /// ```
 pub trait IntoResponses {
     /// Returns an ordered map of response codes to responses.
-    fn responses() -> BTreeMap<String, openapi::RefOr<Response>>;
+    fn responses() -> BTreeMap<String, openapi::RefOr<openapi::response::Response>>;
 }
 
 /// This trait is implemented to document a type which represents a single response which can be
@@ -602,15 +601,15 @@ pub trait IntoResponses {
 /// struct MyResponse;
 ///
 /// impl ToResponse for MyResponse {
-///     fn response() -> (String, Response) {
+///     fn response() -> (String, utoipa::openapi::RefOr<Response>) {
 ///         (
 ///             "MyResponse".to_string(),
-///             ResponseBuilder::new().description("My Response").build(),
+///             ResponseBuilder::new().description("My Response").build().into(),
 ///         )
 ///     }
 /// }
 /// ```
 pub trait ToResponse {
     /// Returns a map of response component name (to be referenced) to a response.
-    fn response() -> (String, Response);
+    fn response() -> (String, openapi::RefOr<openapi::response::Response>);
 }


### PR DESCRIPTION
Add new `ToResponse` derive attribute macro. This can be used alternatively to generate path response. It support all the attributes which are supported in tuple response syntax to further configure the generated response. By default the name of the `struct` which is decorated with `ToResponse` macro will be used as a name for the response and as response type as well.

To define simple response component where name of the repsonse and schema must be same one can use named field struct or enum without `content` attributes.
```rust
 #[derive(utoipa::ToSchema, utoipa::ToResponse)]
 struct Person {
     name: String,
 }
```

To define multiple contents for single response one must use enum style definition.
```rust
 #[derive(utoipa::ToResponse)]
 enum Foo {
   Foo(#[content("type")] Foo),
   Bar(#[content("type")] Bar),
 }
```

To define `Vec` or `Option` response the new type pattern must be used.
```rust
 #[derive(utoipa::ToResponse)]
 struct MyResponse(Vec<String>);
```

#412 