### PR TITLE
enable required usage with schema_with attribute

### DIFF
--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -436,21 +436,19 @@ impl ToTokens for NamedStructSchema<'_> {
                                 .property(#name, #property)
                             });
 
-                            if let Property::Schema(_) = property {
-                                if (!is_option
-                                    && super::is_required(
-                                        field_rule.as_ref(),
-                                        container_rules.as_ref(),
-                                    ))
-                                    || required
-                                        .as_ref()
-                                        .map(super::features::Required::is_true)
-                                        .unwrap_or(false)
-                                {
-                                    object_tokens.extend(quote! {
-                                        .required(#name)
-                                    })
-                                }
+                            if (!is_option
+                                && super::is_required(
+                                    field_rule.as_ref(),
+                                    container_rules.as_ref(),
+                                ))
+                                || required
+                                    .as_ref()
+                                    .map(super::features::Required::is_true)
+                                    .unwrap_or(false)
+                            {
+                                object_tokens.extend(quote! {
+                                    .required(#name)
+                                })
                             }
 
                             object_tokens

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -4273,6 +4273,7 @@ fn derive_schema_with_custom_field_with_schema() {
                     "format": "email"
                 }
             },
+            "required": [ "id" ],
             "type": "object"
         })
     )


### PR DESCRIPTION
This PR fixes a bug which lead to the `required` attribute being ignored when `schema_with` was also used.

```rust
fn custom_schema() -> Object {
	ObjectBuilder::new()
		.schema_type(utoipa::openapi::SchemaType::Integer)
		.format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
			KnownFormat::Int32,
		)))
		.build()
}

#[derive(Debug, Serialize, Deserialize, ToSchema)]
/// Test Structure
struct Test {
        #[schema(schema_with = custom_schema, required)]
        id: Option<i32>,
}
```

Previously this would result in the following OpenApi Schema:

```json
{
  "type": "object",
  "description": "Test Structure",
  "required": [],
  "properties": {
    "id": {
      "type": "integer",
      "format": "int32"
    }
  }
}
```

But should be this instead: 
```json
{
  "type": "object",
  "description": "Test Structure",
  "required": [
     "id"
  ],
  "properties": {
    "id": {
      "type": "integer",
      "format": "int32"
    }
  }
}
```