### PR TITLE
Fix `Arc<T>` and `Rc<T>` and `SmallVec<[T]>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also an awesome type of beer 
 - **indexmap** Add support for [indexmap](https://crates.io/crates/indexmap). When enabled `IndexMap` will be rendered as a map similar to
   `BTreeMap` and `HashMap`.
 - **non_strict_integers** Add support for non-standard integer formats `int8`, `int16`, `uint8`, `uint16`, `uint32`, and `uint64`.
+- **rc_schema** Add `ToSchema` support for `Arc<T>` and `Rc<T>` types. **Note!** serde `rc` feature flag must be enabled separately to allow 
+  serialization and deserialization of `Arc<T>` and `Rc<T>` types. See more about [serde feature flags](https://serde.rs/feature-flags.html).
 
 Utoipa implicitly has partial support for `serde` attributes. See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html#partial-serde-attributes-support) for more details.
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -9,7 +9,7 @@ echo "Testing crate: $crate..."
 if [[ "$crate" == "utoipa" ]]; then
     cargo test -p utoipa --features openapi_extensions,preserve_order,preserve_path_order,debug
 elif [[ "$crate" == "utoipa-gen" ]]; then
-    cargo test -p utoipa-gen --features utoipa/actix_extras,chrono,decimal,utoipa/uuid,utoipa/time,time,utoipa/repr
+    cargo test -p utoipa-gen --features utoipa/actix_extras,chrono,decimal,utoipa/uuid,utoipa/time,time,utoipa/repr,utoipa/smallvec,smallvec,rc_schema,utoipa/rc_schema
 
     cargo test -p utoipa-gen --test path_derive_auto_into_responses --features auto_into_responses,utoipa/uuid,uuid
     cargo test -p utoipa-gen --test path_derive_actix --test path_parameter_derive_actix --features actix_extras,utoipa/uuid,uuid

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utoipa-gen"
 description = "Code generation implementation for utoipa"
-version = "3.4.2"
+version = "3.4.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -50,6 +50,7 @@ time = []
 smallvec = []
 repr = []
 indexmap = []
+rc_schema = []
 
 # EXPERIEMENTAL! use with cauntion
 auto_into_responses = []

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use std::{borrow::Cow, cell::RefCell, collections::HashMap, marker::PhantomData, vec};
 
 use assert_json_diff::{assert_json_eq, assert_json_matches, CompareMode, Config, NumericMode};
@@ -3448,8 +3447,8 @@ fn derive_component_with_raw_identifier() {
     )
 }
 
-#[cfg(feature = "smallvec")]
 #[test]
+#[cfg(feature = "smallvec")]
 fn derive_component_with_smallvec_feature() {
     use smallvec::SmallVec;
 
@@ -4602,7 +4601,10 @@ fn derive_schema_with_unit_hashmap() {
 }
 
 #[test]
+#[cfg(feature = "rc_schema")]
 fn derive_struct_with_arc() {
+    use std::sync::Arc;
+
     let greeting = api_doc! {
         struct Greeting {
             greeting: Arc<String>
@@ -4626,9 +4628,13 @@ fn derive_struct_with_arc() {
 }
 
 #[test]
+#[cfg(feature = "rc_schema")]
 fn derive_struct_with_nested_arc() {
+    use std::sync::Arc;
+
     let greeting = api_doc! {
         struct Greeting {
+            #[allow(clippy::redundant_allocation)]
             greeting: Arc<Arc<String>>
         }
     };
@@ -4650,7 +4656,10 @@ fn derive_struct_with_nested_arc() {
 }
 
 #[test]
+#[cfg(feature = "rc_schema")]
 fn derive_struct_with_collection_of_arcs() {
+    use std::sync::Arc;
+
     let greeting = api_doc! {
         struct Greeting {
             greeting: Arc<Vec<String>>
@@ -4666,6 +4675,33 @@ fn derive_struct_with_collection_of_arcs() {
                         "type": "string",
                     },
                     "type": "array"
+                },
+            },
+            "required": [
+                "greeting"
+            ],
+            "type": "object"
+        })
+    )
+}
+
+#[test]
+#[cfg(feature = "rc_schema")]
+fn derive_struct_with_rc() {
+    use std::rc::Rc;
+
+    let greeting = api_doc! {
+        struct Greeting {
+            greeting: Rc<String>
+        }
+    };
+
+    assert_json_eq!(
+        greeting,
+        json!({
+            "properties": {
+                "greeting": {
+                    "type": "string"
                 },
             },
             "required": [

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utoipa"
 description = "Compile time generated OpenAPI documentation for Rust"
-version = "3.4.1"
+version = "3.4.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -37,6 +37,7 @@ openapi_extensions = []
 repr = ["utoipa-gen/repr"]
 preserve_order = []
 preserve_path_order = []
+rc_schema = ["utoipa-gen/rc_schema"]
 
 # EXPERIEMENTAL! use with cauntion
 auto_into_responses = ["utoipa-gen/auto_into_responses"]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -83,6 +83,8 @@
 //! * **indexmap** Add support for [indexmap](https://crates.io/crates/indexmap). When enabled `IndexMap` will be rendered as a map similar to
 //!   `BTreeMap` and `HashMap`.
 //! * **non_strict_integers** Add support for non-standard integer formats `int8`, `int16`, `uint8`, `uint16`, `uint32`, and `uint64`.
+//! * **rc_schema** Add `ToSchema` support for `Arc<T>` and `Rc<T>` types. **Note!** serde `rc` feature flag must be enabled separately to allow
+//!   serialization and deserialization of `Arc<T>` and `Rc<T>` types. See more about [serde feature flags](https://serde.rs/feature-flags.html).
 //!
 //! Utoipa implicitly has partial support for `serde` attributes. See [`ToSchema` derive][serde] for more details.
 //!
@@ -245,6 +247,7 @@
 //! * Browse to [examples](https://github.com/juhaku/utoipa/tree/master/examples) for more comprehensive examples.
 //! * Check [`derive@IntoResponses`] and [`derive@ToResponse`] for examples on deriving responses.
 //! * More about OpenAPI security in [security documentation][security].
+//! * Dump generated API doc to file at build time. See [issue 214 comment](https://github.com/juhaku/utoipa/issues/214#issuecomment-1179589373).
 //!
 //! [path]: attr.path.html
 //! [rocket_path]: attr.path.html#rocket_extras-support-for-rocket


### PR DESCRIPTION
This commit adds `rc_schema` feature flag that enables `ToSchema` support for `Arc<T>` and `Rc<T>` types. This does not itself enable serde `rc` feature flag but it must be enabled separately.

Also this fixes `smallvec` support where it previously created double nested array in generated schema.

#698 #691 