### PR TITLE
Add support for auto-populating field default values

### DIFF
--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -416,6 +416,12 @@ name!(Example = "example");
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Default(AnyValue);
 
+impl Default {
+    pub fn new_default_trait(struct_ident: Ident, field_ident: Ident) -> Self {
+        Self(AnyValue::new_default_trait(struct_ident, field_ident))
+    }
+}
+
 impl Parse for Default {
     fn parse(input: syn::parse::ParseStream, _: Ident) -> syn::Result<Self> {
         parse_utils::parse_next(input, || AnyValue::parse_any(input)).map(Self)

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -414,10 +414,10 @@ name!(Example = "example");
 
 #[derive(Clone)]
 #[cfg_attr(feature = "debug", derive(Debug))]
-pub struct Default(Option<AnyValue>);
+pub struct Default(pub(crate) Option<AnyValue>);
 
 impl Default {
-    pub fn new_default_trait(struct_ident: Ident, field_ident: Ident) -> Self {
+    pub fn new_default_trait(struct_ident: Ident, field_ident: syn::Member) -> Self {
         Self(Some(AnyValue::new_default_trait(struct_ident, field_ident)))
     }
 }

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -298,10 +298,7 @@ impl NamedStructSchema<'_> {
                 let field_ident = field.ident.as_ref().unwrap().to_owned();
                 let struct_ident = format_ident!("{}", &self.struct_name);
                 features_inner.push(Feature::Default(
-                    crate::features::Default::new_default_trait(
-                        struct_ident,
-                        field_ident,
-                    ),
+                    crate::features::Default::new_default_trait(struct_ident, field_ident.into()),
                 ));
             }
         }
@@ -530,6 +527,20 @@ impl ToTokens for UnnamedStructSchema<'_> {
                     .as_ref()
                     .map(|override_type| matches!(override_type.value_type, ValueType::Object))
                     .unwrap_or_default();
+            }
+
+            if fields_len == 1 {
+                if let Some(ref mut features) = unnamed_struct_features {
+                    if pop_feature!(features => Feature::Default(crate::features::Default(None)))
+                        .is_some()
+                    {
+                        let struct_ident = format_ident!("{}", &self.struct_name);
+                        let index: syn::Index = 0.into();
+                        features.push(Feature::Default(
+                            crate::features::Default::new_default_trait(struct_ident, index.into()),
+                        ));
+                    }
+                }
             }
 
             tokens.extend(

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -290,17 +290,19 @@ impl NamedStructSchema<'_> {
             .unwrap_or(false);
 
         if schema_default || serde_default {
-            let field_ident = field.ident.as_ref().unwrap().to_owned();
-            let struct_ident = format_ident!("{}", &self.struct_name);
-            let default_feature = Feature::Default(
-                crate::component::features::Default::new_default_trait(struct_ident, field_ident),
-            );
-            let features_inner = field_features.get_or_insert(vec![default_feature.clone()]);
+            let features_inner = field_features.get_or_insert(vec![]);
             if !features_inner
                 .iter()
                 .any(|f| matches!(f, Feature::Default(_)))
             {
-                features_inner.push(default_feature);
+                let field_ident = field.ident.as_ref().unwrap().to_owned();
+                let struct_ident = format_ident!("{}", &self.struct_name);
+                features_inner.push(Feature::Default(
+                    crate::features::Default::new_default_trait(
+                        struct_ident,
+                        field_ident,
+                    ),
+                ));
             }
         }
 

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -24,7 +24,8 @@ impl Parse for NamedFieldStructFeatures {
             RenameAll,
             MaxProperties,
             MinProperties,
-            As
+            As,
+            Default
         )))
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -23,7 +23,7 @@ use proc_macro2::{Group, Ident, Punct, TokenStream as TokenStream2};
 use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
-    DeriveInput, ExprPath, ItemFn, Lit, LitStr, Token,
+    DeriveInput, ExprPath, ItemFn, Lit, LitStr, Member, Token,
 };
 
 mod component;
@@ -110,7 +110,9 @@ use self::{
 ///
 /// # Unnamed Field Struct Optional Configuration Options for `#[schema(...)]`
 /// * `example = ...` Can be method reference or _`json!(...)`_.
-/// * `default = ...` Can be method reference or _`json!(...)`_.
+/// * `default = ...` Can be method reference or _`json!(...)`_. If no value is specified, and the struct has
+///   only one field, the field's default value in the schema will be set from the struct's
+///   [`Default`](std::default::Default) implementation.
 /// * `format = ...` May either be variant of the [`KnownFormat`][known_format] enum, or otherwise
 ///   an open value as a string. By default the format is derived from the type of the property
 ///   according OpenApi spec.
@@ -2500,7 +2502,7 @@ pub(self) enum AnyValue {
     Json(TokenStream2),
     DefaultTrait {
         struct_ident: Ident,
-        field_ident: Ident,
+        field_ident: Member,
     },
 }
 
@@ -2557,7 +2559,7 @@ impl AnyValue {
         }
     }
 
