### PR TITLE
Add support for #[schema(default = )] on user-defined types (#712)

### DIFF
--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -262,6 +262,80 @@ fn derive_struct_with_default_attr() {
 }
 
 #[test]
+fn derive_struct_with_default_attr_field() {
+    struct Book;
+    let owner = api_doc! {
+        struct Owner {
+            #[schema(default = json!({ "name": "Dune" }))]
+            favorite_book: Book,
+            #[schema(default = json!([{ "name": "The Fellowship Of The Ring" }]))]
+            books: Vec<Book>,
+            #[schema(default = json!({ "National Library": { "name": "The Stranger" } }))]
+            leases: HashMap<String, Book>,
+            #[schema(default = json!({ "name": "My Book" }))]
+            authored: Option<Book>,
+        }
+    };
+
+    assert_json_eq!(
+        owner,
+        json!({
+            "properties": {
+                "favorite_book": {
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/Book",
+                        },
+                    ],
+                    "default": {
+                        "name": "Dune",
+                    },
+                },
+                "books": {
+                    "items": {
+                        "$ref": "#/components/schemas/Book",
+                    },
+                    "type": "array",
+                    "default": [
+                        {
+                            "name": "The Fellowship Of The Ring"
+                        }
+                    ]
+                },
+                "leases": {
+                    "additionalProperties": {
+                        "$ref": "#/components/schemas/Book",
+                    },
+                    "default": {
+                        "National Library": {
+                            "name": "The Stranger",
+                        },
+                    },
+                    "type": "object",
+                },
+                "authored": {
+                    "allOf": [
+                        {
+                            "$ref": "#/components/schemas/Book",
+                        },
+                    ],
+                    "default": {
+                        "name": "My Book",
+                    },
+                    "nullable": true,
+                },
+            },
+            "required": [
+                "favorite_book",
+                "books",
+                "leases",
+            ],
+            "type": "object",
+        })
+    );
+}
+
+#[test]
 fn derive_struct_with_serde_default_attr() {
     let book = api_doc! {
         #[derive(serde::Deserialize)]

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -1161,6 +1161,10 @@ builder! {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub example: Option<Value>,
 
+        /// Default value which is provided when user has not provided the input in Swagger UI.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub default: Option<Value>,
+
         /// Max length of the array.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub max_items: Option<usize>,
@@ -1194,6 +1198,7 @@ impl Default for Array {
             description: Default::default(),
             deprecated: Default::default(),
             example: Default::default(),
+            default: Default::default(),
             max_items: Default::default(),
             min_items: Default::default(),
             xml: Default::default(),
@@ -1244,6 +1249,11 @@ impl ArrayBuilder {
     /// Add or change example shown in UI of the value for richer documentation.
     pub fn example(mut self, example: Option<Value>) -> Self {
         set_value!(self example example)
+    }
+
+    /// Add or change default value for the object which is provided when user has not provided the input in Swagger UI.
+    pub fn default(mut self, default: Option<Value>) -> Self {
+        set_value!(self default default)
     }
 
     /// Set maximum allowed length for [`Array`].


### PR DESCRIPTION
Related issue: https://github.com/juhaku/utoipa/issues/712

This PR adds support for `#[schema(default = ...)]` for fields with user-defined types.

Example:

```rust
struct Owner {
    #[schema(default = json!({ "name": "Dune" }))]
    favorite_books: Vec<Book>,
    #[schema(default = json!([{ "name": "The Fellowship Of The Ring" }]))]
    books: Vec<Book>,
    #[schema(default = json!({ "National Library": { "name": "The Stranger" } }))]
    leases: HashMap<String, Book>,
    #[schema(default = json!({ "name": "My Book" }))]
    authored: Option<Book>,
}
```

Result:

```json
{
  "openapi": "3.0.3",
  "info": {
    "title": "utoipa-test",
    "description": "",
    "license": {
      "name": ""
    },
    "version": "0.1.0"
  },
  "paths": {
    "/library/{id}": {
      "get": {
        "tags": [
          "crate"
        ],
        "operationId": "get_library_by_id",
        "parameters": [
          {
            "name": "id",
            "in": "path",
            "description": "Library database id to get Library for",
            "required": true,
            "schema": {
              "type": "integer",
              "format": "int64",
              "minimum": 0
            }
          }
        ],
        "responses": {
          "200": {
            "description": "Library found succesfully",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/Library"
                }
              }
            }
          },
          "404": {
            "description": "Library was not found"
          }
        }
      }
    }
  },
  "components": {
    "schemas": {
      "Book": {
        "type": "object",
        "required": [
          "name"
        ],
        "properties": {
          "name": {
            "type": "string"
          }
        }
      },
      "Library": {
        "type": "object",
        "required": [
          "id",
          "books",
          "leases"
        ],
        "properties": {
          "books": {
            "type": "array",
            "items": {
              "$ref": "#/components/schemas/Book"
            },
            "default": [
              {
                "name": "Lord of The Rings"
              }
            ]
          },
          "id": {
            "type": "integer",
            "format": "int64",
            "minimum": 0
          },
          "leases": {
            "type": "object",
            "default": {
              "Jean-Luc": {
                "name": "Lord of The Rings"
              }
            },
            "additionalProperties": {
              "$ref": "#/components/schemas/Book"
            }
          },
          "authored": {
            "allOf": [
                {
                    "$ref": "#/components/schemas/Book"
                }
            ],
            "default": {
                "name": "My Book"
            },
            "nullable": true
        }
        }
      }
    }
  }
}
```

I have added the `derive_struct_with_default_attr_field` unit test that tests user-defined types with `Vec<>` and `HashMap<>` and `Option<>` generic types.
