### PR TITLE
Make unsigned integers implicityly minimum zero

### DIFF
--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -925,6 +925,12 @@ name!(Maximum = "maximum");
 #[derive(Clone)]
 pub struct Minimum(f64, Ident);
 
+impl Minimum {
+    pub fn new(value: f64, span: Span) -> Self {
+        Self(value, Ident::new("empty", span))
+    }
+}
+
 impl Validate for Minimum {
     fn validate(&self, validator: impl Validator) {
         if let Err(error) = validator.is_valid() {

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -95,6 +95,13 @@ impl SchemaType<'_> {
         )
     }
 
+    pub fn is_unsigned_integer(&self) -> bool {
+        matches!(
+            &*self.last_segment_to_string(),
+            "u8" | "u16" | "u32" | "u64" | "u128" | "usize"
+        )
+    }
+
     pub fn is_number(&self) -> bool {
         match &*self.last_segment_to_string() {
             "f32" | "f64" => true,
@@ -140,7 +147,10 @@ fn is_primitive(name: &str) -> bool {
 #[inline]
 #[cfg(feature = "chrono")]
 fn is_primitive_chrono(name: &str) -> bool {
-    matches!(name, "DateTime" | "Date" | "NaiveDate" | "Duration" | "NaiveDateTime")
+    matches!(
+        name,
+        "DateTime" | "Date" | "NaiveDate" | "Duration" | "NaiveDateTime"
+    )
 }
 
 #[inline]

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -251,6 +251,7 @@ fn derive_struct_with_optional_properties() {
                     "type": "integer",
                     "format": "int64",
                     "default": 1,
+                    "minimum": 0.0,
                 },
                 "enabled": {
                     "type": "boolean",
@@ -3590,6 +3591,12 @@ fn derive_struct_with_validation_fields() {
 
             #[schema(max_items = 5, min_items = 1, min_length = 1)]
             items: Vec<String>,
+
+            unsigned: u16,
+
+            #[schema(minimum = 2)]
+            unsigned_value: u32,
+
         }
     };
 
@@ -3618,13 +3625,25 @@ fn derive_struct_with_validation_fields() {
                     },
                     "maxItems": 5,
                     "minItems": 1,
+                },
+                "unsigned": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 0.0
+                },
+                "unsigned_value": {
+                    "type": "integer",
+                    "format": "int32",
+                    "minimum": 2.0,
                 }
             },
             "type": "object",
             "required": [
                 "id",
                 "value",
-                "items"
+                "items",
+                "unsigned",
+                "unsigned_value"
             ]
         })
     );
@@ -3824,7 +3843,8 @@ fn derive_schema_with_generics_and_lifetimes() {
                         "nullable": true,
                     },
                     "total": {
-                        "type": "integer"
+                        "type": "integer",
+                        "minimum": 0.0,
                      }
                     },
                     "required": [
@@ -3855,7 +3875,8 @@ fn derive_schema_with_generics_and_lifetimes() {
                             "nullable": true,
                         },
                         "total": {
-                            "type": "integer"
+                            "type": "integer",
+                            "minimum": 0.0
                         }
                     },
                     "required": [


### PR DESCRIPTION
Make `ToSchema` struct fields with unsigned integer types implicityly have minimum 0 validation rule.

Fixes #501 