-    fn new_default_trait(struct_ident: Ident, field_ident: Ident) -> Self {
+    fn new_default_trait(struct_ident: Ident, field_ident: Member) -> Self {
         Self::DefaultTrait {
             struct_ident,
             field_ident,

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -84,8 +84,8 @@ use self::{
 /// * `as = ...` Can be used to define alternative path and name for the schema what will be used in
 ///   the OpenAPI. E.g _`as = path::to::Pet`_. This would make the schema appear in the generated
 ///   OpenAPI spec as _`path.to.Pet`_.
-/// * `default` Can be used to populate default values on all fields using the struct's 
-///   [`Default`](std::default::Default) implementation. 
+/// * `default` Can be used to populate default values on all fields using the struct's
+///   [`Default`](std::default::Default) implementation.
 ///
 /// # Enum Optional Configuration Options for `#[schema(...)]`
 /// * `example = ...` Can be method reference or _`json!(...)`_.

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -232,7 +232,7 @@ fn derive_struct_with_custom_properties_success() {
 #[test]
 fn derive_struct_with_default_attr() {
     let book = api_doc! {
-        #[schema(default="")]
+        #[schema(default)]
         struct Book {
             name: String,
             #[schema(default = 0)]

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -537,6 +537,43 @@ fn derive_struct_unnamed_field_vec_type_success() {
 }
 
 #[test]
+fn derive_struct_unnamed_field_single_value_default_success() {
+    let point = api_doc! {
+        #[schema(default)]
+        struct Point(f32);
+
+        impl Default for Point {
+            fn default() -> Self {
+                Self(3.5)
+            }
+        }
+    };
+
+    assert_value! {point=>
+        "type" = r#""number""#, "Point type"
+        "format" = r#""float""#, "Point format"
+        "default" = r#"3.5"#, "Point default"
+    }
+}
+
+#[test]
+fn derive_struct_unnamed_field_multiple_value_default_ignored() {
+    let point = api_doc! {
+        #[schema(default)]
+        struct Point(f32, f32);
+
+        impl Default for Point {
+            fn default() -> Self {
+                Self(3.5, 6.4)
+            }
+        }
+    };
+    // Default values shouldn't be assigned as the struct is represented
+    // as an array
+    assert!(!point.to_string().contains("default"))
+}
+
+#[test]
 fn derive_struct_nested_vec_success() {
     let vecs = api_doc! {
         struct VecTest {

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -230,6 +230,71 @@ fn derive_struct_with_custom_properties_success() {
 }
 
 #[test]
+fn derive_struct_with_default_attr() {
+    let book = api_doc! {
+        #[schema(default="")]
+        struct Book {
+            name: String,
+            #[schema(default = 0)]
+            id: u64,
+            year: u64,
+            hash: String,
+        }
+
+        impl Default for Book {
+            fn default() -> Self {
+                Self {
+                    name: "No name".to_string(),
+                    id: 999,
+                    year: 2020,
+                    hash: "Test hash".to_string(),
+                }
+            }
+        }
+    };
+
+    assert_value! { book =>
+        "properties.name.default" = r#""No name""#, "Book name default"
+        "properties.id.default" = r#"0"#, "Book id default"
+        "properties.year.default" = r#"2020"#, "Book year default"
+        "properties.hash.default" = r#""Test hash""#, "Book hash default"
+    };
+}
+
+#[test]
+fn derive_struct_with_serde_default_attr() {
+    let book = api_doc! {
+        #[derive(serde::Deserialize)]
+        #[serde(default)]
+        struct Book {
+            name: String,
+            #[schema(default = 0)]
+            id: u64,
+            year: u64,
+            hash: String,
+        }
+
+        impl Default for Book {
+            fn default() -> Self {
+                Self {
+                    name: "No name".to_string(),
+                    id: 999,
+                    year: 2020,
+                    hash: "Test hash".to_string(),
+                }
+            }
+        }
+    };
+
+    assert_value! { book =>
+        "properties.name.default" = r#""No name""#, "Book name default"
+        "properties.id.default" = r#"0"#, "Book id default"
+        "properties.year.default" = r#"2020"#, "Book year default"
+        "properties.hash.default" = r#""Test hash""#, "Book hash default"
+    };
+}
+
+#[test]
 fn derive_struct_with_optional_properties() {
     struct Book;
     let owner = api_doc! {
@@ -3279,7 +3344,8 @@ fn derive_schema_with_default_struct() {
         json!({
             "properties": {
                 "field": {
-                    "type": "string"
+                    "type": "string",
+                    "default": ""
                 }
             },
             "type": "object"


### PR DESCRIPTION
Closes #519

Thanks again for your feedback on the issue! Here is an attempt at solving it.

## Summary
A named struct with `#[schema(default="")]` or `#[serde(default)]` attribute will use `<struct_name>::default().<field_name>` as the default value for all of its fields.
Any existing `#[default]` attribute on a field takes precedence.

## Caveats / to do
- I couldn't figure out how to allow `#[schema(default)]`, as the attribute parser expects an equals sign and a value. Any ideas would be welcome!
- I added a variant to `AnyValue` that represents this way of setting a default value -- I am not sure if this is very clean / consistent with how `AnyValue` is used currently. Please let me know if there is a better approach (same goes for naming and organization of course).
