### PR TITLE
Refactor alises support on `ToSchema` derive

### DIFF
--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -14,7 +14,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1.0"
-syn = { version = "2.0", features = ["full"] }
+syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro-error = "1.0"
 regex = { version = "1.7", optional = true }

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -295,6 +295,24 @@ impl<'t> TypeTree<'t> {
         is
     }
 
+    fn find_mut(&mut self, type_tree: &TypeTree) -> Option<&mut Self> {
+        let is = self
+            .path
+            .as_mut()
+            .map(|p| matches!(&type_tree.path, Some(path) if path.as_ref() == p.as_ref()))
+            .unwrap_or(false);
+
+        if is {
+            Some(self)
+        } else {
+            self.children.as_mut().and_then(|children| {
+                children
+                    .iter_mut()
+                    .find_map(|child| Self::find_mut(child, type_tree))
+            })
+        }
+    }
+
     /// `Object` virtual type is used when generic object is required in OpenAPI spec. Typically used
     /// with `value_type` attribute to hinder the actual type.
     pub fn is_object(&self) -> bool {

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -295,48 +295,6 @@ impl<'t> TypeTree<'t> {
         is
     }
 
-    fn find_mut_by_ident(&mut self, ident: &'_ Ident) -> Option<&mut Self> {
-        let is = self
-            .path
-            .as_mut()
-            .map(|path| path.segments.iter().any(|segment| &segment.ident == ident))
-            .unwrap_or(false);
-
-        if is {
-            Some(self)
-        } else {
-            self.children.as_mut().and_then(|children| {
-                children
-                    .iter_mut()
-                    .find_map(|child| Self::find_mut_by_ident(child, ident))
-            })
-        }
-    }
-
-    /// Update current [`TypeTree`] from given `ident`.
-    ///
-    /// It will update everything else except `children` for the `TypeTree`. This means that the
-    /// `TypeTree` will not be changed and will be traveled as before update.
-    fn update(&mut self, ident: Ident) {
-        let new_path = Path::from(ident);
-
-        let segments = &new_path.segments;
-        let last_segment = segments
-            .last()
-            .expect("TypeTree::update path should have at least one segment");
-
-        let generic_type = Self::get_generic_type(last_segment);
-        let value_type = if SchemaType(&new_path).is_primitive() {
-            ValueType::Primitive
-        } else {
-            ValueType::Object
-        };
-
-        self.value_type = value_type;
-        self.generic_type = generic_type;
-        self.path = Some(Cow::Owned(new_path));
-    }
-
     /// `Object` virtual type is used when generic object is required in OpenAPI spec. Typically used
     /// with `value_type` attribute to hinder the actual type.
     pub fn is_object(&self) -> bool {

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -294,24 +294,11 @@ impl NamedStructSchema<'_> {
     ) -> R {
         let type_tree = &mut TypeTree::from_type(&field.ty);
         if let Some(aliases) = &self.aliases {
-            if let Some(ref mut field_types) = type_tree.children {
-                for (new_generic, old_generic_matcher) in aliases.iter() {
-                    if let Some(field_old_generic) = field_types
-                        .iter()
-                        .enumerate()
-                        .find_map(|(index, field_ty)| {
-                            if field_ty == *old_generic_matcher {
-                                Some(index)
-                            } else {
-                                None
-                            }
-                        })
-                        .and_then(|index| field_types.get_mut(index))
-                    {
-                        *field_old_generic = new_generic.clone();
-                    }
+            for (new_generic, old_generic_matcher) in aliases.iter() {
+                if let Some(generic_match) = type_tree.find_mut(old_generic_matcher) {
+                    *generic_match = new_generic.clone();
                 }
-            };
+            }
         }
 
         let mut field_features = field

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -300,7 +300,7 @@ impl NamedStructResponse<'_> {
         let inline_schema = NamedStructSchema {
             attributes,
             fields,
-            alias: None,
+            aliases: None,
             features: None,
             generics: None,
             rename_all: None,
@@ -364,7 +364,7 @@ impl<'p> ToResponseNamedStructResponse<'p> {
         let ty = Self::to_type(ident);
 
         let inline_schema = NamedStructSchema {
-            alias: None,
+            aliases: None,
             fields,
             features: None,
             generics: None,

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -4023,7 +4023,7 @@ fn derive_schema_with_generics_and_lifetimes() {
     struct TResult;
 
     let value = api_doc_aliases! {
-        #[aliases(Paginated1<'b> = Paginated<'b, String>, Paginated2<'b> = Paginated<'b, Cow<'b, bool>>)]
+        #[aliases(Paginated1 = Paginated<'b, String>, Paginated2 = Paginated<'b, Cow<'c, bool>>)]
         struct Paginated<'r, TResult> {
             pub total: usize,
             pub data: Vec<TResult>,

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -4023,7 +4023,7 @@ fn derive_schema_with_generics_and_lifetimes() {
     struct TResult;
 
     let value = api_doc_aliases! {
-        #[aliases(Paginated1<'b> = Paginated<'b, String>, Paginated2 = Paginated<'b, Value>)]
+        #[aliases(Paginated1<'b> = Paginated<'b, String>, Paginated2<'b> = Paginated<'b, Cow<'b, bool>>)]
         struct Paginated<'r, TResult> {
             pub total: usize,
             pub data: Vec<TResult>,
@@ -4072,7 +4072,7 @@ fn derive_schema_with_generics_and_lifetimes() {
                         "data": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/components/schemas/Value",
+                                "type": "boolean"
                             }
                         },
                         "next": {


### PR DESCRIPTION
Prior to this commit the implementation was not able to resolve nested generics within aliases. That lead scenarios where types with extensive use of lifetimes was not possible.

This commit takes another approach on aliases support for `ToSchema` derive macro that provides generic schema types. Instead of trying to parse `Generics` manually we parse `syn::Type` instead that contains generics as is allowing complex generic arguments with lifetimes to be used.

Fundamental difference is that we create `TypeTree` for alias and the implementor type. Then we compare generic arguments to the field arguments and replace matching occurrences.
```rust
 #[derive(ToSchema)]
 #[aliases(Paginated1 = Paginated<'b, String>, Paginated2 = Paginated<'b, Cow<'b, bool>>)]
 struct Paginated<'r, T> {
     pub total: usize,
     pub data: Vec<T>,
     pub next: Option<&'r str>,
     pub prev: Option<&'r str>,
 }
```

~One caveat with this approach is that the lifetimes now need to be also defined on the left side of the equals (=) mark.~

Removed  the need to define lifetimes on left side of the equals (=) sign.

Fixes #427, Fixes #524