### PR TITLE
Feat std::collections::LinkedList as a known field type for schema

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -275,6 +275,7 @@ impl<'t> TypeTree<'t> {
             #[cfg(feature = "indexmap")]
             "IndexMap" => Some(GenericType::Map),
             "Vec" => Some(GenericType::Vec),
+            "LinkedList" => Some(GenericType::LinkedList),
             #[cfg(feature = "smallvec")]
             "SmallVec" => Some(GenericType::SmallVec),
             "Option" => Some(GenericType::Option),
@@ -391,6 +392,7 @@ pub enum ValueType {
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub enum GenericType {
     Vec,
+    LinkedList,
     #[cfg(feature = "smallvec")]
     SmallVec,
     Map,
@@ -486,6 +488,14 @@ impl<'c> ComponentSchema {
                 deprecated_stream,
             ),
             Some(GenericType::Vec) => ComponentSchema::vec_to_tokens(
+                &mut tokens,
+                features,
+                type_tree,
+                object_name,
+                description_stream,
+                deprecated_stream,
+            ),
+            Some(GenericType::LinkedList) => ComponentSchema::vec_to_tokens(
                 &mut tokens,
                 features,
                 type_tree,

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3571,9 +3571,7 @@ fn derive_component_with_linked_list() {
     use std::collections::LinkedList;
 
     let example_schema = api_doc! {
-        struct ExampleSchema<'a> {
-            id: u64,
-            name: &'a str,
+        struct ExampleSchema {
             values: LinkedList<f64>
         }
     };
@@ -3582,20 +3580,14 @@ fn derive_component_with_linked_list() {
         example_schema,
         json!({
             "properties": {
-                "id": {
-                    "type": "uint64"
-                },
-                "name": {
-                    "type": "string"
-                },
                 "values": {
                     "items": {
-                        "type": "string"
+                        "type": "number"
                     },
                     "type": "array"
                 }
             },
-            "required": ["links"],
+            "required": ["values"],
             "type": "object"
         })
     )

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3567,6 +3567,41 @@ fn derive_component_with_raw_identifier() {
 }
 
 #[test]
+fn derive_component_with_linked_list() {
+    use std::collections::LinkedList;
+
+    let example_schema = api_doc! {
+        struct ExampleSchema<'a> {
+            id: u64,
+            name: &'a str,
+            values: LinkedList<f64>
+        }
+    };
+
+    assert_json_eq!(
+        example_schema,
+        json!({
+            "properties": {
+                "id": {
+                    "type": "uint64"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "values": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["links"],
+            "type": "object"
+        })
+    )
+}
+
+#[test]
 #[cfg(feature = "smallvec")]
 fn derive_component_with_smallvec_feature() {
     use smallvec::SmallVec;

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3582,7 +3582,8 @@ fn derive_component_with_linked_list() {
             "properties": {
                 "values": {
                     "items": {
-                        "type": "number"
+                        "type": "number",
+                        "format": "double"
                     },
                     "type": "array"
                 }


### PR DESCRIPTION
One might find `std::collections::LinkedList` more preferable than `Vec`, when defining the return type of an API responder. Hence, it would be great to be able to use `LinkedList` in schema declaration.

This PR registeres `LinkedList` as another `GenericType` and makes aforesaid possible.

I am open to any comments and suggestions.