### PR TITLE
add openapi extensions "x-tokenName"

### DIFF
--- a/utoipa/src/openapi/info.rs
+++ b/utoipa/src/openapi/info.rs
@@ -6,6 +6,8 @@
 //! [info]: <https://spec.openapis.org/oas/latest.html#info-object>
 //! [openapi_trait]: ../../trait.OpenApi.html
 //! [derive]: ../../derive.OpenApi.html
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::{builder, set_value};
@@ -66,6 +68,10 @@ builder! {
 
         /// Document version typically the API version.
         pub version: String,
+
+        /// Optional extensions "x-something"
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<HashMap<String, serde_json::Value>>,
     }
 }
 
@@ -119,6 +125,11 @@ impl InfoBuilder {
     /// Add license of the API.
     pub fn license(mut self, license: Option<License>) -> Self {
         set_value!(self license license)
+    }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+        set_value!(self extensions extensions)
     }
 }
 

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -1,7 +1,7 @@
 //! Implements [OpenAPI Path Object][paths] types.
 //!
 //! [paths]: https://spec.openapis.org/oas/latest.html#paths-object
-use std::iter;
+use std::{collections::HashMap, iter};
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -34,6 +34,10 @@ builder! {
         /// Map of relative paths with [`PathItem`]s holding [`Operation`]s matching
         /// api endpoints.
         pub paths: PathsMap<String, PathItem>,
+
+        /// Optional extensions "x-something"
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<HashMap<String, serde_json::Value>>,
     }
 }
 
@@ -97,6 +101,11 @@ impl PathsBuilder {
 
         self
     }
+
+    /// Add extensions to the paths section.
+    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+        set_value!(self extensions extensions)
+    }
 }
 
 builder! {
@@ -135,6 +144,10 @@ builder! {
         /// per [`PathItemType`].
         #[serde(flatten)]
         pub operations: PathsMap<PathItemType, Operation>,
+
+        /// Optional extensions "x-something"
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<HashMap<String, serde_json::Value>>,
     }
 }
 
@@ -183,6 +196,11 @@ impl PathItemBuilder {
     /// Append list of [`Parameter`]s common to all [`Operation`]s to this [`PathItem`].
     pub fn parameters<I: IntoIterator<Item = Parameter>>(mut self, parameters: Option<I>) -> Self {
         set_value!(self parameters parameters.map(|parameters| parameters.into_iter().collect()))
+    }
+
+    /// Add openapi extensions (x-something) to this [`PathItem`].
+    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+        set_value!(self extensions extensions)
     }
 }
 
@@ -295,6 +313,10 @@ builder! {
         /// Alternative [`Server`]s for this [`Operation`].
         #[serde(skip_serializing_if = "Option::is_none")]
         pub servers: Option<Vec<Server>>,
+
+        /// Optional extensions "x-something"
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<HashMap<String, serde_json::Value>>,
     }
 }
 
@@ -436,6 +458,11 @@ impl OperationBuilder {
 
         self
     }
+
+    /// Add openapi extensions (x-something) of the [`Operation`].
+    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+        set_value!(self extensions extensions)
+    }
 }
 
 builder! {
@@ -506,6 +533,10 @@ builder! {
         /// within [`Parameter::schema`] if defined.
         #[serde(skip_serializing_if = "Option::is_none")]
         example: Option<Value>,
+
+        /// Optional extensions "x-something"
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<HashMap<String, serde_json::Value>>,
     }
 }
 
@@ -576,6 +607,11 @@ impl ParameterBuilder {
     /// Add or change example of [`Parameter`]'s potential value.
     pub fn example(mut self, example: Option<Value>) -> Self {
         set_value!(self example example)
+    }
+
+    /// Add openapi extensions (x-something) to the [`Parameter`].
+    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+        set_value!(self extensions extensions)
     }
 }
 

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -187,7 +187,7 @@ impl PathItemBuilder {
 }
 
 /// Path item operation type.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Debug)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum PathItemType {

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -187,7 +187,7 @@ impl PathItemBuilder {
 }
 
 /// Path item operation type.
-#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
+#[derive(Serialize, Deserialize, PartialEq, Eq, Hash, PartialOrd, Ord, Clone, Debug)]
 #[serde(rename_all = "lowercase")]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum PathItemType {

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -1,7 +1,7 @@
 //! Implements [OpenApi Responses][responses].
 //!
 //! [responses]: https://spec.openapis.org/oas/latest.html#responses-object
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -118,6 +118,10 @@ builder! {
         /// will create and show default example according to the first entry in `content` map.
         #[serde(skip_serializing_if = "IndexMap::is_empty", default)]
         pub content: IndexMap<String, Content>,
+
+        /// Optional extensions "x-something"
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<HashMap<String, serde_json::Value>>,
     }
 }
 
@@ -151,6 +155,11 @@ impl ResponseBuilder {
         self.headers.insert(name.into(), header);
 
         self
+    }
+
+    /// Add openapi extensions (x-something) to the [`Header`].
+    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+        set_value!(self extensions extensions)
     }
 }
 

