### PR TITLE
Fix `Option<Query<T>>` type support

### DIFF
--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -461,9 +461,21 @@ pub mod fn_arg {
     // if type is either Path or Query with direct children as Object types without generics
     #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
     pub(super) fn is_into_params(fn_arg: &FnArg) -> bool {
-        (fn_arg.ty.is("Path") || fn_arg.ty.is("Query"))
-            && fn_arg
+        use crate::component::GenericType;
+        let mut ty = &fn_arg.ty;
+
+        if fn_arg.ty.generic_type == Some(GenericType::Option) {
+            ty = fn_arg
                 .ty
+                .children
+                .as_ref()
+                .expect("FnArg Option must have children")
+                .first()
+                .expect("FnArg Option must have 1 child");
+        }
+
+        (ty.is("Path") || ty.is("Query"))
+            && ty
                 .children
                 .as_ref()
                 .map(|children| {

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -971,8 +971,6 @@ fn path_with_all_args_using_custom_uuid() {
     let doc = serde_json::to_value(Doc::openapi()).unwrap();
     let operation = doc.pointer("/paths/~1item~1{custom_uuid}/post").unwrap();
 
-    dbg!(&operation);
-
     assert_json_eq!(
         &operation.pointer("/parameters").unwrap(),
         json!([

--- a/utoipa-gen/tests/path_derive_axum_test.rs
+++ b/utoipa-gen/tests/path_derive_axum_test.rs
@@ -457,3 +457,41 @@ fn path_with_path_query_body_resolved() {
         })
     )
 }
+
+#[test]
+fn test_into_params_for_option_query_type() {
+    #[utoipa::path(
+        get,
+        path = "/items",
+        params(("id" = u32, Query, description = "")),
+        responses(
+            (status = 200, description = "success response")
+        )
+    )]
+    #[allow(unused)]
+    async fn get_item(id: Option<Query<u32>>) {}
+
+    #[derive(OpenApi)]
+    #[openapi(paths(get_item))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
+    let operation = doc.pointer("/paths/~1items/get").unwrap();
+
+    assert_json_eq!(
+        operation.pointer("/parameters"),
+        json!([
+            {
+                "description": "",
+                "in": "query",
+                "name": "id",
+                "required": true,
+                "schema": {
+                    "format": "int32",
+                    "type": "integer",
+                    "minimum": 0
+                }
+            }
+        ])
+    )
+}


### PR DESCRIPTION
Fix `Option<Query<T>>` for primitive types. Prior to this commit defining before mentioned type as an argument to path operation handler caused a compile error in 3.4.0 release. This bug has been there before but it manifested only after the changes regarding automatic query parameter detection was made.

This commit allows optional query parameters for handler function:
```rust
 async fn get_item(id: Option<Query<u32>>) {}
```

**Note!** The automatic query parameter detection does not work for primitive types on `axum` and in `actix_web` frameworks because it has never been implemented. It will always be expected to work with `IntoParams` trait. This said with these frameworks the primitive query parameters if not used with `IntoParams` must be declared manually to the `#[utoipa::path(params(...))]` macro as input arguments.

#677 #675 