### PR TITLE
Document `preserve_order` feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also awesome type of beer :be
   See the [`request_body` docs](https://docs.rs/utoipa/latest/utoipa/openapi/request_body) for an example.
 - **repr** Add support for [repr_serde](https://github.com/dtolnay/serde-repr)'s `repr(u*)` and `repr(i*)` attributes to unit type enums for
   C-like enum representation. See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html) for more details.
+- **preserve_order** Preserve order of properties when serializing the schema for a component.
+  When enabled, the properties are listed in order of fields in the corresponding struct definition.
+  When disabled, the properties are listed in alphabetical order.
 
 Utoipa implicitly has partial support for `serde` attributes. See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html#partial-serde-attributes-support) for more details.
 

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -74,6 +74,9 @@
 //!   [`response`](https://docs.rs/utoipa/latest/utoipa/openapi/response/index.html) docs for examples.
 //! * **repr** Add support for [repr_serde](https://github.com/dtolnay/serde-repr)'s `repr(u*)` and `repr(i*)` attributes to unit type enums for
 //!   C-like enum representation. See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html) for more details.
+//! * **preserve_order** Preserve order of properties when serializing the schema for a component.
+//!   When enabled, the properties are listed in order of fields in the corresponding struct definition.
+//!   When disabled, the properties are listed in alphabetical order.
 //!
 //! Utoipa implicitly has partial support for `serde` attributes. See [`ToSchema` derive][serde] for more details.
 //!


### PR DESCRIPTION
This PR documents the `preserve_order` feature flag added in PR #436. 

I forgot to add relevant documentation when I was working on my previous PR. Let me know if any more files have to be updated.