### PR TITLE
Fix generics actix example

### DIFF
--- a/examples/generics-actix/Cargo.toml
+++ b/examples/generics-actix/Cargo.toml
@@ -13,7 +13,7 @@ authors = [
 [dependencies]
 actix-web = "4"
 env_logger = "0.10.0"
-geo-types = "0.7"
+geo-types = { version = "0.7", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 utoipa = { path = "../../utoipa", features = ["actix_extras", "non_strict_integers"] }

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1,3 +1,4 @@
+
 use std::borrow::Cow;
 
 use proc_macro2::{Ident, Span, TokenStream};
@@ -10,7 +11,7 @@ use syn::{
 };
 
 use crate::{
-    component::features::{Description, Example, Rename},
+    component::features::{Example, Rename},
     doc_comment::CommentAttributes,
     Array, Deprecated, ResultExt,
 };

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1,4 +1,3 @@
-
 use std::borrow::Cow;
 
 use proc_macro2::{Ident, Span, TokenStream};


### PR DESCRIPTION
Fix missing feature flag on `geo-types` for generics-actix example. Remove unused import generating warning.