### PR TITLE
Enhance unit type support

### DIFF
--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -565,9 +565,7 @@ impl ToTokens for ParamSchema<'_> {
                         // Detect unit type ()
                         if component.children.is_none() {
                             tokens.extend(quote! {
-                                utoipa::openapi::ObjectBuilder::new()
-                                    .nullable(true)
-                                    .default(Some(serde_json::Value::Null))
+                                utoipa::openapi::schema::empty()
                             })
                         };
                     }

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -246,9 +246,7 @@ struct UnitStructVariant;
 impl ToTokens for UnitStructVariant {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(quote! {
-            utoipa::openapi::schema::ObjectBuilder::new()
-                .nullable(true)
-                .default(Some(serde_json::Value::Null))
+            utoipa::openapi::schema::empty()
         });
     }
 }
@@ -1599,9 +1597,7 @@ impl ToTokens for SchemaProperty<'_> {
                         // Detect unit type ()
                         if type_tree.children.is_none() {
                             tokens.extend(quote! {
-                                utoipa::openapi::ObjectBuilder::new()
-                                    .nullable(true)
-                                    .default(Some(serde_json::Value::Null))
+                                utoipa::openapi::schema::empty()
                             })
                         };
                     }

--- a/utoipa-gen/src/component/schema/enum_variant.rs
+++ b/utoipa-gen/src/component/schema/enum_variant.rs
@@ -215,7 +215,7 @@ pub struct UntaggedEnum;
 
 impl ToTokens for UntaggedEnum {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.extend(quote!(utoipa::openapi::ObjectBuilder::new().nullable(true)));
+        tokens.extend(quote!(utoipa::openapi::schema::empty()));
     }
 }
 

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -81,7 +81,7 @@ impl Parse for OpenApiAttr<'_> {
 
         while !input.is_empty() {
             let ident = input.parse::<Ident>().map_err(|error| {
-                Error::new(error.span(), format!("{}, {}", EXPECTED_ATTRIBUTE, error))
+                Error::new(error.span(), format!("{EXPECTED_ATTRIBUTE}, {error}"))
             })?;
             let attribute = &*ident.to_string();
 
@@ -192,7 +192,7 @@ impl Parse for Tag {
 
         while !input.is_empty() {
             let ident = input.parse::<Ident>().map_err(|error| {
-                syn::Error::new(error.span(), format!("{}, {}", EXPECTED_ATTRIBUTE, error))
+                syn::Error::new(error.span(), format!("{EXPECTED_ATTRIBUTE}, {error}"))
             })?;
             let attribute_name = &*ident.to_string();
 
@@ -469,7 +469,7 @@ impl Parse for Components {
 
         while !content.is_empty() {
             let ident = content.parse::<Ident>().map_err(|error| {
-                Error::new(error.span(), format!("{}, {}", EXPECTED_ATTRIBUTE, error))
+                Error::new(error.span(), format!("{EXPECTED_ATTRIBUTE}, {error}"))
             })?;
             let attribute = &*ident.to_string();
 

--- a/utoipa-gen/src/path/media_type.rs
+++ b/utoipa-gen/src/path/media_type.rs
@@ -89,13 +89,14 @@ impl ToTokens for MediaTypeSchema<'_> {
                 tokens.extend(media_type_schema.to_token_stream())
             }
             None => {
-                let path = type_tree
-                    .path
-                    .as_ref()
-                    .expect("ValueType::Primitive must have path")
-                    .deref();
                 match type_tree.value_type {
                     ValueType::Primitive => {
+                        let path = type_tree
+                            .path
+                            .as_ref()
+                            .expect("ValueType::Primitive must have path")
+                            .deref();
+
                         let schema_type = SchemaType(path);
                         tokens.extend(quote! {
                             utoipa::openapi::ObjectBuilder::new()
@@ -109,6 +110,12 @@ impl ToTokens for MediaTypeSchema<'_> {
                         }
                     }
                     ValueType::Object => {
+                        let path = type_tree
+                            .path
+                            .as_ref()
+                            .expect("ValueType::Object must have path")
+                            .deref();
+
                         if type_tree.is_object() {
                             tokens.extend(quote! {
                                 utoipa::openapi::ObjectBuilder::new()
@@ -134,9 +141,7 @@ impl ToTokens for MediaTypeSchema<'_> {
                         // Detect unit type ()
                         if type_tree.children.is_none() {
                             tokens.extend(quote! {
-                                utoipa::openapi::ObjectBuilder::new()
-                                    .nullable(true)
-                                    .default(Some(serde_json::Value::Null))
+                                utoipa::openapi::schema::empty()
                             })
                         };
                     }

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -82,8 +82,7 @@ impl Parse for RequestBodyAttr<'_> {
                                 Error::new(
                                     error.span(),
                                     format!(
-                                        "unexpected token, expected type such as String, {}",
-                                        error
+                                        "unexpected token, expected type such as String, {error}",
                                     ),
                                 )
                             })?,
@@ -122,7 +121,7 @@ impl Parse for RequestBodyAttr<'_> {
                 content: Some(input.parse().map_err(|error| {
                     Error::new(
                         error.span(),
-                        format!("unexpected token, expected type such as String, {}", error),
+                        format!("unexpected token, expected type such as String, {error}"),
                     )
                 })?),
                 ..Default::default()

--- a/utoipa-gen/tests/request_body_derive_test.rs
+++ b/utoipa-gen/tests/request_body_derive_test.rs
@@ -434,22 +434,20 @@ fn derive_request_body_ref_path_success() {
 
 #[test]
 fn unit_type_request_body() {
-    type UT = ();
-
     #[utoipa::path(
         post,
         path = "/unit_type_test",
-        request_body = UT
+        request_body = ()
     )]
     #[allow(unused)]
     fn unit_type_test() {}
 
     #[derive(OpenApi)]
-    #[openapi(paths(unit_type_test), components(schemas(UT)))]
+    #[openapi(paths(unit_type_test))]
     struct ApiDoc;
 
     let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
-    let request_body: &Value = doc
+    let request_body = doc
         .pointer("/paths/~1unit_type_test/post/requestBody")
         .unwrap();
 
@@ -459,7 +457,9 @@ fn unit_type_request_body() {
             "content": {
                 "application/json": {
                     "schema": {
-                        "$ref": "#/components/schemas/UT"
+                        "default": null,
+                        "nullable": true,
+                        "type": "object"
                     }
                 }
             },

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -366,8 +366,7 @@ pub trait OpenApi {
 ///                   "name":"bob the cat","id":1
 ///                 })))
 ///                 .into(),
-///         )
-///     }
+///         ) }
 /// }
 /// ```
 pub trait ToSchema<'__s> {
@@ -384,15 +383,14 @@ pub trait ToSchema<'__s> {
     }
 }
 
-impl<'__s> ToSchema<'__s> for () {
+/// Represents _`nullable`_ type. This can be used anywhere where "nothing" needs to be evaluated.
+/// This will serialize to _`null`_ in JSON and [`openapi::schema::empty`] is used to create the
+/// [`openapi::schema::Schema`] for the type.
+pub type TupleUnit = ();
+
+impl<'__s> ToSchema<'__s> for TupleUnit {
     fn schema() -> (&'__s str, openapi::RefOr<openapi::schema::Schema>) {
-        (
-            "UnitType",
-            openapi::schema::ObjectBuilder::new()
-                .nullable(true)
-                .default(Some(serde_json::Value::Null))
-                .into(),
-        )
+        ("TupleUnit", openapi::schema::empty().into())
     }
 }
 

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -30,6 +30,19 @@ macro_rules! to_array_builder {
     };
 }
 
+/// Create an _`empty`_ [`Schema`] that serializes to _`null`_.
+/// 
+/// Can be used in places where an item can be serialized as `null`. This is used with unit type
+/// enum variants and tuple unit types.
+pub fn empty() -> Schema {
+    Schema::Object(
+        ObjectBuilder::new()
+            .nullable(true)
+            .default(Some(serde_json::Value::Null))
+            .into(),
+    )
+}
+
 builder! {
     ComponentsBuilder;
 


### PR DESCRIPTION
Use centralized empty schema to create schema for unit type structs and unit enum variants. Add helper function for creating an empty `Schema`. Create `TupleUnit` type alias for `()` _(unit type)_ that can be used as a reference where ever needed if added to the OpenApi schema.

Centralized `TupleUnit` within the OpenAPI doc will render as `nullable` Schema since `()` will render as `null` in JSON.
```rust
 #[derive(utoipa::OpenApi)]
 #[openapi(components(schemas(utoipa::TupleUnit)))]
 struct ApiDoc;
```

Fixes #448, Relates #464 