### PR TITLE
Add support for chrono NaiveDateTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also awesome type of beer :be
   defining the `parameter_in` attribute. See [docs](https://docs.rs/utoipa/latest/utoipa/attr.path.html#axum_extras-feature-support-for-axum)
   or [examples](./examples) for more details.
 - **debug** Add extra traits such as debug traits to openapi definitions and elsewhere.
-- **chrono** Add support for [chrono](https://crates.io/crates/chrono) `DateTime`, `Date`, `NaiveDate` and `Duration`
+- **chrono** Add support for [chrono](https://crates.io/crates/chrono) `DateTime`, `Date`, `NaiveDate`, `NaiveDateTime` and `Duration`
   types. By default these types are parsed to `string` types with additional `format` information.
-  `format: date-time` for `DateTime` and `format: date` for `Date` and `NaiveDate` according
+  `format: date-time` for `DateTime` and `NaiveDateTime` and `format: date` for `Date` and `NaiveDate` according
   [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) as `ISO-8601`. To
   override default `string` representation users have to use `value_type` attribute to override the type.
   See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html) for more details.

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -140,7 +140,7 @@ fn is_primitive(name: &str) -> bool {
 #[inline]
 #[cfg(feature = "chrono")]
 fn is_primitive_chrono(name: &str) -> bool {
-    matches!(name, "DateTime" | "Date" | "NaiveDate" | "Duration")
+    matches!(name, "DateTime" | "Date" | "NaiveDate" | "Duration" | "NaiveDateTime")
 }
 
 #[inline]
@@ -166,6 +166,8 @@ impl ToTokens for SchemaType<'_> {
             "f32" | "f64" => tokens.extend(quote! { utoipa::openapi::SchemaType::Number }),
             #[cfg(feature = "chrono")]
             "DateTime" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
+            #[cfg(feature = "chrono")]
+            "NaiveDateTime" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
             #[cfg(feature = "chrono")]
             "NaiveDate" => tokens.extend(quote!(utoipa::openapi::SchemaType::String)),
             #[cfg(any(feature = "chrono", feature = "time"))]
@@ -250,7 +252,7 @@ impl Type<'_> {
 
             #[cfg(feature = "chrono")]
             if !known_format {
-                known_format = matches!(name, "DateTime" | "Date" | "NaiveDate");
+                known_format = matches!(name, "DateTime" | "Date" | "NaiveDate" | "NaiveDateTime");
             }
 
             #[cfg(feature = "uuid")]
@@ -293,6 +295,8 @@ impl ToTokens for Type<'_> {
             "NaiveDate" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Date) }),
             #[cfg(feature = "chrono")]
             "DateTime" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::DateTime) }),
+            #[cfg(feature = "chrono")]
+            "NaiveDateTime" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::DateTime) }),
             #[cfg(any(feature = "chrono", feature = "time"))]
             "Date" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Date) }),
             #[cfg(feature = "uuid")]

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -2526,13 +2526,14 @@ fn derive_struct_xml_with_optional_vec() {
 #[test]
 fn derive_component_with_chrono_feature() {
     #![allow(deprecated)] // allow deprecated Date in tests as long as it is available from chrono
-    use chrono::{Date, DateTime, Duration, NaiveDate, Utc};
+    use chrono::{Date, DateTime, NaiveDateTime, Duration, NaiveDate, Utc};
 
     let post = api_doc! {
         struct Post {
             id: i32,
             value: String,
             datetime: DateTime<Utc>,
+            naive_datetime: NaiveDateTime,
             date: Date<Utc>,
             naive_date: NaiveDate,
             duration: Duration,
@@ -2542,6 +2543,8 @@ fn derive_component_with_chrono_feature() {
     assert_value! {post=>
         "properties.datetime.type" = r#""string""#, "Post datetime type"
         "properties.datetime.format" = r#""date-time""#, "Post datetime format"
+        "properties.naive_datetime.type" = r#""string""#, "Post datetime type"
+        "properties.naive_datetime.format" = r#""date-time""#, "Post datetime format"
         "properties.date.type" = r#""string""#, "Post date type"
         "properties.date.format" = r#""date""#, "Post date format"
         "properties.naive_date.type" = r#""string""#, "Post date type"


### PR DESCRIPTION
Make chrono `NaiveDateTime` to be recognized as `format: date-time` and `type: string` in OpenAPI spec.

Fixes #505