### PR TITLE
Fix function argument support for `#[utoipa::path]`

### DIFF
--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -197,7 +197,7 @@ pub mod fn_arg {
             match self {
                 Self::Single(ident) => ident,
                 // perform best effort name, by just taking the first one from the list
-                Self::Tuple(tuple) => tuple
+                Self::Destructed(tuple) => tuple
                     .first()
                     .expect("Expected at least one argument in FnArgType::Tuple"),
             }

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -166,6 +166,7 @@ pub mod fn_arg {
     use proc_macro_error::abort;
     #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
     use quote::quote;
+    use syn::PatStruct;
     use syn::{punctuated::Punctuated, token::Comma, Pat, PatType};
 
     use crate::component::TypeTree;
@@ -185,7 +186,7 @@ pub mod fn_arg {
     #[derive(PartialEq, Eq, PartialOrd, Ord)]
     pub enum FnArgType<'t> {
         Single(&'t Ident),
-        Tuple(Vec<&'t Ident>),
+        Destructed(Vec<&'t Ident>),
     }
 
     impl FnArgType<'_> {
@@ -232,11 +233,16 @@ pub mod fn_arg {
     pub fn get_fn_args(fn_args: &Punctuated<syn::FnArg, Comma>) -> impl Iterator<Item = FnArg<'_>> {
         fn_args
             .iter()
-            .map(|arg| {
+            .filter_map(|arg| {
                 let pat_type = get_fn_arg_pat_type(arg);
 
-                let arg_name = get_pat_fn_arg_type(pat_type.pat.as_ref());
-                (TypeTree::from_type(&pat_type.ty), arg_name)
+                match pat_type.pat.as_ref() {
+                    syn::Pat::Wild(_) => None,
+                    _ => {
+                        let arg_name = get_pat_fn_arg_type(pat_type.pat.as_ref());
+                        Some((TypeTree::from_type(&pat_type.ty), arg_name))
+                    }
+                }
             })
             .map(FnArg::from)
     }
@@ -246,7 +252,7 @@ pub mod fn_arg {
         let arg_name = match pat {
             syn::Pat::Ident(ident) => FnArgType::Single(&ident.ident),
             syn::Pat::Tuple(tuple) => {
-                FnArgType::Tuple(tuple.elems.iter().map(|item| {
+                FnArgType::Destructed(tuple.elems.iter().map(|item| {
                     match item {
                         syn::Pat::Ident(ident) => &ident.ident,
                         _ => abort!(item, "expected syn::Ident in get_pat_fn_arg_type Pat::Tuple")
@@ -257,6 +263,18 @@ pub mod fn_arg {
                 get_pat_fn_arg_type(tuple_struct.pat.elems.first().as_ref().expect(
                     "PatTuple expected to have at least one element, cannot get fn argument",
                 ))
+            },
+            syn::Pat::Struct(PatStruct { fields, ..}) => {
+                let idents = fields.iter()
+                    .map(|field| get_pat_fn_arg_type(&field.pat))
+                    .fold(Vec::<&'_ Ident>::new(), |mut idents, field_type| {
+                        if let FnArgType::Single(ident) = field_type {
+                            idents.push(ident)
+                        }
+                        idents
+                    });
+
+                FnArgType::Destructed(idents)
             }
             _ => abort!(pat,
                 "unexpected syn::Pat, expected syn::Pat::Ident,in get_fn_args, cannot get fn argument name"

--- a/utoipa-gen/src/ext/axum.rs
+++ b/utoipa-gen/src/ext/axum.rs
@@ -48,7 +48,7 @@ fn get_value_arguments(value_args: Vec<FnArg>) -> impl Iterator<Item = super::Va
                 .into_iter()
                 .map(|ty| to_value_argument(Some(Cow::Owned(name.to_string())), ty))
                 .collect::<Vec<_>>(),
-            FnArgType::Tuple(tuple) => tuple
+            FnArgType::Destructed(tuple) => tuple
                 .iter()
                 .zip(
                     path_arg

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -144,6 +144,10 @@ impl<'p> PathAttr<'p> {
         &mut self,
         into_params_types: Option<Vec<IntoParamsType>>,
     ) {
+        fn path_segments(path: &syn::Path) -> Vec<&'_ Ident> {
+            path.segments.iter().map(|segment| &segment.ident).collect()
+        }
+
         if !self.params.is_empty() {
             if let Some(mut into_params_types) = into_params_types {
                 self.params
@@ -153,10 +157,12 @@ impl<'p> PathAttr<'p> {
                         Parameter::Struct(parameter) => Some(parameter),
                     })
                     .for_each(|parameter| {
+
                         if let Some(into_params_argument) =
                             into_params_types
                                 .iter_mut()
-                                .find(|argument| matches!(&argument.type_path, Some(path) if path.as_ref() == &parameter.path.path))
+                                .find(|argument| matches!(&argument.type_path, Some(path) if path_segments(path.as_ref()) == path_segments(&parameter.path.path))
+)
                         {
                             parameter.update_parameter_in(
                                 &mut into_params_argument.parameter_in_provider,


### PR DESCRIPTION
This commit fixes function argument support of function decorated with `#[utoipa::path(...)]` attribute macro.

This PR adds support for ignored function arguments as seen below. Arguments which are defined as `_` _(underscore)_ will not cause an error from now on.
```rust
 #[utoipa::path(
     get,
     path = "/person/{id}/{name}",
     params(IdAndName),
     responses(
         (status = 200, description = "success response")
     )
 )]
 #[allow(unused)]
 async fn get_person(_: Auth, person: Path<IdAndName>) {}
```

Destructing function arguments suppor has now been improved to support named field structs as well. Prior to this PR the following declaration caused an error.
```rust
 #[utoipa::path(get, path = "/item", params(QueryParmas))]
 #[allow(unused)]
 async fn get_item(Query(QueryParmas { name }): Query<QueryParmas<'static>>) {}
```

This also fixes a possible issue with IntoParmas when struct implementing `IntoParams` trait did contain lifetime generics, the `parameter_in` was updated correctly to path parameters.

Fixes #423 