### PR TITLE
Disable automatic parameter recognition

### DIFF
--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -73,20 +73,20 @@ impl<'p> PathAttr<'p> {
     ) {
         let ext_params = ext_parameters.into_iter();
 
-        if self.params.is_empty() {
-            self.params = ext_params.collect();
-        } else {
-            let (existing_params, new_params): (Vec<Parameter>, Vec<Parameter>) =
-                ext_params.partition(|param| self.params.iter().any(|p| p == param));
+        let (existing_params, new_params): (Vec<Parameter>, Vec<Parameter>) =
+            ext_params.partition(|param| self.params.iter().any(|p| p == param));
 
-            for existing in existing_params {
-                if let Some(param) = self.params.iter_mut().find(|p| **p == existing) {
-                    param.merge(existing);
-                }
+        for existing in existing_params {
+            if let Some(param) = self.params.iter_mut().find(|p| **p == existing) {
+                param.merge(existing);
             }
-
-            self.params.extend(new_params.into_iter());
         }
+
+        self.params.extend(
+            new_params
+                .into_iter()
+                .filter(|param| !matches!(param, Parameter::IntoParamsIdent(_))),
+        );
     }
 }
 

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -792,7 +792,8 @@ fn path_with_all_args() {
         status: String,
     }
 
-    #[utoipa::path]
+    // NOTE! temporarily disable automatic parameter recognition
+    #[utoipa::path(params(Filter))]
     #[post("/item/{id}/{name}")]
     async fn post_item(
         _path: Path<(i32, String)>,
@@ -813,23 +814,6 @@ fn path_with_all_args() {
         &operation.pointer("/parameters").unwrap(),
         json!([
               {
-                  "in": "path",
-                  "name": "id",
-                  "required": true,
-                  "schema": {
-                      "format": "int32",
-                      "type": "integer"
-                  }
-              },
-              {
-                  "in": "path",
-                  "name": "name",
-                  "required": true,
-                  "schema": {
-                      "type": "string"
-                  }
-              },
-              {
                   "in": "query",
                   "name": "age",
                   "required": true,
@@ -841,6 +825,23 @@ fn path_with_all_args() {
               {
                   "in": "query",
                   "name": "status",
+                  "required": true,
+                  "schema": {
+                      "type": "string"
+                  }
+              },
+              {
+                  "in": "path",
+                  "name": "id",
+                  "required": true,
+                  "schema": {
+                      "format": "int32",
+                      "type": "integer"
+                  }
+              },
+              {
+                  "in": "path",
+                  "name": "name",
                   "required": true,
                   "schema": {
                       "type": "string"
@@ -958,7 +959,8 @@ fn path_with_all_args_using_custom_uuid() {
         }
     }
 
-    #[utoipa::path]
+    // NOTE! temporarily disable automatic parameter recognition
+    #[utoipa::path(params(Id))]
     #[post("/item/{custom_uuid}")]
     async fn post_item(_path: Path<Id>, _body: Json<Item>) -> Result<Json<Item>, Error> {
         Ok(Json(Item(String::new())))

--- a/utoipa-gen/tests/path_derive_axum_test.rs
+++ b/utoipa-gen/tests/path_derive_axum_test.rs
@@ -386,7 +386,7 @@ fn path_with_path_query_body_resolved() {
         status: String,
     }
 
-    #[utoipa::path(path = "/item/{id}/{name}", post)]
+    #[utoipa::path(path = "/item/{id}/{name}", params(Filter), post)]
     #[allow(unused)]
     async fn post_item(
         _path: Path<(i32, String)>,
@@ -407,23 +407,6 @@ fn path_with_path_query_body_resolved() {
         &operation.pointer("/parameters").unwrap(),
         json!([
               {
-                  "in": "path",
-                  "name": "id",
-                  "required": true,
-                  "schema": {
-                      "format": "int32",
-                      "type": "integer"
-                  }
-              },
-              {
-                  "in": "path",
-                  "name": "name",
-                  "required": true,
-                  "schema": {
-                      "type": "string"
-                  }
-              },
-              {
                   "in": "query",
                   "name": "age",
                   "required": true,
@@ -435,6 +418,23 @@ fn path_with_path_query_body_resolved() {
               {
                   "in": "query",
                   "name": "status",
+                  "required": true,
+                  "schema": {
+                      "type": "string"
+                  }
+              },
+              {
+                  "in": "path",
+                  "name": "id",
+                  "required": true,
+                  "schema": {
+                      "format": "int32",
+                      "type": "integer"
+                  }
+              },
+              {
+                  "in": "path",
+                  "name": "name",
                   "required": true,
                   "schema": {
                       "type": "string"

--- a/utoipa-gen/tests/path_derive_rocket.rs
+++ b/utoipa-gen/tests/path_derive_rocket.rs
@@ -440,6 +440,7 @@ fn path_with_all_args_and_body() {
         bar: i64,
     }
 
+    // NOTE! temporarily disable automatic parameter recognition
     #[utoipa::path(
     responses(
         (
@@ -447,6 +448,7 @@ fn path_with_all_args_and_body() {
         ),
         params(
             ("id", description = "Hello id"),
+            QueryParams
         )
     )]
     #[post("/hello/<id>/<name>?<colors>&<rest..>", data = "<hello>")]
@@ -484,6 +486,23 @@ fn path_with_all_args_and_body() {
             },
             {
                 "in": "query",
+                "name": "foo",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "in": "query",
+                "name": "bar",
+                "required": true,
+                "schema": {
+                    "format": "int64",
+                    "type": "integer"
+                }
+            },
+            {
+                "in": "query",
                 "name": "colors",
                 "required": true,
                 "schema": {
@@ -500,24 +519,8 @@ fn path_with_all_args_and_body() {
                 "schema": {
                     "type": "string"
                 }
-            },
-            {
-                "in": "query",
-                "name": "foo",
-                "required": true,
-                "schema": {
-                    "type": "string"
-                }
-            },
-            {
-                "in": "query",
-                "name": "bar",
-                "required": true,
-                "schema": {
-                    "format": "int64",
-                    "type": "integer"
-                }
-            },
+            }
+
         ])
     );
     assert_json_eq!(
@@ -569,9 +572,13 @@ fn path_with_enum_path_param() {
         }
     }
 
+    // NOTE! temporarily disable automatic parameter recognition
     #[utoipa::path(
         post,
         path = "/item",
+        params(
+            ApiVersion
+        ),
         responses(
             (status = 201, description = "Item created successfully"),
         ),


### PR DESCRIPTION
Temporarily disable automatic parameter recognition. This is to mitigate the current issues in `IntoParams` implementation furhter discussed in issues #675 #677 #687. This commit restores the old behavior where the parameters must be declared with `params(...)` attribute within the `#[utoipa::path(...)]` attribute macro. The temporary disablement is to allow furhter releases not be blocked by the changes in the master branch.

The automatic parameter recognition still needs some work and most likely another approach need to experiemented before it can be finally completed.