### PR TITLE
Add missing enum variant examples

### DIFF
--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1387,6 +1387,7 @@ fn derive_complex_enum_example() {
                             ],
                         },
                     },
+                    "required": ["NamedFields"]
                 },
                 {
                     "type": "object",
@@ -1396,6 +1397,7 @@ fn derive_complex_enum_example() {
                             "$ref": "#/components/schemas/Foo",
                         },
                     },
+                    "required": ["UnnamedFields"]
                 },
             ],
         })

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1340,6 +1340,69 @@ fn derive_complex_enum_title() {
 }
 
 #[test]
+fn derive_complex_enum_example() {
+    #[derive(Serialize)]
+    struct Foo(String);
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum EnumWithExample {
+            #[schema(example = "EX: Unit")]
+            UnitValue,
+            #[schema(example = "EX: Named")]
+            NamedFields {
+                #[schema(example = "EX: Named id field")]
+                id: &'static str,
+            },
+            #[schema(example = "EX: Unnamed")]
+            UnnamedFields(Foo),
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "type": "string",
+                    "example": "EX: Unit",
+                    "enum": [
+                        "UnitValue",
+                    ],
+                },
+                {
+                    "type": "object",
+                    "example": "EX: Named",
+                    "properties": {
+                        "NamedFields": {
+                            "type": "object",
+                            "properties": {
+                                "id": {
+                                    "type": "string",
+                                    "example": "EX: Named id field",
+                                },
+                            },
+                            "required": [
+                                "id",
+                            ],
+                        },
+                    },
+                },
+                {
+                    "type": "object",
+                    "example": "EX: Unnamed",
+                    "properties": {
+                        "UnnamedFields": {
+                            "$ref": "#/components/schemas/Foo",
+                        },
+                    },
+                },
+            ],
+        })
+    );
+}
+
+#[test]
 fn derive_complex_enum_serde_rename_all() {
     #[derive(Serialize)]
     struct Foo(String);


### PR DESCRIPTION
Add missing example support for enum variants. According to the docs enum variants should have support for example attribute: https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html#enum-variant-optional-configuration-options-for-schema.

This commit implements the tokenization support for `example` attribute at complex enum.
```rust
let value: Value = api_doc! {
    enum EnumWithExample {
        #[schema(example = "EX: Unit")]
        UnitValue,
        #[schema(example = "EX: Named")]
        NamedFields {
            #[schema(example = "EX: Named id field")]
            id: &'static str,
        },
        #[schema(example = "EX: Unnamed")]
        UnnamedFields(Foo),
    }
};
```

Relates #470