### PR TITLE
Fix Schema as additional properties

### DIFF
--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -4387,3 +4387,35 @@ fn derive_unit_type_untagged_enum() {
         })
     )
 }
+
+#[test]
+fn derive_schema_with_unit_hashmap() {
+    let value = api_doc! {
+        struct Container {
+            volumes: HashMap<String, HashMap<(), ()>>
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "volumes": {
+                    "additionalProperties": {
+                        "additionalProperties": {
+                            "type": "object",
+                            "default": null,
+                            "nullable": true,
+                        },
+                        "type": "object"
+                    },
+                    "type": "object"
+                },
+            },
+            "required": [
+                "volumes"
+            ],
+            "type": "object"
+        })
+    )
+}

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -895,6 +895,12 @@ impl From<Ref> for AdditionalProperties<Schema> {
     }
 }
 
+impl From<Schema> for AdditionalProperties<Schema> {
+    fn from(value: Schema) -> Self {
+        Self::RefOr(RefOr::T(value))
+    }
+}
+
 /// Implements [OpenAPI Reference Object][reference] that can be used to reference
 /// reusable components such as [`Schema`]s or [`Response`]s.
 ///


### PR DESCRIPTION
This PR adds support for unit types used as additional properties of a Schema. Prior to this commit following declarations was not possible because unit type _`()`_ is resolved to `Schema` directly and it was not possible to convert it to additional properties.
```rust
 #[derive(ToSchema)]
 struct Container {
     volumes: HashMap<String, HashMap<(), ()>>
 }
```
