### PR TITLE
allow and ignore #[doc(...)] tags in ToSchema derive

### DIFF
--- a/utoipa-gen/src/doc_comment.rs
+++ b/utoipa-gen/src/doc_comment.rs
@@ -1,7 +1,6 @@
 use std::ops::Deref;
 
 use proc_macro2::Ident;
-use proc_macro_error::abort_call_site;
 use syn::{Attribute, Expr, Lit, Meta};
 
 const DOC_ATTRIBUTE_TYPE: &str = "doc";
@@ -50,7 +49,8 @@ impl CommentAttributes {
                     None
                 }
             }
-            _ => abort_call_site!("Expected only Meta::NameValue type"),
+            // ignore `#[doc(hidden)]` and similar tags.
+            _ => None,
         }
     }
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -4739,3 +4739,17 @@ fn derive_struct_with_rc() {
         })
     )
 }
+
+#[test]
+fn derive_doc_hidden() {
+    let map = api_doc! {
+        #[doc(hidden)]
+        struct Map {
+            map: HashMap<String, String>,
+        }
+    };
+
+    assert_value! { map=>
+        "properties.map.additionalProperties.type" = r#""string""#, "Additional Property Type"
+    };
+}


### PR DESCRIPTION
fix #704 