### PR TITLE
Add descriptions to 2 variants of complex enums 

### DIFF
--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -1328,7 +1328,7 @@ name!(SchemaWith = "schema_with");
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Clone)]
-pub struct Description(String);
+pub struct Description(pub String);
 
 impl Parse for Description {
     fn parse(input: ParseStream, _: Ident) -> syn::Result<Self>

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -1347,7 +1347,7 @@ impl ToTokens for Description {
 
 impl From<String> for Description {
     fn from(value: String) -> Self {
-      Self(value)
+        Self(value)
     }
 }
 

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -1328,7 +1328,7 @@ name!(SchemaWith = "schema_with");
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[derive(Clone)]
-pub struct Description(pub String);
+pub struct Description(String);
 
 impl Parse for Description {
     fn parse(input: ParseStream, _: Ident) -> syn::Result<Self>
@@ -1342,6 +1342,12 @@ impl Parse for Description {
 impl ToTokens for Description {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.0.to_tokens(tokens);
+    }
+}
+
+impl From<String> for Description {
+    fn from(value: String) -> Self {
+      Self(value)
     }
 }
 

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -10,7 +10,7 @@ use syn::{
 };
 
 use crate::{
-    component::features::{Example, Rename},
+    component::features::{Description, Example, Rename},
     doc_comment::CommentAttributes,
     Array, Deprecated, ResultExt,
 };
@@ -1007,7 +1007,12 @@ impl ComplexEnum<'_> {
                     rename_all,
                 );
 
-                let example = pop_feature!(unit_features => Feature::Example(_));
+                let example: Option<Feature> = pop_feature!(unit_features => Feature::Example(_));
+
+                let description =
+                    CommentAttributes::from_attributes(&variant.attrs).as_formatted_string();
+                let description = (!description.is_empty())
+                    .then(|| Feature::Description(Description(description)));
 
                 // Unit variant is just simple enum with single variant.
                 Enum::new([SimpleEnumVariant {
@@ -1017,6 +1022,7 @@ impl ComplexEnum<'_> {
                 }])
                 .with_title(title.as_ref().map(ToTokens::to_token_stream))
                 .with_example(example.as_ref().map(ToTokens::to_token_stream))
+                .with_description(description.as_ref().map(ToTokens::to_token_stream))
                 .to_token_stream()
             }
         }

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1012,7 +1012,7 @@ impl ComplexEnum<'_> {
                 let description =
                     CommentAttributes::from_attributes(&variant.attrs).as_formatted_string();
                 let description = (!description.is_empty())
-                    .then(|| Feature::Description(Description(description)));
+                    .then(|| Feature::Description(description.into()));
 
                 // Unit variant is just simple enum with single variant.
                 Enum::new([SimpleEnumVariant {

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1011,8 +1011,8 @@ impl ComplexEnum<'_> {
 
                 let description =
                     CommentAttributes::from_attributes(&variant.attrs).as_formatted_string();
-                let description = (!description.is_empty())
-                    .then(|| Feature::Description(description.into()));
+                let description =
+                    (!description.is_empty()).then(|| Feature::Description(description.into()));
 
                 // Unit variant is just simple enum with single variant.
                 Enum::new([SimpleEnumVariant {

--- a/utoipa-gen/src/component/schema/enum_variant.rs
+++ b/utoipa-gen/src/component/schema/enum_variant.rs
@@ -90,6 +90,7 @@ pub struct Enum<'e, V: Variant> {
     items: Array<'e, TokenStream>,
     schema_type: TokenStream,
     enum_type: TokenStream,
+    description: Option<TokenStream>,
     _p: PhantomData<V>,
 }
 
@@ -109,6 +110,12 @@ impl<V: Variant> Enum<'_, V> {
 
         self
     }
+
+    pub fn with_description<I: Into<TokenStream>>(mut self, description: Option<I>) -> Self {
+        self.description = description.map(|description| description.into());
+
+        self
+    }
 }
 
 impl<T> ToTokens for Enum<'_, T>
@@ -122,10 +129,12 @@ where
         let items = &self.items;
         let schema_type = &self.schema_type;
         let enum_type = &self.enum_type;
+        let description = &self.description;
 
         tokens.extend(quote! {
             utoipa::openapi::ObjectBuilder::new()
                 #title
+                #description
                 #example
                 .schema_type(#schema_type)
                 .enum_values::<[#enum_type; #len], #enum_type>(Some(#items))
@@ -154,6 +163,7 @@ impl<V: Variant> FromIterator<V> for Enum<'_, V> {
         Self {
             title: None,
             example: None,
+            description: None,
             len,
             items,
             schema_type,

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -4932,7 +4932,6 @@ fn derive_schema_with_docstring_on_tuple_variant_first_element_option() {
 
     assert_json_eq!(
         value,
-
         json!({
             "description": "top level doc for My enum",
             "oneOf": [


### PR DESCRIPTION
Add descriptions to 2 variants of complex enums:
1 unit variants
2. tuple variants with an `Option` as the first element

Resolves:
https://github.com/juhaku/utoipa/issues/681
https://github.com/juhaku/utoipa/issues/679