### PR TITLE
Add support for chrono::NaiveTime

### DIFF
--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -153,7 +153,7 @@ fn is_primitive(name: &str) -> bool {
 fn is_primitive_chrono(name: &str) -> bool {
     matches!(
         name,
-        "DateTime" | "Date" | "NaiveDate" | "Duration" | "NaiveDateTime"
+        "DateTime" | "Date" | "NaiveDate" | "NaiveTime" | "Duration" | "NaiveDateTime"
     )
 }
 
@@ -184,6 +184,8 @@ impl ToTokens for SchemaType<'_> {
             "NaiveDateTime" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
             #[cfg(feature = "chrono")]
             "NaiveDate" => tokens.extend(quote!(utoipa::openapi::SchemaType::String)),
+            #[cfg(feature = "chrono")]
+            "NaiveTime" => tokens.extend(quote!(utoipa::openapi::SchemaType::String)),
             #[cfg(any(feature = "chrono", feature = "time"))]
             "Date" | "Duration" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
             #[cfg(feature = "decimal")]
@@ -266,7 +268,10 @@ impl Type<'_> {
 
             #[cfg(feature = "chrono")]
             if !known_format {
-                known_format = matches!(name, "DateTime" | "Date" | "NaiveDate" | "NaiveDateTime");
+                known_format = matches!(
+                    name,
+                    "DateTime" | "Date" | "NaiveDate" | "NaiveTime" | "NaiveDateTime"
+                );
             }
 
             #[cfg(feature = "uuid")]
@@ -325,6 +330,8 @@ impl ToTokens for Type<'_> {
             "f64" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Double) }),
             #[cfg(feature = "chrono")]
             "NaiveDate" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Date) }),
+            #[cfg(feature = "chrono")]
+            "NaiveTime" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::String) }),
             #[cfg(feature = "chrono")]
             "DateTime" => tokens.extend(quote! { utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::DateTime) }),
             #[cfg(feature = "chrono")]

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -2694,7 +2694,7 @@ fn derive_struct_xml_with_optional_vec() {
 #[test]
 fn derive_component_with_chrono_feature() {
     #![allow(deprecated)] // allow deprecated Date in tests as long as it is available from chrono
-    use chrono::{Date, DateTime, Duration, NaiveDate, NaiveDateTime, Utc};
+    use chrono::{Date, DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 
     let post = api_doc! {
         struct Post {
@@ -2704,6 +2704,7 @@ fn derive_component_with_chrono_feature() {
             naive_datetime: NaiveDateTime,
             date: Date<Utc>,
             naive_date: NaiveDate,
+            naive_time: NaiveTime,
             duration: Duration,
         }
     };
@@ -2717,6 +2718,8 @@ fn derive_component_with_chrono_feature() {
         "properties.date.format" = r#""date""#, "Post date format"
         "properties.naive_date.type" = r#""string""#, "Post date type"
         "properties.naive_date.format" = r#""date""#, "Post date format"
+        "properties.naive_time.type" = r#""string""#, "Post time type"
+        "properties.naive_time.format" = r#""null""#, "Post time format"
         "properties.duration.type" = r#""string""#, "Post duration type"
         "properties.duration.format" = r#"null"#, "Post duration format"
         "properties.id.type" = r#""integer""#, "Post id type"

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -53,7 +53,7 @@
 //!   without defining the `parameter_in` attribute. See [axum extras support][axum_path]
 //!   or [examples](https://github.com/juhaku/utoipa/tree/master/examples) for more details.
 //! * **debug** Add extra traits such as debug traits to openapi definitions and elsewhere.
-//! * **chrono** Add support for [chrono](https://crates.io/crates/chrono) `DateTime`, `Date`, `NaiveDate` and `Duration`
+//! * **chrono** Add support for [chrono](https://crates.io/crates/chrono) `DateTime`, `Date`, `NaiveDate`, `NaiveTime` and `Duration`
 //!   types. By default these types are parsed to `string` types with additional `format` information.
 //!   `format: date-time` for `DateTime` and `format: date` for `Date` and `NaiveDate` according
 //!   [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14) as `ISO-8601`. To


### PR DESCRIPTION
Since the OpenAPI spec does not explicitly support times without attached dates, I have implemented this in the same way that support for `duration` was done, but formatting them as strings.