### PR TITLE
Support `#[serde(flatten)]` for maps.

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -347,6 +347,11 @@ impl<'t> TypeTree<'t> {
     pub fn is_option(&self) -> bool {
         matches!(self.generic_type, Some(GenericType::Option))
     }
+
+    /// Check whether the [`TypeTree`]'s `generic_type` is [`GenericType::Map`]
+    pub fn is_map(&self) -> bool {
+        matches!(self.generic_type, Some(GenericType::Map))
+    }
 }
 
 impl PartialEq for TypeTree<'_> {
@@ -910,6 +915,68 @@ impl<'c> ComponentSchema {
 }
 
 impl ToTokens for ComponentSchema {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.tokens.to_tokens(tokens)
+    }
+}
+
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct FlattenedMapSchema {
+    tokens: TokenStream,
+}
+
+impl<'c> FlattenedMapSchema {
+    pub fn new(
+        ComponentSchemaProps {
+            type_tree,
+            features,
+            description,
+            deprecated,
+            object_name,
+        }: ComponentSchemaProps,
+    ) -> Self {
+        let mut tokens = TokenStream::new();
+        let mut features = features.unwrap_or(Vec::new());
+        let deprecated_stream = ComponentSchema::get_deprecated(deprecated);
+        let description_stream = ComponentSchema::get_description(description);
+
+        let example = features.pop_by(|feature| matches!(feature, Feature::Example(_)));
+        let nullable = pop_feature!(features => Feature::Nullable(_));
+        let default = pop_feature!(features => Feature::Default(_));
+
+        // Maps are treated as generic objects with no named properties and
+        // additionalProperties denoting the type
+        // maps have 2 child schemas and we are interested the second one of them
+        // which is used to determine the additional properties
+        let schema_property = ComponentSchema::new(ComponentSchemaProps {
+            type_tree: type_tree
+                .children
+                .as_ref()
+                .expect("ComponentSchema Map type should have children")
+                .iter()
+                .nth(1)
+                .expect("ComponentSchema Map type should have 2 child"),
+            features: Some(features),
+            description: None,
+            deprecated: None,
+            object_name,
+        });
+
+        tokens.extend(quote! {
+            #schema_property
+                #description_stream
+                #deprecated_stream
+                #default
+        });
+
+        example.to_tokens(&mut tokens);
+        nullable.to_tokens(&mut tokens);
+
+        Self { tokens }
+    }
+}
+
+impl ToTokens for FlattenedMapSchema {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         self.tokens.to_tokens(tokens)
     }

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -126,6 +126,50 @@ fn derive_map_free_form_property() {
 }
 
 #[test]
+fn derive_flattened_map_string_property() {
+    let map = api_doc! {
+        #[derive(Serialize)]
+        struct Map {
+            #[serde(flatten)]
+            map: HashMap<String, String>,
+        }
+    };
+
+    assert_json_eq!(
+        map,
+        json!({
+            "additionalProperties": {"type": "string"},
+            "type": "object"
+        })
+    )
+}
+
+#[test]
+fn derive_flattened_map_ref_property() {
+    #[derive(Serialize, ToSchema)]
+    #[allow(unused)]
+    enum Foo {
+        Variant,
+    }
+
+    let map = api_doc! {
+        #[derive(Serialize)]
+        struct Map {
+            #[serde(flatten)]
+            map: HashMap<String, Foo>,
+        }
+    };
+
+    assert_json_eq!(
+        map,
+        json!({
+            "additionalProperties": {"$ref": "#/components/schemas/Foo"},
+            "type": "object"
+        })
+    )
+}
+
+#[test]
 fn derive_enum_with_additional_properties_success() {
     let mode = api_doc! {
         #[schema(default = "Mode1", example = "Mode2")]


### PR DESCRIPTION
`utoipa` already supported `#[serde(flatten)]` on fields with structure type, by putting the fields inside those structures into the parent type. This is commonly used for factoring out frequently used keys, as documented at <https://serde.rs/attr-flatten.html#factor-out-frequently-grouped-keys>.

`#[serde(flatten)]` has another use that utoipa does not support: to capture additional unnamed fields within a structure, as documented at <https://serde.rs/attr-flatten.html#capture-additional-fields>.  This commit adds support for that functionality as well as a pair of tests. It only makes sense to have one such field per structure, so this commit reports an error if there is more than one.