### PR TITLE
Refactor to schema casting as

### DIFF
--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -542,7 +542,7 @@ impl ToTokens for ParamSchema<'_> {
                             .expect("component should have a path");
                         if self.schema_features.is_inline() {
                             tokens.extend(quote_spanned! {component_path.span()=>
-                                <#component_path as utoipa::ToSchema>::schema()
+                                <#component_path as utoipa::ToSchema>::schema().1
                             })
                         } else if component.is_object() {
                             tokens.extend(quote! {

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -10,7 +10,7 @@ use syn::{
 };
 
 use crate::{
-    component::features::{Rename, Title},
+    component::features::Rename,
     doc_comment::CommentAttributes,
     schema_type::{SchemaFormat, SchemaType},
     Array, Deprecated,
@@ -555,7 +555,7 @@ impl<'e> EnumSchema<'e> {
                                 Ok(parse_features!(
                                     input as super::features::Example,
                                     super::features::Default,
-                                    Title,
+                                    super::features::Title,
                                     As
                                 ))
                             })

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -5,7 +5,7 @@ use syn::{
 };
 
 use crate::component::features::{
-    impl_into_inner, impl_merge, parse_features, Default, Example, ExclusiveMaximum,
+    impl_into_inner, impl_merge, parse_features, As, Default, Example, ExclusiveMaximum,
     ExclusiveMinimum, Feature, Format, Inline, IntoInner, MaxItems, MaxLength, MaxProperties,
     Maximum, Merge, MinItems, MinLength, MinProperties, Minimum, MultipleOf, Nullable, Pattern,
     ReadOnly, Rename, RenameAll, SchemaWith, Title, ValueType, WriteOnly, XmlAttr,
@@ -22,7 +22,8 @@ impl Parse for NamedFieldStructFeatures {
             Title,
             RenameAll,
             MaxProperties,
-            MinProperties
+            MinProperties,
+            As
         )))
     }
 }
@@ -39,7 +40,8 @@ impl Parse for UnnamedFieldStructFeatures {
             Default,
             Title,
             Format,
-            ValueType
+            ValueType,
+            As
         )))
     }
 }
@@ -54,7 +56,8 @@ impl Parse for EnumFeatures {
             input as Example,
             Default,
             Title,
-            RenameAll
+            RenameAll,
+            As
         )))
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -284,7 +284,7 @@ use self::path::response::derive::{IntoResponses, ToResponse};
 /// _**You can use `skip` and `tag` attributes from serde.**_
 /// ```rust
 /// # use utoipa::ToSchema;
-/// #[derive(ToSchema)]
+/// #[derive(ToSchema, serde::Serialize)]
 /// #[repr(i8)]
 /// #[serde(tag = "code")]
 /// enum ExitCode {

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -78,6 +78,9 @@ use self::path::response::derive::{IntoResponses, ToResponse};
 /// * `rename_all = ...` Supports same syntax as _serde_ _`rename_all`_ attribute. Will rename all fields
 ///   of the structs accordingly. If both _serde_ `rename_all` and _schema_ _`rename_all`_ are defined
 ///   __serde__ will take precedence.
+/// * `as = ...` Can be used to define alternative path and name for the schema what will be used in
+///   the OpenAPI. E.g _`as = path::to::Pet`_. This would make the schema appear in the generated
+///   OpenAPI spec as _`path.to.Pet`_.
 ///
 /// # Enum Optional Configuration Options for `#[schema(...)]`
 /// * `example = ...` Can be method reference or _`json!(...)`_.
@@ -88,6 +91,9 @@ use self::path::response::derive::{IntoResponses, ToResponse};
 /// * `rename_all = ...` Supports same syntax as _serde_ _`rename_all`_ attribute. Will rename all
 ///   variants of the enum accordingly. If both _serde_ `rename_all` and _schema_ _`rename_all`_
 ///   are defined __serde__ will take precedence.
+/// * `as = ...` Can be used to define alternative path and name for the schema what will be used in
+///   the OpenAPI. E.g _`as = path::to::Pet`_. This would make the schema appear in the generated
+///   OpenAPI spec as _`path.to.Pet`_.
 ///
 /// # Enum Variant Optional Configuration Options for `#[schema(...)]`
 /// Supports all variant specific configuration options e.g. if variant is _`UnnamedStruct`_ then
@@ -111,6 +117,9 @@ use self::path::response::derive::{IntoResponses, ToResponse};
 /// * `title = ...` Literal string value. Can be used to define title for struct in OpenAPI
 ///   document. Some OpenAPI code generation libraries also use this field as a name for the
 ///   struct.
