### PR TITLE
Add support for double number format

### DIFF
--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -300,7 +300,8 @@ impl ToTokens for Type<'_> {
                 tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int32) })
             }
             "i64" | "u64" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int64) }),
-            "f32" | "f64" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Float) }),
+            "f32" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Float) }),
+            "f64" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Double) }),
             #[cfg(feature = "chrono")]
             "NaiveDate" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Date) }),
             #[cfg(feature = "chrono")]

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -382,7 +382,7 @@ fn derive_enum_with_comments_success() {
 #[test]
 fn derive_struct_unnamed_field_single_value_type_success() {
     let point = api_doc! {
-        struct Point(f64);
+        struct Point(f32);
     };
 
     assert_value! {point=>
@@ -403,7 +403,7 @@ fn derive_struct_unnamed_fields_tuple_with_same_type_success() {
     assert_value! {point=>
         "type" = r#""array""#, "Point type"
         "items.type" = r#""number""#, "Point items type"
-        "items.format" = r#""float""#, "Point items format"
+        "items.format" = r#""double""#, "Point items format"
         "items.description" = r#""Contains x and y coordinates\n\nCoordinates are used to pinpoint location on a map""#, "Point items description"
         "maxItems" = r#"2"#, "Wrapper max items"
         "minItems" = r#"2"#, "Wrapper min items"

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -2805,7 +2805,7 @@ fn derive_struct_with_rust_decimal_with_type_override() {
         "properties.id.type" = r#""integer""#, "Post id type"
         "properties.id.format" = r#""int32""#, "Post id format"
         "properties.rating.type" = r#""number""#, "Post rating type"
-        "properties.rating.format" = r#""float""#, "Post rating format"
+        "properties.rating.format" = r#""double""#, "Post rating format"
     }
 }
 


### PR DESCRIPTION
A simple commit that adds mapping from f64 to
```
{
type: 'number',
format: 'double'
}
```

https://swagger.io/docs/specification/data-models/data-types/