### PR TITLE
add preserve_path_order feature

### DIFF
--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -37,6 +37,7 @@ openapi_extensions = []
 repr = ["utoipa-gen/repr"]
 preserve_order = []
 auto_types = ["utoipa-gen/auto_types"]
+preserve_path_order = []
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -180,7 +180,7 @@ impl OpenApi {
                 .paths
                 .paths
                 .retain(|path, _| self.paths.get_path_item(path).is_none());
-            self.paths.paths.append(&mut other.paths.paths);
+            self.paths.paths.extend(&mut other.paths.paths.into_iter());
         };
 
         if let Some(other_components) = &mut other.components {

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -670,16 +670,19 @@ mod tests {
             )
             .build();
 
-        let mut actual_value = Vec::new();
-
-        for path in paths_list.paths.keys() {
-            let path_item = paths_list.paths.get(path);
-            if let Some(path_item) = path_item {
-                for method in path_item.operations.keys() {
-                    actual_value.push((path.as_str(), method));
-                }
-            }
-        }
+        let actual_value = paths_list
+            .paths
+            .iter()
+            .flat_map(|(path, path_item)| {
+                path_item.operations.iter().fold(
+                    Vec::<(&str, &PathItemType)>::with_capacity(paths_list.paths.len()),
+                    |mut acc, (method, _)| {
+                        acc.push((path.as_str(), method));
+                        acc
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
 
         let get = PathItemType::Get;
         let post = PathItemType::Post;

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -4,7 +4,7 @@
 use std::iter;
 
 #[cfg(not(feature = "preserve_path_order"))]
-use std::{collections::BTreeMap};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -91,7 +91,9 @@ impl PathsBuilder {
     pub fn path<I: Into<String>>(mut self, path: I, item: PathItem) -> Self {
         let path_string = path.into();
         if let Some(existing_item) = self.paths.get_mut(&path_string) {
-            existing_item.operations.extend(&mut item.operations.into_iter());
+            existing_item
+                .operations
+                .extend(&mut item.operations.into_iter());
         } else {
             self.paths.insert(path_string, item);
         }

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -1,7 +1,10 @@
 //! Implements [OpenAPI Path Object][paths] types.
 //!
 //! [paths]: https://spec.openapis.org/oas/latest.html#paths-object
-use std::{collections::BTreeMap, iter};
+use std::iter;
+
+#[cfg(not(feature = "preserve_path_order"))]
+use std::{collections::BTreeMap};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -12,6 +15,11 @@ use super::{
     response::{Response, Responses},
     set_value, Deprecated, ExternalDocs, RefOr, Required, Schema, SecurityRequirement, Server,
 };
+
+#[cfg(not(feature = "preserve_path_order"))]
+type PathsMap<K, V> = BTreeMap<K, V>;
+#[cfg(feature = "preserve_path_order")]
+type PathsMap<K, V> = indexmap::IndexMap<K, V>;
 
 builder! {
     PathsBuilder;
@@ -28,7 +36,7 @@ builder! {
     pub struct Paths {
         /// Map of relative paths with [`PathItem`]s holding [`Operation`]s matching
         /// api endpoints.
-        pub paths: BTreeMap<String, PathItem>,
+        pub paths: PathsMap<String, PathItem>,
     }
 }
 
@@ -80,10 +88,10 @@ impl Paths {
 impl PathsBuilder {
     /// Append [`PathItem`] with path to map of paths. If path already exists it will merge [`Operation`]s of
     /// [`PathItem`] with already found path item operations.
-    pub fn path<I: Into<String>>(mut self, path: I, mut item: PathItem) -> Self {
+    pub fn path<I: Into<String>>(mut self, path: I, item: PathItem) -> Self {
         let path_string = path.into();
         if let Some(existing_item) = self.paths.get_mut(&path_string) {
-            existing_item.operations.append(&mut item.operations);
+            existing_item.operations.extend(&mut item.operations.into_iter());
         } else {
             self.paths.insert(path_string, item);
         }
@@ -127,14 +135,14 @@ builder! {
         /// Map of operations in this [`PathItem`]. Operations can hold only one operation
         /// per [`PathItemType`].
         #[serde(flatten)]
-        pub operations: BTreeMap<PathItemType, Operation>,
+        pub operations: PathsMap<PathItemType, Operation>,
     }
 }
 
 impl PathItem {
     /// Construct a new [`PathItem`] with provided [`Operation`] mapped to given [`PathItemType`].
     pub fn new<O: Into<Operation>>(path_item_type: PathItemType, operation: O) -> Self {
-        let operations = BTreeMap::from_iter(iter::once((path_item_type, operation.into())));
+        let operations = PathsMap::from_iter(iter::once((path_item_type, operation.into())));
 
         Self {
             operations,


### PR DESCRIPTION
As discussed in [602](https://github.com/juhaku/utoipa/issues/602) this PR introduces a cargo feature named preserve_path_order to retain path order when serializing OpenAPI paths.

Closes #602 