### PR TITLE
Fix untagged enum unit variant support

### DIFF
--- a/utoipa-gen/src/component/schema/enum_variant.rs
+++ b/utoipa-gen/src/component/schema/enum_variant.rs
@@ -5,6 +5,7 @@ use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{parse_quote, TypePath};
 
+use crate::component::features::Feature;
 use crate::schema_type::SchemaType;
 use crate::Array;
 
@@ -224,11 +225,30 @@ impl<'t, V: Variant> FromIterator<(Cow<'t, str>, V)> for TaggedEnum<V> {
     }
 }
 
-pub struct UntaggedEnum;
+pub struct UntaggedEnum {
+    title: Option<Feature>,
+}
+
+impl UntaggedEnum {
+    pub fn new() -> Self {
+        Self { title: None }
+    }
+
+    pub fn with_title(title: Option<Feature>) -> Self {
+        Self { title }
+    }
+}
 
 impl ToTokens for UntaggedEnum {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.extend(quote!(utoipa::openapi::schema::empty()));
+        let title = &self.title;
+
+        tokens.extend(quote! {
+            utoipa::openapi::schema::ObjectBuilder::new()
+                .nullable(true)
+                .default(Some(serde_json::Value::Null))
+                #title
+        })
     }
 }
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -4313,3 +4313,34 @@ fn derive_nullable_tuple() {
         })
     )
 }
+
+#[test]
+fn derive_unit_type_untagged_enum() {
+    #[derive(Serialize)]
+    struct AggregationRequest;
+
+    let value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(untagged)]
+        enum ComputeRequest {
+            Aggregation(AggregationRequest),
+            Breakdown,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "oneOf": [
+                {
+                    "$ref": "#/components/schemas/AggregationRequest"
+                },
+                {
+                    "type": "object",
+                    "nullable": true,
+                    "default": null,
+                }
+            ]
+        })
+    )
+}


### PR DESCRIPTION
Prior to this commit untagged enums with unit variants caused compile error because they where counted as unnamed field variants. However this is incorrect behavior and they need to rendered as unit structs that render to `null` according to serde.

This commit fixes this by allowing use of `#[serde(untagged)]` attribute on enums with unit type fields.
```rust
 #[derive(ToSchema)]
 #[serde(untagged)]
 enum ComputeRequest {
     Aggregation(AggregationRequest),
     Breakdown,
 }
```

Fixes #543