### PR TITLE
Rename `auto_types` feature flag

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -11,14 +11,14 @@ if [[ "$crate" == "utoipa" ]]; then
 elif [[ "$crate" == "utoipa-gen" ]]; then
     cargo test -p utoipa-gen --features utoipa/actix_extras,chrono,decimal,utoipa/uuid,utoipa/time,time,utoipa/repr
 
-    cargo test -p utoipa-gen --test path_derive_auto_types --features auto_types
+    cargo test -p utoipa-gen --test path_derive_auto_into_responses --features auto_into_responses
     cargo test -p utoipa-gen --test path_derive_actix --test path_parameter_derive_actix --features actix_extras
-    cargo test -p utoipa-gen --test path_derive_auto_types_actix --features actix_extras,auto_types
+    cargo test -p utoipa-gen --test path_derive_auto_into_responses_actix --features actix_extras,utoipa/auto_into_responses
 
     cargo test -p utoipa-gen --test path_derive_rocket --features rocket_extras
 
     cargo test -p utoipa-gen --test path_derive_axum_test --features axum_extras
-    cargo test -p utoipa-gen --test path_derive_auto_types_axum --features axum_extras,auto_types
+    cargo test -p utoipa-gen --test path_derive_auto_into_responses_axum --features axum_extras,utoipa/auto_into_responses
 elif [[ "$crate" == "utoipa-swagger-ui" ]]; then
     cargo test -p utoipa-swagger-ui --features actix-web,rocket,axum
 fi

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -51,4 +51,6 @@ time = []
 smallvec = []
 repr = []
 indexmap = []
-auto_types = []
+
+# EXPERIEMENTAL! use with cauntion
+auto_into_responses = []

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -12,7 +12,7 @@ use syn::{punctuated::Punctuated, token::Comma, ItemFn};
 use crate::component::{ComponentSchema, ComponentSchemaProps, TypeTree};
 use crate::path::{PathOperation, PathTypeTree};
 
-#[cfg(feature = "auto_types")]
+#[cfg(feature = "auto_into_responses")]
 pub mod auto_types;
 
 #[cfg(feature = "actix_extras")]

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -73,7 +73,7 @@ fn split_path_args_and_request(
     impl Iterator<Item = TypeTree>,
     impl Iterator<Item = TypeTree>,
 ) {
-    let (path_args, _body_types): (Vec<FnArg>, Vec<FnArg>) = value_args
+    let (path_args, body_types): (Vec<FnArg>, Vec<FnArg>) = value_args
         .into_iter()
         .filter(|arg| {
             arg.ty.is("Path") || arg.ty.is("Json") || arg.ty.is("Form") || arg.ty.is("Bytes")
@@ -98,17 +98,7 @@ fn split_path_args_and_request(
                     unreachable!("Value arguments does not have ValueType::Object arguments")
                 }
             }),
-        {
-            #[cfg(feature = "auto_types")]
-            {
-                _body_types.into_iter().map(|json| json.ty)
-            }
-
-            #[cfg(not(feature = "auto_types"))]
-            {
-                std::iter::empty()
-            }
-        },
+        body_types.into_iter().map(|json| json.ty),
     )
 }
 

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1296,14 +1296,14 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
         feature = "actix_extras",
         feature = "rocket_extras",
         feature = "axum_extras",
-        feature = "auto_types"
+        feature = "auto_into_responses"
     ))]
     let mut path_attribute = path_attribute;
 
     let ast_fn = syn::parse::<ItemFn>(item).unwrap_or_abort();
     let fn_name = &*ast_fn.sig.ident.to_string();
 
-    #[cfg(feature = "auto_types")]
+    #[cfg(feature = "auto_into_responses")]
     {
         if let Some(responses) = ext::auto_types::parse_fn_operation_responses(&ast_fn) {
             path_attribute.responses_from_into_responses(responses);
@@ -1334,14 +1334,13 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
     {
         use ext::ArgumentResolver;
         let args = resolved_path.as_mut().map(|path| mem::take(&mut path.args));
-        let (arguments, into_params_types, _body) =
+        let (arguments, into_params_types, body) =
             PathOperations::resolve_arguments(&ast_fn.sig.inputs, args);
 
         path_attribute.update_parameters(arguments);
         path_attribute.update_parameters_parameter_in(into_params_types);
 
-        #[cfg(feature = "auto_types")]
-        path_attribute.update_request_body(_body);
+        path_attribute.update_request_body(body);
     }
 
     let path = Path::new(path_attribute, fn_name)

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -14,7 +14,6 @@ use super::{PathType, PathTypeTree};
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum RequestBody<'r> {
     Parsed(RequestBodyAttr<'r>),
-    #[cfg(feature = "auto_types")]
     #[cfg(any(
         feature = "actix_extras",
         feature = "rocket_extras",
@@ -27,7 +26,6 @@ impl ToTokens for RequestBody<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
         match self {
             Self::Parsed(parsed) => parsed.to_tokens(tokens),
-            #[cfg(feature = "auto_types")]
             #[cfg(any(
                 feature = "actix_extras",
                 feature = "rocket_extras",

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -1,5 +1,3 @@
-#![cfg(not(feature = "auto_types"))]
-
 use std::collections::BTreeMap;
 
 use assert_json_diff::{assert_json_eq, assert_json_matches, CompareMode, Config, NumericMode};

--- a/utoipa-gen/tests/path_derive_auto_into_responses.rs
+++ b/utoipa-gen/tests/path_derive_auto_into_responses.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "auto_types", feature = "axum_extras"))]
+#![cfg(feature = "auto_into_responses")]
 
 use assert_json_diff::assert_json_eq;
 use utoipa::OpenApi;
@@ -54,4 +54,21 @@ fn path_operation_auto_types_responses() {
             }
         })
     )
