### PR TITLE
Add automatic request body recognition

### DIFF
--- a/utoipa-gen/src/ext/axum.rs
+++ b/utoipa-gen/src/ext/axum.rs
@@ -18,11 +18,12 @@ impl ArgumentResolver for PathOperations {
     ) -> (
         Option<Vec<super::ValueArgument<'_>>>,
         Option<Vec<super::IntoParamsType<'_>>>,
+        Option<super::RequestBody<'_>>,
     ) {
-        let (into_params_args, value_args): (Vec<FnArg>, Vec<FnArg>) = fn_arg::get_fn_args(args)
-            .into_iter()
-            .partition(fn_arg::is_into_params);
+        let (into_params_args, value_args): (Vec<FnArg>, Vec<FnArg>) =
+            fn_arg::get_fn_args(args).partition(fn_arg::is_into_params);
 
+        // TODO value args resolve request body
         (
             Some(get_value_arguments(value_args).collect()),
             Some(
@@ -32,6 +33,7 @@ impl ArgumentResolver for PathOperations {
                     .map(fn_arg::into_into_params_type)
                     .collect(),
             ),
+            None,
         )
     }
 }

--- a/utoipa-gen/src/ext/rocket.rs
+++ b/utoipa-gen/src/ext/rocket.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use super::{
     fn_arg::{self, FnArg},
-    ArgumentResolver, MacroPath, PathOperationResolver, PathOperations, PathResolver,
+    ArgumentResolver, MacroPath, PathOperationResolver, PathOperations, PathResolver, RequestBody,
     ResolvedOperation,
 };
 
@@ -28,11 +28,13 @@ impl ArgumentResolver for PathOperations {
     ) -> (
         Option<Vec<ValueArgument<'_>>>,
         Option<Vec<IntoParamsType<'_>>>,
+        Option<RequestBody<'_>>,
     ) {
         let mut args = fn_arg::get_fn_args(fn_args).collect::<Vec<_>>();
         args.sort_unstable();
         let (into_params_args, value_args): (Vec<FnArg>, Vec<FnArg>) =
             args.into_iter().partition(is_into_params);
+        // TODO resolve request body from value_args
 
         macro_args
             .map(|args| {
@@ -55,9 +57,10 @@ impl ArgumentResolver for PathOperations {
                             .map(fn_arg::into_into_params_type)
                             .collect(),
                     ),
+                    None,
                 )
             })
-            .unwrap_or_else(|| (None, None))
+            .unwrap_or_else(|| (None, None, None))
     }
 }
 

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1334,11 +1334,14 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
     {
         use ext::ArgumentResolver;
         let args = resolved_path.as_mut().map(|path| mem::take(&mut path.args));
-        let (arguments, into_params_types) =
+        let (arguments, into_params_types, body) =
             PathOperations::resolve_arguments(&ast_fn.sig.inputs, args);
 
         path_attribute.update_parameters(arguments);
         path_attribute.update_parameters_parameter_in(into_params_types);
+
+        #[cfg(feature = "auto_types")]
+        path_attribute.update_request_body(body);
     }
 
     let path = Path::new(path_attribute, fn_name)

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -11,6 +11,23 @@ use crate::{parse_utils, AnyValue, Array, Required};
 use super::example::Example;
 use super::{PathType, PathTypeTree};
 
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub enum RequestBody<'r> {
+    Parsed(RequestBodyAttr<'r>),
+    #[cfg(feature = "auto_types")]
+    Ext(crate::ext::RequestBody<'r>),
+}
+
+impl ToTokens for RequestBody<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        match self {
+            Self::Parsed(parsed) => parsed.to_tokens(tokens),
+            #[cfg(feature = "auto_types")]
+            Self::Ext(ext) => ext.to_tokens(tokens),
+        }
+    }
+}
+
 /// Parsed information related to request body of path.
 ///
 /// Supported configuration options:

--- a/utoipa-gen/tests/path_derive_auto_types.rs
+++ b/utoipa-gen/tests/path_derive_auto_types.rs
@@ -70,6 +70,5 @@ fn path_operation_auto_types_default_response_type() {
     let value = serde_json::to_value(&doc).unwrap();
     let path = value.pointer("/paths/~1item/get").unwrap();
 
-    dbg!(&path);
     assert_json_eq!(&path.pointer("/responses").unwrap(), serde_json::json!({}))
 }

--- a/utoipa-gen/tests/path_derive_auto_types_actix.rs
+++ b/utoipa-gen/tests/path_derive_auto_types_actix.rs
@@ -1,11 +1,12 @@
 #![cfg(all(feature = "auto_types", feature = "actix_extras"))]
 
+use actix_web::web::{Form, Json};
 use std::fmt::Display;
 use utoipa::OpenApi;
 
 use actix_web::body::BoxBody;
 use actix_web::http::header::ContentType;
