### PR TITLE
Path impl_for override. PathBuilder::path_from

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -673,6 +673,10 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///
 /// * `path = "..."` Must be OpenAPI format compatible str with arguments within curly braces. E.g _`{id}`_
 ///
+///
+/// * `impl_for = ...` Optional type to implement the [`Path`][path] trait. By default a new type
+///   is used for the implementation.
+///
 /// * `operation_id = ...` Unique operation id for the endpoint. By default this is mapped to function name.
 ///   The operation_id can be any valid expression (e.g. string literals, macro invocations, variables) so long
 ///   as its result can be converted to a `String` using `String::from`.

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -294,7 +294,6 @@ impl<'p> Path<'p> {
 
 impl<'p> ToTokens for Path<'p> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
-        let path_struct = format_ident!("{}{}", PATH_STRUCT_PREFIX, self.fn_name);
         let operation_id = self
             .path_attr
             .operation_id
@@ -391,14 +390,15 @@ impl<'p> ToTokens for Path<'p> {
             security: self.path_attr.security.as_ref(),
         };
         let impl_for = if let Some(impl_for) = &self.path_attr.impl_for {
-            impl_for
+            impl_for.clone()
         } else {
+            let path_struct = format_ident!("{}{}", PATH_STRUCT_PREFIX, self.fn_name);
             tokens.extend(quote! {
                 #[allow(non_camel_case_types)]
                 #[doc(hidden)]
                 pub struct #path_struct;
             });
-            &path_struct
+            path_struct
         };
         tokens.extend(quote! {
 

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -109,7 +109,7 @@ impl PathsBuilder {
     }
     /// Appends a [`Path`] to map of paths. By calling [`path`](PathsBuilder::path) method.
     /// None will be passed into [Path::path_item] method.
-    pub fn path_from<P: Path>(self) -> Self {
+    pub fn path_from<P: Path>(mut self) -> Self {
         self.path(P::path(), P::path_item(None))
     }
 }

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -109,7 +109,7 @@ impl PathsBuilder {
     }
     /// Appends a [`Path`] to map of paths. By calling [`path`](PathsBuilder::path) method.
     /// None will be passed into [Path::path_item] method.
-    pub fn path_from<P: Path>(mut self) -> Self {
+    pub fn path_from<P: Path>(self) -> Self {
         self.path(P::path(), P::path_item(None))
     }
 }

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -3,6 +3,7 @@
 //! [paths]: https://spec.openapis.org/oas/latest.html#paths-object
 use std::{collections::HashMap, iter};
 
+use crate::Path;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -105,6 +106,11 @@ impl PathsBuilder {
     /// Add extensions to the paths section.
     pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
         set_value!(self extensions extensions)
+    }
+    /// Appends a [`Path`] to map of paths. By calling [`path`](PathsBuilder::path) method.
+    /// None will be passed into [Path::path_item] method.
+    pub fn path_from<P: Path>(self) -> Self {
+        self.path(P::path(), P::path_item(None))
     }
 }
 


### PR DESCRIPTION
I personally do like the derive OpenAPI macro

So I tend to implement [OpenAPI](https://docs.rs/utoipa/3.5.0/utoipa/trait.OpenApi.html) by hand.

However it generates a pretty ugly to look at type `__path_{function_name}` I use Actix so Actix already generates a type for my route. So I just want the path macro to implement for that type.

## Example

```rust
#[utoipa::path(get,  
    impl_for = me,  
    path = "/api/me",  
    responses(  
        (status = 200, description = "You are Logged In", body = User),  
        (status = 401, description = "You are not logged in")  
    ),  
    security(  
        ("api_key" = [])  
    )  
)]  
#[get("")]  
pub async fn me(auth: Authentication) -> JsonResponse<User> {  
    JsonResponse::from(Into::<User>::into(auth))  
}  
```

Then I added a new function to PathBuilder path\_from. Just for a cleaner way of appending a path.