### PR TITLE
Enhance `ToResponse` implementation

### DIFF
--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -216,14 +216,14 @@ impl ToTokens for UnitStructVariant {
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
-struct NamedStructSchema<'a> {
-    struct_name: Cow<'a, str>,
-    fields: &'a Punctuated<Field, Comma>,
-    attributes: &'a [Attribute],
-    features: Option<Vec<Feature>>,
-    rename_all: Option<RenameAll>,
-    generics: Option<&'a Generics>,
-    alias: Option<&'a AliasSchema>,
+pub struct NamedStructSchema<'a> {
+    pub struct_name: Cow<'a, str>,
+    pub fields: &'a Punctuated<Field, Comma>,
+    pub attributes: &'a [Attribute],
+    pub features: Option<Vec<Feature>>,
+    pub rename_all: Option<RenameAll>,
+    pub generics: Option<&'a Generics>,
+    pub alias: Option<&'a AliasSchema>,
 }
 
 impl NamedStructSchema<'_> {
@@ -483,10 +483,10 @@ impl ToTokens for UnnamedStructSchema<'_> {
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
-struct EnumSchema<'a> {
-    enum_name: Cow<'a, str>,
-    variants: &'a Punctuated<Variant, Comma>,
-    attributes: &'a [Attribute],
+pub struct EnumSchema<'a> {
+   pub enum_name: Cow<'a, str>,
+   pub variants: &'a Punctuated<Variant, Comma>,
+   pub attributes: &'a [Attribute],
 }
 
 impl ToTokens for EnumSchema<'_> {

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1737,7 +1737,7 @@ pub fn into_params(input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_error]
-#[proc_macro_derive(ToResponse, attributes(response, content))]
+#[proc_macro_derive(ToResponse, attributes(response, content, to_schema))]
 /// Derive response macro.
 ///
 /// This is `#[derive]` implementation for [`ToResponse`][to_response] trait.

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1742,17 +1742,28 @@ pub fn into_params(input: TokenStream) -> TokenStream {
 ///
 /// This is `#[derive]` implementation for [`ToResponse`][to_response] trait.
 ///
-/// _`ToResponse`_ can be used in three different ways to generate OpenAPI response component.
 ///
-/// 1. By decorating `struct` or `enum` with [`ToResponse`] derive macro. This is the simpliest
-///    form of response and is typically useful used in tandem with [`ToSchema`] derive macro. This
-///    will create a response with name of the decorated _`struct`_ or _`enum`_ and will expect
-///    that existing schema is created with same name as well.
+/// _`#[response]`_ attribute can be used to alter and add [response attributes](#toresponse-response-attributes).
+///
+/// _`#[content]`_ attributes is used to make enum variant a content of a specific type for the
+/// response.
+///
+/// _`#[to_schema]`_ attribute is used to inline a schema for a response in unnamed structs or
+/// enum variants with `#[content]` attribute. **Note!** [`ToSchema`] need to be implemented for
+/// the field or variant type.
+///
+/// Type derived with _`ToResponse`_ uses doc comment provided as a description for the reponse. It
+/// can alternatively be overridden with _`description = ...`_ attribute.
+///
+/// _`ToResponse`_ can be used in four different ways to generate OpenAPI response component.
+///
+/// 1. By decorating `struct` or `enum` with [`ToResponse`] derive macro. This will create a
+///    response with inlined schema resolved from the fields of the `struct` or `variants` of the
+///    enum.
 ///
 ///    ```rust
-///     # use utoipa::{ToResponse, ToSchema};
-///     /// Person entity
-///     #[derive(ToResponse, ToSchema)]
+///     # use utoipa::ToResponse;
+///     #[derive(ToResponse)]
 ///     #[response(description = "Person response returns single Person entity")]
 ///     struct Person {
 ///         name: String,
@@ -1762,6 +1773,8 @@ pub fn into_params(input: TokenStream) -> TokenStream {
 /// 2. By decorating unnamed field `struct` with [`ToResponse`] derive macro. Unnamed field struct
 ///    allows users to use new type pattern to define one inner field which is used as a schema for
 ///    the generated response. This allows users to define `Vec` and `Option` response types.
+///    Additionally these types can also be used with `#[to_schema]` attribute to inline the
+///    field's type schema if it implements [`ToSchema`] derive macro.
 ///
 ///    ```rust
 ///     # #[derive(utoipa::ToSchema)]
@@ -1773,10 +1786,21 @@ pub fn into_params(input: TokenStream) -> TokenStream {
 ///     struct PersonList(Vec<Person>);
 ///    ```
 ///
-/// 3. By deocrating `enum` with variants having `#[content(...)]` attribute. This allows users to
+/// 3. By decorating unit struct with [`ToResponse`] derive macro. Unit structs will produce a
+///    response without body.
+///
+///    ```rust
+///     //// Success response which does not have body.
+///     #[derive(utoipa::ToResponse)]
+///     struct SuccessResponse;
+///    ```
+///
+/// 4. By deocrating `enum` with variants having `#[content(...)]` attribute. This allows users to
 ///    define multiple response content schemas to single response according to OpenAPI spec.
 ///    **Note!** Enum with _`content`_ attribute in variants cannot have enum level _`example`_ or
-///    _`examples`_ defined. Instead examples need to be defined per variant basis.
+///    _`examples`_ defined. Instead examples need to be defined per variant basis. Additionally
+///    these variants can also be used with `#[to_schema]` attribute to inline the variant's type schema
+///    if it implements [`ToSchema`] derive macro.
 ///
 ///    ```rust
 ///     #[derive(utoipa::ToSchema)]
@@ -1798,13 +1822,14 @@ pub fn into_params(input: TokenStream) -> TokenStream {
 ///         Admin(#[content("application/vnd-custom-v1+json")] Admin),
 ///
 ///         #[response(example = json!({"name": "name3", "id": 1}))]
-///         Admin2(#[content("application/vnd-custom-v2+json")] Admin2),
+///         Admin2(#[content("application/vnd-custom-v2+json")] #[to_schema] Admin2),
 ///     }
 ///    ```
 ///
 /// # ToResponse `#[response(...)]` attributes
 ///
-/// * `description = "..."` Define description for the response as str.
+/// * `description = "..."` Define description for the response as str. This can be used to
+///   override the default description resolved from doc comments if present.
 ///
 /// * `content_type = "..." | content_type = [...]` Can be used to override the default behavior of auto resolving the content type
 ///   from the `body` attribute. If defined the value should be valid content type such as
@@ -1858,6 +1883,26 @@ pub fn into_params(input: TokenStream) -> TokenStream {
 ///  )]
 ///  struct Person {
 ///      name: String,
+///  }
+/// ```
+///
+/// _**Create inlined person list response.**_
+/// ```rust
+///  # #[derive(utoipa::ToSchema)]
+///  # struct Person {
+///  #     name: String,
+///  # }
+///  /// Person list response
+///  #[derive(utoipa::ToResponse)]
+///  struct PersonList(#[to_schema] Vec<Person>);
+/// ```
+///
+/// _**Create enum response from variants.**_
+/// ```rust
+///  #[derive(utoipa::ToResponse)]
+///  enum PersonType {
+///      Value(String),
+///      Foobar,
 ///  }
 /// ```
 ///

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -537,6 +537,7 @@ impl ToTokens for Operation<'_> {
 enum PathType {
     Ref(String),
     Type(InlineType),
+    InlineSchema(TokenStream2, Type),
 }
 
 impl Parse for PathType {

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -622,8 +622,13 @@ fn path_response_with_inline_ref_type() {
                 "content": {
                     "application/json": {
                         "schema": {
-                            "$ref":
-                                "#/components/schemas/User",
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["name"],
+                            "type": "object",
                         },
                     },
                 },


### PR DESCRIPTION
This commit will add support for unit type responses. Structs without fields will be threated as a responses without body.

```rust
 #[derive(ToSchema, ToResponse)]
 struct PersonSuccessResponse;
```

This commit changes `ToResponse` behaviour in named field structs and enums without `#[content]` attribute so that the fields and variants of those types will become inlined schema for the response. Prior to this PR `ToSchema` ignored fields and variants of those types and created a reference to the type having same name as response. That behaviour was not correct and was illogical since you can use new type pattern to create a reference response.

```rust
 #[derive(ToResponse)]
 struct Person {
     name: String,
 }
```

Add new attribute `#[to_schema]` which can be used to inline schema of unnamed field struct or enum variant which already has `#[content]` attribute. Without `#[to_schema]` attribute response will be created with a reference to the field type.

```rust
 #[derive(ToResponse)]
 struct PersonSuccessResponse(#[to_schema] Vec<Person>);
```

#412 