### PR TITLE
Add `preserve_order` feature to preserve property order

### DIFF
--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -32,6 +32,7 @@ time = ["utoipa-gen/time"]
 smallvec = ["utoipa-gen/smallvec"]
 openapi_extensions = []
 repr = ["utoipa-gen/repr"]
+preserve_order = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
As discussed in #428, this PR introduces a cargo feature named `preserve_order` to retain property order when serializing a component schema.

Closes #428.