--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -6,6 +6,7 @@
 use std::{collections::BTreeMap, iter};
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use super::builder;
 
@@ -349,13 +350,13 @@ pub struct OAuth2 {
     /// Map of supported OAuth2 flows.
     pub flows: BTreeMap<String, Flow>,
 
-    /// Optional name of token to use
-    #[serde(skip_serializing_if = "Option::is_none", rename = "x-tokenName")]
-    pub token_name: Option<String>,
-
     /// Optional description for the [`OAuth2`] [`Flow`] [`SecurityScheme`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Optional extensions "x-something"
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub extensions: Option<Value>,
 }
 
 impl OAuth2 {
@@ -395,7 +396,7 @@ impl OAuth2 {
                     .into_iter()
                     .map(|auth_flow| (String::from(auth_flow.get_type_as_str()), auth_flow)),
             ),
-            token_name: None,
+            extensions: None,
             description: None,
         }
     }
@@ -438,13 +439,13 @@ impl OAuth2 {
                     .into_iter()
                     .map(|auth_flow| (String::from(auth_flow.get_type_as_str()), auth_flow)),
             ),
-            token_name: None,
+            extensions: None,
             description: Some(description.into()),
         }
     }
 
-    pub fn set_token_name(&mut self, token_name: Option<String>) {
-        self.token_name = token_name;
+    pub fn set_extensions(&mut self, extensions: Option<Value>) {
+        self.extensions = extensions;
     }
 }
 

--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -3,10 +3,12 @@
 //! Refer to [`SecurityScheme`] for usage and more details.
 //!
 //! [security]: https://spec.openapis.org/oas/latest.html#security-scheme-object
-use std::{collections::BTreeMap, iter};
+use std::{
+    collections::{BTreeMap, HashMap},
+    iter,
+};
 
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 
 use super::builder;
 
@@ -356,7 +358,7 @@ pub struct OAuth2 {
 
     /// Optional extensions "x-something"
     #[serde(skip_serializing_if = "Option::is_none", flatten)]
-    pub extensions: Option<Value>,
+    pub extensions: Option<HashMap<String, serde_json::Value>>,
 }
 
 impl OAuth2 {
@@ -442,10 +444,6 @@ impl OAuth2 {
             extensions: None,
             description: Some(description.into()),
         }
-    }
-
-    pub fn set_extensions(&mut self, extensions: Option<Value>) {
-        self.extensions = extensions;
     }
 }
 

--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -349,6 +349,10 @@ pub struct OAuth2 {
     /// Map of supported OAuth2 flows.
     pub flows: BTreeMap<String, Flow>,
 
+    /// Optional name of token to use
+    #[serde(skip_serializing_if = "Option::is_none", rename = "x-tokenName")]
+    pub token_name: Option<String>,
+
     /// Optional description for the [`OAuth2`] [`Flow`] [`SecurityScheme`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -391,6 +395,7 @@ impl OAuth2 {
                     .into_iter()
                     .map(|auth_flow| (String::from(auth_flow.get_type_as_str()), auth_flow)),
             ),
+            token_name: None,
             description: None,
         }
     }
@@ -433,8 +438,13 @@ impl OAuth2 {
                     .into_iter()
                     .map(|auth_flow| (String::from(auth_flow.get_type_as_str()), auth_flow)),
             ),
+            token_name: None,
             description: Some(description.into()),
         }
+    }
+
+    pub fn set_token_name(&mut self, token_name: Option<String>) {
+        self.token_name = token_name;
     }
 }
 

--- a/utoipa/src/openapi/tag.rs
+++ b/utoipa/src/openapi/tag.rs
@@ -1,6 +1,8 @@
 //! Implements [OpenAPI Tag Object][tag] types.
 //!
 //! [tag]: https://spec.openapis.org/oas/latest.html#tag-object
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::{builder, external_docs::ExternalDocs, set_value};
@@ -28,6 +30,10 @@ builder! {
         /// Additional external documentation for the tag.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub external_docs: Option<ExternalDocs>,
+
+        /// Optional extensions "x-something"
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<HashMap<String, serde_json::Value>>,
     }
 }
 
@@ -55,5 +61,10 @@ impl TagBuilder {
     /// Add additional external documentation for the tag.
     pub fn external_docs(mut self, external_docs: Option<ExternalDocs>) -> Self {
         set_value!(self external_docs external_docs)
+    }
+
+    /// Add openapi extensions (x-something) to the tag.
+    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+        set_value!(self extensions extensions)
     }
 }


### PR DESCRIPTION
Setting x-tokenname makes it possible to choose which token to use. This is useful for OICD and non-standard oauth servers. ex. if you want to use id_token from google instead of auth_token.

https://github.com/swagger-api/swagger-ui/issues/7561

For some reason the Debug derive was missing from PathItemType which made the build fail