+/// * `as = ...` Can be used to define alternative path and name for the schema what will be used in
+///   the OpenAPI. E.g _`as = path::to::Pet`_. This would make the schema appear in the generated
+///   OpenAPI spec as _`path.to.Pet`_.
 ///
 /// # Named Fields Optional Configuration Options for `#[schema(...)]`
 /// * `example = ...` Can be method reference or _`json!(...)`_.
@@ -239,40 +248,27 @@ use self::path::response::derive::{IntoResponses, ToResponse};
 ///
 /// # `#[repr(...)]` attribute support
 ///
-/// ToSchema derive has support for `repr(u*)` and `repr(i*)` attributes for field-less enums.
-/// This allows you to create enums from their discriminant values.
-/// **repr** feature need to be enabled.
-/// Otherwise, string representations of the fields will be used as values.
+/// [Serde repr](https://github.com/dtolnay/serde-repr) allows field-less enums be represented by
+/// their numeric value.
+///
+/// * `repr(u*)` for unsigned integer.
+/// * `repr(i*)` for signed integer.
+///
+/// **Supported schema attributes**
+///
+/// * `example = ...` Can be method reference or _`json!(...)`_.
+/// * `default = ...` Can be method reference or _`json!(...)`_.
+/// * `title = ...` Literal string value. Can be used to define title for enum in OpenAPI
+///   document. Some OpenAPI code generation libraries also use this field as a name for the
+///   enum. __Note!__  ___Complex enum (enum with other than unit variants) does not support title!___
+/// * `as = ...` Can be used to define alternative path and name for the schema what will be used in
+///   the OpenAPI. E.g _`as = path::to::Pet`_. This would make the schema appear in the generated
+///   OpenAPI spec as _`path.to.Pet`_.
+///
+/// _**Create enum with numeric values.**_
 /// ```rust
-/// # use serde::{Deserialize, Serialize};
 /// # use utoipa::ToSchema;
-/// #[derive(ToSchema, Deserialize, Serialize)]
-/// #[repr(u8)]
-/// enum ApiVersion {
-///     One = 1,
-///     Two,
-///     Three,
-/// }
-/// ```
-/// _**You can use `skip` and `tag` attributes from serde.**_
-/// ```rust
-/// # use serde::{Deserialize, Serialize};
-/// # use utoipa::ToSchema;
-/// #[derive(ToSchema, Deserialize, Serialize)]
-/// #[repr(i8)]
-/// #[serde(tag = "code")]
-/// enum ExitCode {
-///     Error = -1,
-///     #[serde(skip)]
-///     Unknown = 0,
-///     Ok = 1,
-///  }
-/// ```
-/// _**As well as [`schema attributes`][enum_schema] for enums.**_
-/// ```rust
-/// # use serde::{Deserialize, Serialize};
-/// # use utoipa::ToSchema;
-/// #[derive(ToSchema, Deserialize, Serialize)]
+/// #[derive(ToSchema)]
 /// #[repr(u8)]
 /// #[schema(default = default_value, example = 2)]
 /// enum Mode {
@@ -283,6 +279,20 @@ use self::path::response::derive::{IntoResponses, ToResponse};
 /// fn default_value() -> u8 {
 ///     1
 /// }
+/// ```
+///
+/// _**You can use `skip` and `tag` attributes from serde.**_
+/// ```rust
+/// # use utoipa::ToSchema;
+/// #[derive(ToSchema)]
+/// #[repr(i8)]
+/// #[serde(tag = "code")]
+/// enum ExitCode {
+///     Error = -1,
+///     #[serde(skip)]
+///     Unknown = 0,
+///     Ok = 1,
+///  }
 /// ```
 ///
 /// # Generic schemas with aliases
@@ -537,6 +547,16 @@ use self::path::response::derive::{IntoResponses, ToResponse};
 ///     #[schema(schema_with = custom_type)]
 ///     id: String,
 /// }
+/// ```
+///
+/// _**Use `as` attribute to change the name and the path of the schema in the generated OpenAPI
+/// spec.**_
+/// ```rust
+///  #[derive(utoipa::ToSchema)]
+///  #[schema(as = api::models::person::Person)]
+///  struct Person {
+///      name: String,
+///  }
 /// ```
 ///
 /// More examples for _`value_type`_ in [`IntoParams` derive docs][into_params].

--- a/utoipa-gen/src/path/media_type.rs
+++ b/utoipa-gen/src/path/media_type.rs
@@ -115,7 +115,7 @@ impl ToTokens for MediaTypeSchema<'_> {
                             })
                         } else if *is_inline {
                             tokens.extend(quote_spanned! {path.span()=>
-                                <#path as utoipa::ToSchema>::schema()
+                                <#path as utoipa::ToSchema>::schema().1
                             })
                         } else {
                             let name = type_tree

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -273,6 +273,7 @@ impl NamedStructResponse<'_> {
             generics: None,
             rename_all: None,
             struct_name: Cow::Owned(ident.to_string()),
+            schema_as: None,
         };
 
         let ty = Self::to_type(ident);
