### PR TITLE
Fix empty string path parameter name for Axum

### DIFF
--- a/utoipa-gen/src/ext/axum.rs
+++ b/utoipa-gen/src/ext/axum.rs
@@ -41,12 +41,12 @@ fn get_value_arguments(value_args: Vec<FnArg>) -> impl Iterator<Item = super::Va
         .into_iter()
         .filter(|arg| arg.ty.is("Path"))
         .flat_map(|path_arg| match path_arg.arg_type {
-            FnArgType::Single(_) => path_arg
+            FnArgType::Single(name) => path_arg
                 .ty
                 .children
                 .expect("Path argument must have children")
                 .into_iter()
-                .map(|ty| to_value_argument(None, ty))
+                .map(|ty| to_value_argument(Some(Cow::Owned(name.to_string())), ty))
                 .collect::<Vec<_>>(),
             FnArgType::Tuple(tuple) => tuple
                 .iter()


### PR DESCRIPTION
Using `#[utoipa::path(...)]` with the axum path extractor (`axum::extract::Path`) yields empty parameter names in the resulting OpenAPI spec, i.e. 
```yaml
      parameters:
      - name: ''
        in: path
        required: true
        deprecated: false
        schema:
          type: integer
          format: int64
```

This PR fixes this, however there is a small catch: the name of the parameter defined in `#[utoipa::path(..., path = ...)` must match the name of the ident found in the parameters.