### PR TITLE
Add missing `As` attribute to complex enum

### DIFF
--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -72,7 +72,8 @@ impl Parse for ComplexEnumFeatures {
         Ok(ComplexEnumFeatures(parse_features!(
             input as Example,
             Default,
-            RenameAll
+            RenameAll,
+            As
         )))
     }
 }


### PR DESCRIPTION
Add missing `As` attribute to `ToSchema` complex enum. This allows renaming complex enum schemas same way as struct and simple enums are allowed.
```rust
 #[derive(ToSchema)]
 #[schema(as = named::BarBar)]
 enum BarBar {
     Foo { foo: Foobar },
 }
```