-use actix_web::{get, HttpResponse, Responder, ResponseError};
+use actix_web::{get, post, HttpResponse, Responder, ResponseError};
 use assert_json_diff::assert_json_eq;
 
 #[test]
@@ -86,6 +87,388 @@ fn path_operation_auto_types_responses() {
             "500": {
                 "description": "Error"
             }
+        })
+    )
+}
+
+#[test]
+fn path_operation_auto_types_fn_parameters() {
+    /// Test item to to return
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct Item<'s> {
+        value: &'s str,
+    }
+
+    #[derive(utoipa::IntoResponses)]
+    #[allow(unused)]
+    enum ItemResponse<'s> {
+        /// Item found
+        #[response(status = 200)]
+        Success(Item<'s>),
+        /// No item found
+        #[response(status = NOT_FOUND)]
+        NotFound,
+    }
+
+    impl Responder for ItemResponse<'static> {
+        type Body = BoxBody;
+
+        fn respond_to(self, _: &actix_web::HttpRequest) -> actix_web::HttpResponse<Self::Body> {
+            match self {
+                Self::Success(item) => HttpResponse::Ok()
+                    .content_type(ContentType::json())
+                    .body(serde_json::to_string(&item).expect("Item must serialize to json")),
+                Self::NotFound => HttpResponse::NotFound().finish(),
+            }
+        }
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct ItemBody {
+        value: String,
+    }
+
+    #[utoipa::path]
+    #[post("/item")]
+    #[allow(unused)]
+    async fn post_item(item: Json<ItemBody>) -> ItemResponse<'static> {
+        ItemResponse::Success(Item { value: "super" })
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(paths(post_item), components(schemas(ItemBody)))]
+    struct ApiDoc;
+
+    let doc = ApiDoc::openapi();
+    let value = serde_json::to_value(&doc).unwrap();
+    let path = value.pointer("/paths/~1item/post").unwrap();
+
+    assert_json_eq!(
+        &path.pointer("/responses").unwrap(),
+        serde_json::json!({
+            "200": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Item"
+                        }
+                    }
+                },
+                "description": "Item found",
+            },
+            "404": {
+                "description": "No item found"
+            },
+        })
+    );
+
+    assert_json_eq!(
+        &path.pointer("/requestBody"),
+        serde_json::json!({
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "$ref": "#/components/schemas/ItemBody"
+                    }
+                }
+            },
+            "description": "",
+            "required": true,
+        })
+    )
+}
+
+#[test]
+fn path_operation_optional_json_body() {
+    /// Test item to to return
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct Item<'s> {
+        value: &'s str,
+    }
+
+    #[derive(utoipa::IntoResponses)]
+    #[allow(unused)]
+    enum ItemResponse<'s> {
+        /// Item found
+        #[response(status = 200)]
+        Success(Item<'s>),
+        /// No item found
+        #[response(status = NOT_FOUND)]
+        NotFound,
+    }
+
+    impl Responder for ItemResponse<'static> {
+        type Body = BoxBody;
+
+        fn respond_to(self, _: &actix_web::HttpRequest) -> actix_web::HttpResponse<Self::Body> {
+            match self {
+                Self::Success(item) => HttpResponse::Ok()
+                    .content_type(ContentType::json())
+                    .body(serde_json::to_string(&item).expect("Item must serialize to json")),
+                Self::NotFound => HttpResponse::NotFound().finish(),
+            }
+        }
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct ItemBody {
+        value: String,
+    }
+
+    #[utoipa::path]
+    #[post("/item")]
+    #[allow(unused)]
+    async fn post_item(item: Option<Json<ItemBody>>) -> ItemResponse<'static> {
+        ItemResponse::Success(Item { value: "super" })
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(paths(post_item), components(schemas(ItemBody)))]
+    struct ApiDoc;
+
+    let doc = ApiDoc::openapi();
+    let value = serde_json::to_value(&doc).unwrap();
+    let path = value.pointer("/paths/~1item/post").unwrap();
+
+    assert_json_eq!(
+        &path.pointer("/responses").unwrap(),
+        serde_json::json!({
+            "200": {
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/Item"
+                        }
+                    }
+                },
+                "description": "Item found",
+            },
+            "404": {
+                "description": "No item found"
+            },
+        })
+    );
+
+    assert_json_eq!(
+        &path.pointer("/requestBody"),
+        serde_json::json!({
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ItemBody"
+                            }
+                        ],
+                        "nullable": true,
+                    }
+                }
+            },
+            "description": "",
+            "required": false,
+        })
+    )
+}
+
+#[test]
+fn path_operation_auto_types_tuple() {
+    /// Test item to to return
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct Item<'s> {
+        value: &'s str,
+    }
+
+    #[derive(utoipa::IntoResponses)]
+    #[allow(unused)]
+    enum ItemResponse<'s> {
+        /// Item found
+        #[response(status = 200)]
+        Success(Item<'s>),
+    }
+
+    impl Responder for ItemResponse<'static> {
+        type Body = BoxBody;
+
+        fn respond_to(self, _: &actix_web::HttpRequest) -> actix_web::HttpResponse<Self::Body> {
+            match self {
+                Self::Success(item) => HttpResponse::Ok()
+                    .content_type(ContentType::json())
+                    .body(serde_json::to_string(&item).expect("Item must serialize to json")),
+            }
+        }
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct ItemBody {
+        value: String,
+    }
+
+    #[utoipa::path]
+    #[post("/item")]
+    #[allow(unused)]
+    async fn post_item(item: Json<(ItemBody, String)>) -> ItemResponse<'static> {
+        ItemResponse::Success(Item { value: "super" })
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(paths(post_item), components(schemas(ItemBody)))]
+    struct ApiDoc;
+
+    let doc = ApiDoc::openapi();
+    let value = serde_json::to_value(&doc).unwrap();
+    let path = value.pointer("/paths/~1item/post").unwrap();
+
+    assert_json_eq!(
+        &path.pointer("/requestBody"),
+        serde_json::json!({
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "items": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/ItemBody"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        },
+                        "type": "array",
+                    }
+                }
+            },
+            "description": "",
+            "required": true,
+        })
+    )
+}
+
+#[test]
+fn path_operation_request_body_bytes() {
+    /// Test item to to return
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct Item<'s> {
+        value: &'s str,
+    }
+
+    #[derive(utoipa::IntoResponses)]
+    #[allow(unused)]
+    enum ItemResponse<'s> {
+        /// Item found
+        #[response(status = 200)]
+        Success(Item<'s>),
+    }
+
+    impl Responder for ItemResponse<'static> {
+        type Body = BoxBody;
+
+        fn respond_to(self, _: &actix_web::HttpRequest) -> actix_web::HttpResponse<Self::Body> {
+            match self {
+                Self::Success(item) => HttpResponse::Ok()
+                    .content_type(ContentType::json())
+                    .body(serde_json::to_string(&item).expect("Item must serialize to json")),
+            }
+        }
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct ItemBody {
+        value: String,
+    }
+
+    #[utoipa::path]
+    #[post("/item")]
+    #[allow(unused)]
+    async fn post_item(item: actix_web::web::Bytes) -> ItemResponse<'static> {
+        ItemResponse::Success(Item { value: "super" })
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(paths(post_item), components(schemas(ItemBody)))]
+    struct ApiDoc;
+
+    let doc = ApiDoc::openapi();
+    let value = serde_json::to_value(&doc).unwrap();
+    let path = value.pointer("/paths/~1item/post").unwrap();
+
+    assert_json_eq!(
+        &path.pointer("/requestBody"),
+        serde_json::json!({
+            "content": {
+                "application/octet-stream": {
+                    "schema": {
+                        "type": "string",
+                        "format": "binary",
+                    }
+                }
+            },
+            "description": "",
+            "required": true,
+        })
+    )
+}
+
+#[test]
+fn path_operation_request_body_form() {
+    /// Test item to to return
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct Item<'s> {
+        value: &'s str,
+    }
+
+    #[derive(utoipa::IntoResponses)]
+    #[allow(unused)]
+    enum ItemResponse<'s> {
+        /// Item found
+        #[response(status = 200)]
+        Success(Item<'s>),
+    }
+
+    impl Responder for ItemResponse<'static> {
+        type Body = BoxBody;
+
+        fn respond_to(self, _: &actix_web::HttpRequest) -> actix_web::HttpResponse<Self::Body> {
+            match self {
+                Self::Success(item) => HttpResponse::Ok()
+                    .content_type(ContentType::json())
+                    .body(serde_json::to_string(&item).expect("Item must serialize to json")),
+            }
+        }
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
+    struct ItemBody {
+        value: String,
+    }
+
+    #[utoipa::path]
+    #[post("/item")]
+    #[allow(unused)]
+    async fn post_item(item: Form<ItemBody>) -> ItemResponse<'static> {
+        ItemResponse::Success(Item { value: "super" })
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(paths(post_item), components(schemas(ItemBody)))]
+    struct ApiDoc;
+
+    let doc = ApiDoc::openapi();
+    let value = serde_json::to_value(&doc).unwrap();
+    let path = value.pointer("/paths/~1item/post").unwrap();
+
+    assert_json_eq!(
+        &path.pointer("/requestBody"),
+        serde_json::json!({
+            "content": {
+                "application/x-www-form-urlencoded": {
+                    "schema": {
+                        "$ref": "#/components/schemas/ItemBody"
+                    }
+                }
+            },
+            "description": "",
+            "required": true,
         })
     )
 }


### PR DESCRIPTION
Implement automatic request body recognition from path operation handler
arguments. Types such as `Json<T>`, `Form<T>` are recognized now and are
automatically added to the path operation schema as a request body if
`auto_types` feature flag is enabled.

Add `auto_types` fn args request body resolving for `actix_web`.