+}
+
+#[test]
+fn path_operation_auto_types_default_response_type() {
+    #[utoipa::path(get, path = "/item")]
+    #[allow(unused)]
+    async fn post_item() {}
+
+    #[derive(OpenApi)]
+    #[openapi(paths(post_item))]
+    struct ApiDoc;
+
+    let doc = ApiDoc::openapi();
+    let value = serde_json::to_value(&doc).unwrap();
+    let path = value.pointer("/paths/~1item/get").unwrap();
+
+    assert_json_eq!(&path.pointer("/responses").unwrap(), serde_json::json!({}))
 }

--- a/utoipa-gen/tests/path_derive_auto_into_responses_actix.rs
+++ b/utoipa-gen/tests/path_derive_auto_into_responses_actix.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "auto_types", feature = "actix_extras"))]
+#![cfg(all(feature = "auto_into_responses", feature = "actix_extras"))]
 
 use actix_web::web::{Form, Json};
 use std::fmt::Display;

--- a/utoipa-gen/tests/path_derive_auto_into_responses_axum.rs
+++ b/utoipa-gen/tests/path_derive_auto_into_responses_axum.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "auto_types")]
+#![cfg(all(feature = "auto_into_responses", feature = "axum_extras"))]
 
 use assert_json_diff::assert_json_eq;
 use utoipa::OpenApi;
@@ -54,21 +54,4 @@ fn path_operation_auto_types_responses() {
             }
         })
     )
-}
-
-#[test]
-fn path_operation_auto_types_default_response_type() {
-    #[utoipa::path(get, path = "/item")]
-    #[allow(unused)]
-    async fn post_item() {}
-
-    #[derive(OpenApi)]
-    #[openapi(paths(post_item))]
-    struct ApiDoc;
-
-    let doc = ApiDoc::openapi();
-    let value = serde_json::to_value(&doc).unwrap();
-    let path = value.pointer("/paths/~1item/get").unwrap();
-
-    assert_json_eq!(&path.pointer("/responses").unwrap(), serde_json::json!({}))
 }

--- a/utoipa-gen/tests/path_parameter_derive_actix.rs
+++ b/utoipa-gen/tests/path_parameter_derive_actix.rs
@@ -1,5 +1,4 @@
 #![cfg(feature = "actix_extras")]
-#![cfg(not(feature = "auto_types"))]
 
 use utoipa::OpenApi;
 

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -36,8 +36,10 @@ indexmap = ["utoipa-gen/indexmap"]
 openapi_extensions = []
 repr = ["utoipa-gen/repr"]
 preserve_order = []
-auto_types = ["utoipa-gen/auto_types"]
 preserve_path_order = []
+
+# EXPERIEMENTAL! use with cauntion
+auto_into_responses = ["utoipa-gen/auto_into_responses"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -878,6 +878,7 @@ pub trait IntoResponses {
     fn responses() -> BTreeMap<String, openapi::RefOr<openapi::response::Response>>;
 }
 
+#[cfg(feature = "auto_into_responses")]
 impl<T: IntoResponses, E: IntoResponses> IntoResponses for Result<T, E> {
     fn responses() -> BTreeMap<String, openapi::RefOr<openapi::response::Response>> {
         let mut responses = T::responses();
@@ -887,6 +888,7 @@ impl<T: IntoResponses, E: IntoResponses> IntoResponses for Result<T, E> {
     }
 }
 
+#[cfg(feature = "auto_into_responses")]
 impl IntoResponses for () {
     fn responses() -> BTreeMap<String, openapi::RefOr<openapi::response::Response>> {
         BTreeMap::new()


### PR DESCRIPTION
Rename `auto_types` feature flag to `auto_into_responses` since it actually is only used for automatic IntoResponses definition. This feature is higly experiemental and should be used with cauntion. It is more likely that the final implementation will look different thus changes are to be expected.

Simultaneusly allow automatic resolvation for request bodies without extra feature flag. Supported only with `actix_extras` feature by now.