### PR TITLE
Add description support for object field.

### DIFF
--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3821,3 +3821,28 @@ fn derive_struct_with_deprecated_fields() {
         })
     )
 }
+
+#[test]
+fn derive_schema_with_object_type_description() {
+    let value = api_doc! {
+        struct Value {
+            /// This is object value
+            #[schema(value_type = Object)]
+            object: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "object": {
+                    "description": "This is object value",
+                    "type": "object"
+                },
+            },
+            "required": ["object"],
+            "type": "object"
+        })
+    )
+}


### PR DESCRIPTION
This commit add description support for `ToSchema` field with `value_type = Object`.
```rust
 #[derive(ToSchema)]
 struct Value {
     /// This is object value
     #[schema(value_type = Object)]
     object: String,
 }
```

Fixes #491 