### PR TITLE
Fix explicit lifetimes for consts

### DIFF
--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -51,7 +51,7 @@ pub struct Schema<'a> {
 }
 
 impl<'a> Schema<'a> {
-    const TO_SCHEMA_LIFETIME: &str = "'__s";
+    const TO_SCHEMA_LIFETIME: &'static str = "'__s";
     pub fn new(
         data: &'a Data,
         attributes: &'a [Attribute],

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -31,7 +31,7 @@ pub struct ToResponse<'r> {
 }
 
 impl<'r> ToResponse<'r> {
-    const LIFETIME: &str = "'__r";
+    const LIFETIME: &'static str = "'__r";
 
     pub fn new(
         attributes: Vec<Attribute>,


### PR DESCRIPTION
Introduce explicit lifetimes for `ToSchema` and `ToResponse` lifetime variables to make library build in Rust 1.60. Automatic lifetime elision for const seems to be available from Rust 1.64 onwards and we want to make sure this lib builds in Rust 1.60 as well.