### PR TITLE
bugfix: use `map()` instead of `unwrap()`

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -39,7 +39,7 @@ fn is_default(container_rules: &Option<&SerdeContainer>, field_rule: &Option<&Se
 /// or field attributes of struct.
 fn get_deprecated(attributes: &[Attribute]) -> Option<Deprecated> {
     attributes.iter().find_map(|attribute| {
-        if *attribute.path.get_ident().unwrap() == "deprecated" {
+        if attribute.path.get_ident().map(|ident| *ident == "deprecated").unwrap_or(false) {
             Some(Deprecated::True)
         } else {
             None

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -185,7 +185,7 @@ impl_merge!(
 pub fn parse_schema_features<T: Sized + Parse + Merge<T>>(attributes: &[Attribute]) -> Option<T> {
     attributes
         .iter()
-        .filter(|attribute| attribute.path.get_ident().unwrap() == "schema")
+        .filter(|attribute| attribute.path.get_ident().map(|ident| *ident == "schema").unwrap_or(false))
         .map(|attribute| attribute.parse_args::<T>().unwrap_or_abort())
         .reduce(|acc, item| acc.merge(item))
 }
@@ -199,7 +199,7 @@ pub fn parse_schema_features_with<
 ) -> Option<T> {
     attributes
         .iter()
-        .filter(|attribute| attribute.path.get_ident().unwrap() == "schema")
+        .filter(|attribute| attribute.path.get_ident().map(|ident| *ident == "schema").unwrap_or(false))
         .map(|attributes| attributes.parse_args_with(parser).unwrap_or_abort())
         .reduce(|acc, item| acc.merge(item))
 }


### PR DESCRIPTION
Closes #535 

This PR replaces few of the `unwraps()` used in the codebase to `map()` and then call `unwrap_or()` on those fields to provide a default value. This change is required because when using `rustfmt::skip` `get_ident()` function returns `None`, calling `unwrap()` on this value results in `panic`.