### PR TITLE
Remove superfluous `deprecated` path attribute

### DIFF
--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -514,13 +514,9 @@ impl ToTokens for Operation<'_> {
             .operation_id(Some(#operation_id))
         });
 
-        let deprecated = self
-            .deprecated
-            .map(Into::<Deprecated>::into)
-            .unwrap_or(Deprecated::False);
-        tokens.extend(quote! {
-           .deprecated(Some(#deprecated))
-        });
+        if let Some(deprecated) = self.deprecated.map(Into::<Deprecated>::into) {
+            tokens.extend(quote!( .deprecated(Some(#deprecated))))
+        }
 
         if let Some(summary) = self.summary {
             tokens.extend(quote! {

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -185,7 +185,7 @@ fn derive_path_with_defaults_success() {
     };
 
     assert_value! {operation=>
-       "deprecated" = r#"false"#, "Api fn deprecated status"
+       "deprecated" = r#"null"#, "Api fn deprecated status"
        "operationId" = r#""test_operation3""#, "Api fn operation_id"
        "tags.[0]" = r#""derive_path_with_defaults""#, "Api fn tag"
        "parameters" = r#"null"#, "Api parameters"
@@ -222,7 +222,7 @@ fn derive_path_with_extra_attributes_without_nested_module() {
 
     common::assert_json_array_len(operation.pointer("/parameters").unwrap(), 2);
     assert_value! {operation=>
-        "deprecated" = r#"false"#, "Api operation deprecated"
+        "deprecated" = r#"null"#, "Api operation deprecated"
         "description" = r#""This is test operation\n\nThis is long description for test operation""#, "Api operation description"
         "operationId" = r#""get_foos_by_id_since""#, "Api operation operation_id"
         "summary" = r#""This is test operation""#, "Api operation summary"

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -304,7 +304,6 @@ fn derive_response_body_inline_schema_component() {
     assert_json_eq!(
         doc,
         json!({
-            "deprecated": false,
             "operationId": "get_foo",
             "responses": {
                 "200": {


### PR DESCRIPTION
Remove superfluous `deprecated` attribute from path. This commit will change `deprecated` to be added to the path operation only if it is marked as deprecated.

Fixes #487 