### PR TITLE
Make sure to parse a comma token after the status in IntoResponses

### DIFF
--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -518,6 +518,10 @@ impl Parse for DeriveIntoResponsesValue {
             return Err(Error::new(first_span, MISSING_STATUS_ERROR));
         }
 
+        if !input.is_empty() {
+            input.parse::<Token![,]>()?;
+        }
+
         while !input.is_empty() {
             let ident = input.parse::<Ident>()?;
             let attribute_name = &*ident.to_string();
@@ -547,7 +551,7 @@ impl Parse for DeriveIntoResponsesValue {
             }
 
             if !input.is_empty() {
-                input.parse::<Comma>()?;
+                input.parse::<Token![,]>()?;
             }
         }
 


### PR DESCRIPTION
This fixes the issue I filed earlier today: #629 

Just adds a little logic to the `DeriveIntoResponsesValue` implementation that makes it consume a comma after consuming the `status` attribute if there is more to consume.

Fixes #629 