### PR TITLE
Allow expression as macro arg

### DIFF
--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -1923,3 +1923,118 @@ fn derive_into_params_with_serde_skip_serializing() {
         ])
     )
 }
+
+#[test]
+fn derive_path_with_const_expression_context_path() {
+    const FOOBAR: &str = "/api/v1/prefix";
+
+    #[utoipa::path(
+        context_path = FOOBAR,
+        get,
+        path = "/items",
+        responses(
+            (status = 200, description = "success response")
+        ),
+    )]
+    #[allow(unused)]
+    fn get_items() -> String {
+        "".to_string()
+    }
+
+    let operation = test_api_fn_doc! {
+        get_items,
+        operation: get,
+        path: "/api/v1/prefix/items"
+    };
+
+    assert_ne!(operation, Value::Null);
+}
+
+#[test]
+fn derive_path_with_const_expression_reference_context_path() {
+    const FOOBAR: &str = "/api/v1/prefix";
+
+    #[utoipa::path(
+        context_path = &FOOBAR,
+        get,
+        path = "/items",
+        responses(
+            (status = 200, description = "success response")
+        ),
+    )]
+    #[allow(unused)]
+    fn get_items() -> String {
+        "".to_string()
+    }
+
+    let operation = test_api_fn_doc! {
+        get_items,
+        operation: get,
+        path: "/api/v1/prefix/items"
+    };
+
+    assert_ne!(operation, Value::Null);
+}
+
+#[test]
+fn derive_path_with_const_expression() {
+    const FOOBAR: &str = "/items";
+
+    #[utoipa::path(
+        get,
+        path = FOOBAR,
+        responses(
+            (status = 200, description = "success response")
+        ),
+    )]
+    #[allow(unused)]
+    fn get_items() -> String {
+        "".to_string()
+    }
+
+    let operation = test_api_fn_doc! {
+        get_items,
+        operation: get,
+        path: "/items"
+    };
+
+    assert_ne!(operation, Value::Null);
+}
+
+#[test]
+fn derive_path_with_tag_constant() {
+    const TAG: &str = "mytag";
+
+    #[utoipa::path(
+        get,
+        tag = TAG,
+        path = "/items",
+        responses(
+            (status = 200, description = "success response")
+        ),
+    )]
+    #[allow(unused)]
+    fn get_items() -> String {
+        "".to_string()
+    }
+
+    let operation = test_api_fn_doc! {
+        get_items,
+        operation: get,
+        path: "/items"
+    };
+
+    assert_ne!(operation, Value::Null);
+    assert_json_eq!(
+        &operation,
+        json!({
+            "operationId": "get_items",
+            "responses": {
+                "200": {
+                    "description": "success response",
+                },
+            },
+            "tags": ["mytag"]
+        })
+    );
+}

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -715,7 +715,7 @@ impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for Option<HashMap
 ///
 /// [derive]: attr.path.html
 pub trait Path {
-    fn path() -> &'static str;
+    fn path() -> String;
 
     fn path_item(default_tag: Option<&str>) -> openapi::path::PathItem;
 }


### PR DESCRIPTION
This PR adds support for expression arguments as macro argument in addition to literal string args.
```rust
 const FOOBAR: &str = "/api/v1/prefix";
 #[utoipa::path(
     context_path = FOOBAR,
     get,
     path = "/items",
     responses(
         (status = 200, description = "success response")
     ),
 )]
 fn get_string() -> String {
     "string".to_string()
 }
```

Currently `context_path`, `path` and `tag` supports expression argument in addition to the literal string.

This is a breaking change that changes the `Path` trait implementation to one seen below. Previously the `path()` fn had return type of `&'static str`.
```rust
pub trait Path {
    fn path() -> String;

    fn path_item(default_tag: Option<&str>) -> openapi::path::PathItem;
}
```

Resolves #518 Resolves #632 Resolves #761 