@@ -338,6 +339,7 @@ impl<'p> ToResponseNamedStructResponse<'p> {
             attributes,
             struct_name: Cow::Owned(ident.to_string()),
             rename_all: None,
+            schema_as: None,
         };
         let response_type = PathType::InlineSchema(inline_schema.to_token_stream(), ty);
 
@@ -442,11 +444,8 @@ impl<'r> EnumResponse<'r> {
             description,
         });
         response_value.response_type = if content.is_empty() {
-            let inline_schema = EnumSchema {
-                variants,
-                attributes,
-                enum_name: Cow::Owned(ident.to_string()),
-            };
+            let inline_schema =
+                EnumSchema::new(Cow::Owned(ident.to_string()), variants, attributes);
 
             Some(PathType::InlineSchema(
                 inline_schema.into_token_stream(),

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -7,6 +7,7 @@ use utoipa::{
     openapi::{RefOr, Response, ResponseBuilder},
     OpenApi, ToResponse,
 };
+use utoipa_gen::ToSchema;
 
 mod common;
 

--- a/utoipa-gen/tests/request_body_derive_test.rs
+++ b/utoipa-gen/tests/request_body_derive_test.rs
@@ -398,16 +398,25 @@ fn derive_request_body_complex_primitive_array_success() {
 }
 
 test_fn! {
-    module: derive_request_body_primitive_ref_path,
+    module: derive_request_body_ref_path,
     body: = path::to::Foo
 }
 
 #[test]
-fn derive_request_body_primitive_ref_path_success() {
+fn derive_request_body_ref_path_success() {
+    /// Some struct
+    #[derive(ToSchema)]
+    #[schema(as = path::to::Foo)]
+    #[allow(unused)]
+    pub struct Foo {
+        /// Some name
+        name: String,
+    }
+
     #[derive(OpenApi, Default)]
     #[openapi(
-        paths(derive_request_body_primitive_ref_path::post_foo),
-        components(schemas(derive_request_body_primitive_ref_path::Foo as path::to::Foo))
+        paths(derive_request_body_ref_path::post_foo),
+        components(schemas(Foo))
     )]
     struct ApiDoc;
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -21,10 +21,10 @@ macro_rules! api_doc {
         }
     };
     ( @schema $ident:ident < $($life:lifetime , )? $generic:ident > $($tt:tt)* ) => {
-         <$ident<$generic> as utoipa::ToSchema>::schema()
+         <$ident<$generic> as utoipa::ToSchema>::schema().1
     };
     ( @schema $ident:ident $($tt:tt)* ) => {
-         <$ident as utoipa::ToSchema>::schema()
+         <$ident as utoipa::ToSchema>::schema().1
     };
 }
 
@@ -3060,6 +3060,7 @@ fn derive_schema_for_repr_enum() {
     let value = api_doc! {
         #[derive(serde::Deserialize)]
         #[repr(i32)]
+        #[schema(example = 1, default = 0)]
         enum ExitCode {
             Error  = -1,
             Ok     = 0,
@@ -3067,10 +3068,15 @@ fn derive_schema_for_repr_enum() {
         }
     };
 
-    assert_value! {value=>
-        "enum" = r#"[-1,0,1]"#, "ExitCode enum variants"
-        "type" = r#""integer""#, "ExitCode enum type"
-    };
+    assert_json_eq!(
+        value,
+        json!({
+            "enum": [-1, 0, 1],
+            "type": "integer",
+            "default": 0,
+            "example": 1,
+        })
+    );
 }
 
 #[test]
@@ -3539,7 +3545,6 @@ fn derive_unit_struct_schema() {
             "type": "object",
             "nullable": true,
             "default": null,
-            "example": null
         })
     )
 }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -305,6 +305,8 @@ pub trait OpenApi {
 
 /// Trait for implementing OpenAPI Schema object.
 ///
+/// Generated schemas can be referenced or reused in path operations.
+///
 /// This trait is derivable and can be used with `[#derive]` attribute. For a details of
 /// `#[derive(ToSchema)]` refer to [derive documentation][derive].
 ///
@@ -369,8 +371,14 @@ pub trait OpenApi {
 /// }
 /// ```
 pub trait ToSchema<'__s> {
+    /// Return a tuple of name and schema or reference to a schema that can be referenced by the
+    /// name or inlined directly to responses, request bodies or parameters.
     fn schema() -> (&'__s str, openapi::RefOr<openapi::schema::Schema>);
 
+    /// Optional set of alias schemas for the [`ToSchema::schema`].
+    ///
+    /// Typically there is no need to manually implement this method but it is instead implemented
+    /// by derive [`macro@ToSchema`] when `#[aliases(...)]` attribute is defined.
     fn aliases() -> Vec<(&'__s str, openapi::schema::Schema)> {
         Vec::new()
     }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -361,10 +361,10 @@ pub trait OpenApi {
 ///     }
 /// }
 /// ```
-pub trait ToSchema {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema>;
+pub trait ToSchema<'__s> {
+    fn schema() -> (&'__s str, openapi::RefOr<openapi::schema::Schema>);
 
-    fn aliases() -> Vec<(&'static str, openapi::schema::Schema)> {
+    fn aliases() -> Vec<(&'__s str, openapi::schema::Schema)> {
         Vec::new()
     }
 }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -332,32 +332,39 @@ pub trait OpenApi {
 /// #     age: Option<i32>,
 /// # }
 /// #
-/// impl utoipa::ToSchema for Pet {
-///     fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-///         use utoipa::openapi::ToArray;
-///         utoipa::openapi::ObjectBuilder::new()
-///             .property(
-///                 "id",
-///                 utoipa::openapi::ObjectBuilder::new()
-///                     .schema_type(utoipa::openapi::SchemaType::Integer)
-///                     .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int64))),
-///             )
-///             .required("id")
-///             .property(
-///                 "name",
-///                 utoipa::openapi::Object::with_type(utoipa::openapi::SchemaType::String),
-///             )
-///             .required("name")
-///             .property(
-///                 "age",
-///                 utoipa::openapi::ObjectBuilder::new()
-///                     .schema_type(utoipa::openapi::SchemaType::Integer)
-///                     .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int32))),
-///             )
-///             .example(Some(serde_json::json!({
-///               "name": "bob the cat", "id": 1
-///             })))
-///             .into()
+/// impl<'__s> utoipa::ToSchema<'__s> for Pet {
+///     fn schema() -> (&'__s str, utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>) {
+///          (
+///             "Pet",
+///             utoipa::openapi::ObjectBuilder::new()
+///                 .property(
+///                     "id",
+///                     utoipa::openapi::ObjectBuilder::new()
+///                         .schema_type(utoipa::openapi::SchemaType::Integer)
+///                         .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
+///                             utoipa::openapi::KnownFormat::Int64,
+///                         ))),
+///                 )
+///                 .required("id")
+///                 .property(
+///                     "name",
+///                     utoipa::openapi::ObjectBuilder::new()
+///                         .schema_type(utoipa::openapi::SchemaType::String),
+///                 )
+///                 .required("name")
+///                 .property(
+///                     "age",
+///                     utoipa::openapi::ObjectBuilder::new()
+///                         .schema_type(utoipa::openapi::SchemaType::Integer)
+///                         .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
+///                             utoipa::openapi::KnownFormat::Int32,
+///                         ))),
+///                 )
+///                 .example(Some(serde_json::json!({
+///                   "name":"bob the cat","id":1
+///                 })))
+///                 .into(),
+///         )
 ///     }
 /// }
 /// ```


### PR DESCRIPTION
This commit changes the `ToSchema` trait to be similar with `ToResponse` trait. It also introduces lifetimes to avoid unnecessary allocations.
```rust
pub trait ToSchema<'__s> {
    fn schema() -> (&'__s str, openapi::RefOr<openapi::schema::Schema>);

    fn aliases() -> Vec<(&'__s str, openapi::schema::Schema)> {
        Vec::new()
    }
}
```

Prior to this commit the name that was used to register a schema to OpenAPI spec was defined in `#[openapi(components(schemas(...)))]` attribute with syntax like `schemas(path::to::Schema as path::MySchema)`. This is a bit inconvenient at least and behaved completely opposite to how response and request bodies behave when defined in `#[utoipa::path]` macro.

From now the name of the schema registered in OpenAPI spec will be defined by the `ToSchema` trait itself the same way as `ToResponse` does it. It will return a tuple of `(name, component)` pair.

This also introduces new feature `As` what is then used to define alternative name for the schema derived from `ToSchema` if necessary. For example the below struct would be registered to the OpenAPI with name `path.to.Foo` instead of just `Foo` when it is added to openapi with `#[openapi(components(schemas(Foo)))]`.
```rust
 #[derive(ToSchema)]
 #[schema(as = path::to::Foo)]
 pub struct Foo {
     name: String,
 }
```