### PR TITLE
Add automatic body recognition for rocket

### DIFF
--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -27,7 +27,7 @@ serde = "1"
 actix-web = { version = "4", features = ["macros"], default-features = false }
 axum = "0.6"
 paste = "1"
-rocket = "0.5.0-rc.3"
+rocket = { version = "0.5.0-rc.3", features = ["json"] }
 smallvec = { version = "1.10", features = ["serde"] }
 rust_decimal = "1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -249,12 +249,14 @@ pub struct ArgValue {
 pub struct ResolvedOperation {
     pub path_operation: PathOperation,
     pub path: String,
+    pub body: String,
 }
 
 pub trait ArgumentResolver {
     fn resolve_arguments(
         _: &'_ Punctuated<syn::FnArg, Comma>,
         _: Option<Vec<MacroArg>>,
+        _: String,
     ) -> (
         Option<Vec<ValueArgument<'_>>>,
         Option<Vec<IntoParamsType<'_>>>,

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -21,6 +21,7 @@ impl ArgumentResolver for PathOperations {
     fn resolve_arguments(
         fn_args: &Punctuated<syn::FnArg, Comma>,
         macro_args: Option<Vec<MacroArg>>,
+        _: String,
     ) -> (
         Option<Vec<super::ValueArgument<'_>>>,
         Option<Vec<super::IntoParamsType<'_>>>,
@@ -121,6 +122,7 @@ impl PathOperationResolver for PathOperations {
                         path_operation: PathOperation::from_ident(
                             attribute.path().get_ident().unwrap(),
                         ),
+                        body: String::new(),
                     }),
                     Err(error) => abort!(
                         error.span(),

--- a/utoipa-gen/src/ext/axum.rs
+++ b/utoipa-gen/src/ext/axum.rs
@@ -16,6 +16,7 @@ impl ArgumentResolver for PathOperations {
     fn resolve_arguments(
         args: &'_ Punctuated<syn::FnArg, Comma>,
         macro_args: Option<Vec<super::MacroArg>>,
+        _: String,
     ) -> (
         Option<Vec<super::ValueArgument<'_>>>,
         Option<Vec<super::IntoParamsType<'_>>>,

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1334,8 +1334,13 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
         use ext::ArgumentResolver;
         use path::parameter::Parameter;
         let args = resolved_path.as_mut().map(|path| mem::take(&mut path.args));
+        let body = resolved_operation
+            .as_mut()
+            .map(|path| mem::take(&mut path.body))
+            .unwrap_or_default();
+
         let (arguments, into_params_types, body) =
-            PathOperations::resolve_arguments(&ast_fn.sig.inputs, args);
+            PathOperations::resolve_arguments(&ast_fn.sig.inputs, args, body);
 
         let parameters = arguments
             .into_iter()


### PR DESCRIPTION
Add functionality to `utoipa` to recognize request body from rocket handler function based on `data` attribute and handler function argument.
```rust
#[post("/hello", data = "<hello>")]
fn post_hello(
    hello: Json<Hello>,
) -> String {
    "Hello".to_string()
}
```

#591 