### PR TITLE
Refactor `ToReponse` trait

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -2072,12 +2072,7 @@ pub fn to_response(input: TokenStream) -> TokenStream {
         ..
     } = syn::parse_macro_input!(input);
 
-    let response = ToResponse {
-        attributes: attrs,
-        ident,
-        generics,
-        data,
-    };
+    let response = ToResponse::new(attrs, &data, generics, ident);
 
     response.to_token_stream().into()
 }

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -522,7 +522,7 @@ impl ToTokens for Components {
                     let Response(path) = responses;
 
                     builder_tokens.extend(quote_spanned! {path.span() =>
-                        .response_from_into::<#path>()
+                        .response_from::<#path>()
                     });
                     builder_tokens
                 });

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -117,10 +117,10 @@ fn derive_openapi_with_responses() {
     #[allow(unused)]
     struct MyResponse;
 
-    impl ToResponse for MyResponse {
-        fn response() -> (String, RefOr<Response>) {
+    impl<'r> ToResponse<'r> for MyResponse {
+        fn response() -> (&'r str, RefOr<Response>) {
             (
-                "MyResponse".to_string(),
+                "MyResponse",
                 ResponseBuilder::new().description("Ok").build().into(),
             )
         }

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -119,10 +119,10 @@ fn derive_http_status_code_responses() {
 
 struct ReusableResponse;
 
-impl ToResponse for ReusableResponse {
-    fn response() -> (String, RefOr<Response>) {
+impl<'r> ToResponse<'r> for ReusableResponse {
+    fn response() -> (&'r str, RefOr<Response>) {
         (
-            String::from("ReusableResponseName"),
+            "ReusableResponseName",
             Response::new("reusable response").into(),
         )
     }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -654,10 +654,10 @@ pub trait IntoResponses {
 ///
 /// struct MyResponse;
 ///
-/// impl ToResponse for MyResponse {
-///     fn response() -> (String, RefOr<Response>) {
+/// impl<'__r> ToResponse<'__r> for MyResponse {
+///     fn response() -> (&'__r str, RefOr<Response>) {
 ///         (
-///             "MyResponse".to_string(),
+///             "MyResponse",
 ///             ResponseBuilder::new().description("My Response").build().into(),
 ///         )
 ///     }
@@ -665,7 +665,7 @@ pub trait IntoResponses {
 /// ```
 ///
 /// [derive]: derive.ToResponse.html
-pub trait ToResponse {
-    /// Returns a map of response component name (to be referenced) to a response.
-    fn response() -> (String, openapi::RefOr<openapi::response::Response>);
+pub trait ToResponse<'__r> {
+    /// Returns a tuple of response component name (to be referenced) to a response.
+    fn response() -> (&'__r str, openapi::RefOr<openapi::response::Response>);
 }

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -180,7 +180,7 @@ impl ComponentsBuilder {
         self
     }
 
-    pub fn response_from_into<I: ToResponse>(self) -> Self {
+    pub fn response_from<'r, I: ToResponse<'r>>(self) -> Self {
         let (name, response) = I::response();
         self.response(name, response)
     }


### PR DESCRIPTION
Refactor `ToResponse` trait to match `ToSchema` with lifetime usage. Update documentation and tests.
```rust
pub trait ToResponse<'__r> {
    fn response() -> (&'__r str, openapi::RefOr<openapi::response::Response>);
}
```