### PR TITLE
Add support for specifying multiple security requirement keys

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1009,10 +1009,22 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// (),
 /// ("name" = []),
 /// ("name" = ["scope1", "scope2"]),
+/// ("name" = ["scope1", "scope2"], "name2" = []),
 /// ```
 ///
 /// Leaving empty _`()`_ creates an empty [`SecurityRequirement`][security] this is useful when
 /// security requirement is optional for operation.
+///
+/// You can define multiple security requirements within same parenthesis seperated by comma. This
+/// allows you to define keys that must be simultaneously provided for the endpoint / API.
+///
+/// _**Following could be explained as: Security is optional and if provided it must either contain
+/// `api_key` or `key AND key2`.**_
+/// ```text
+/// (),
+/// ("api_key" = []),
+/// ("key" = [], "key2" = []),
+/// ```
 ///
 /// # actix_extras feature support for actix-web
 ///

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -12,7 +12,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 
 use crate::{
-    parse_utils, path::PATH_STRUCT_PREFIX, security_requirement::SecurityRequirementAttr, Array,
+    parse_utils, path::PATH_STRUCT_PREFIX, security_requirement::SecurityRequirementsAttr, Array,
     ExternalDocs, ResultExt,
 };
 
@@ -27,7 +27,7 @@ pub struct OpenApiAttr<'o> {
     paths: Punctuated<ExprPath, Comma>,
     components: Components,
     modifiers: Punctuated<Modifier, Comma>,
-    security: Option<Array<'static, SecurityRequirementAttr>>,
+    security: Option<Array<'static, SecurityRequirementsAttr>>,
     tags: Option<Array<'static, Tag>>,
     external_docs: Option<ExternalDocs>,
     servers: Punctuated<Server, Comma>,

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -14,7 +14,7 @@ use syn::{Expr, ExprLit, Lit, LitStr, Type};
 use crate::component::{GenericType, TypeTree};
 use crate::path::request_body::RequestBody;
 use crate::{parse_utils, Deprecated};
-use crate::{schema_type::SchemaType, security_requirement::SecurityRequirementAttr, Array};
+use crate::{schema_type::SchemaType, security_requirement::SecurityRequirementsAttr, Array};
 
 use self::response::Response;
 use self::{parameter::Parameter, request_body::RequestBodyAttr, response::Responses};
@@ -37,7 +37,7 @@ pub struct PathAttr<'p> {
     operation_id: Option<Expr>,
     tag: Option<parse_utils::Value>,
     params: Vec<Parameter<'p>>,
-    security: Option<Array<'p, SecurityRequirementAttr>>,
+    security: Option<Array<'p, SecurityRequirementsAttr>>,
     context_path: Option<parse_utils::Value>,
 }
 
@@ -421,7 +421,7 @@ struct Operation<'a> {
     parameters: &'a Vec<Parameter<'a>>,
     request_body: Option<&'a RequestBody<'a>>,
     responses: &'a Vec<Response<'a>>,
-    security: Option<&'a Array<'a, SecurityRequirementAttr>>,
+    security: Option<&'a Array<'a, SecurityRequirementsAttr>>,
 }
 
 impl ToTokens for Operation<'_> {

--- a/utoipa-gen/src/security_requirement.rs
+++ b/utoipa-gen/src/security_requirement.rs
@@ -19,24 +19,12 @@ pub struct SecurityRequirementsAttrItem {
 
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
-pub struct SecurityRequirementsAttr(Vec<SecurityRequirementsAttrItem>);
+pub struct SecurityRequirementsAttr(Punctuated<SecurityRequirementsAttrItem, Comma>);
 
 impl Parse for SecurityRequirementsAttr {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        let mut items = Vec::new();
-
-        if input.is_empty() {
-            return Ok(Self(items));
-        }
-
-        items.push(input.parse::<SecurityRequirementsAttrItem>()?);
-
-        while input.lookahead1().peek(Token![,]) {
-            input.parse::<Token![,]>()?;
-            items.push(input.parse::<SecurityRequirementsAttrItem>()?);
-        }
-
-        Ok(Self(items))
+        Punctuated::<SecurityRequirementsAttrItem, Comma>::parse_terminated(input)
+            .map(|o| Self(o.into_iter().collect()))
     }
 }
 

--- a/utoipa-gen/src/security_requirement.rs
+++ b/utoipa-gen/src/security_requirement.rs
@@ -13,8 +13,8 @@ use crate::Array;
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct SecurityRequirementsAttrItem {
-    pub name: String,
-    pub scopes: Vec<String>,
+    pub name: Option<String>,
+    pub scopes: Option<Vec<String>>,
 }
 
 #[derive(Default)]
@@ -44,41 +44,38 @@ impl Parse for SecurityRequirementsAttrItem {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let name = input.parse::<LitStr>()?.value();
 
-        if input.lookahead1().peek(Token![=]) {
-            input.parse::<Token![=]>()?;
+        input.parse::<Token![=]>()?;
 
-            let scopes_stream;
-            bracketed!(scopes_stream in input);
+        let scopes_stream;
+        bracketed!(scopes_stream in input);
 
-            let scopes = Punctuated::<LitStr, Comma>::parse_terminated(&scopes_stream)?
-                .iter()
-                .map(LitStr::value)
-                .collect::<Vec<_>>();
+        let scopes = Punctuated::<LitStr, Comma>::parse_terminated(&scopes_stream)?
+            .iter()
+            .map(LitStr::value)
+            .collect::<Vec<_>>();
 
-            Ok(Self { name, scopes })
-        } else {
-            Ok(Self {
-                name,
-                scopes: vec![],
-            })
-        }
+        Ok(Self {
+            name: Some(name),
+            scopes: Some(scopes),
+        })
     }
 }
 
 impl ToTokens for SecurityRequirementsAttr {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         tokens.extend(quote! {
-            utoipa::openapi::security::SecurityRequirement::new()
+            utoipa::openapi::security::SecurityRequirement::default()
         });
 
         for requirement in &self.0 {
-            let name = &requirement.name;
-            let scopes = requirement.scopes.iter().collect::<Array<&String>>();
-            let scopes_len = scopes.len();
+            if let (Some(name), Some(scopes)) = (&requirement.name, &requirement.scopes) {
+                let scopes = scopes.iter().collect::<Array<&String>>();
+                let scopes_len = scopes.len();
 
-            tokens.extend(quote! {
-                .add::<&str, [&str; #scopes_len], &str>(#name, #scopes)
-            });
+                tokens.extend(quote! {
+                    .add::<&str, [&str; #scopes_len], &str>(#name, #scopes)
+                });
+            }
         }
     }
 }

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -17,7 +17,8 @@ fn derive_openapi_with_security_requirement() {
     #[openapi(security(
             (),
             ("my_auth" = ["read:items", "edit:items"]),
-            ("token_jwt" = [])
+            ("token_jwt" = []),
+            ("api_key1" = [], "api_key2" = []),
         ))]
     struct ApiDoc;
 
@@ -28,6 +29,8 @@ fn derive_openapi_with_security_requirement() {
         "security.[1].my_auth.[0]" = r###""read:items""###, "api_oauth first scope"
         "security.[1].my_auth.[1]" = r###""edit:items""###, "api_oauth second scope"
         "security.[2].token_jwt" = "[]", "jwt_token auth scopes"
+        "security.[3].api_key1" = "[]", "api_key1 auth scopes"
+        "security.[3].api_key2" = "[]", "api_key2 auth scopes"
     }
 }
 

--- a/utoipa-gen/tests/openapi_derive_test.rs
+++ b/utoipa-gen/tests/openapi_derive_test.rs
@@ -58,7 +58,7 @@ mod pet_api {
     modifiers(&Foo),
     security(
         (),
-        ("my_auth" = ["read:items", "edit:items"]),
+        ("my_auth1" = ["read:items", "edit:items"], "my_auth2" = ["read:items"]),
         ("token_jwt" = [])
     )
 )]

--- a/utoipa-gen/tests/openapi_derive_test.rs
+++ b/utoipa-gen/tests/openapi_derive_test.rs
@@ -37,7 +37,7 @@ mod pet_api {
         ),
         security(
             (),
-            ("my_auth" = ["read:items", "edit:items"]),
+            ("my_auth1" = ["read:items", "edit:items"], "my_auth2" = ["read:items"]),
             ("token_jwt" = [])
         )
     )]

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -10,7 +10,8 @@ use super::{
     builder,
     request_body::RequestBody,
     response::{Response, Responses},
-    set_value, Deprecated, ExternalDocs, RefOr, Required, Schema, SecurityRequirement, Server,
+    security::SecurityRequirement,
+    set_value, Deprecated, ExternalDocs, RefOr, Required, Schema, Server,
 };
 
 #[cfg(not(feature = "preserve_path_order"))]
@@ -770,11 +771,12 @@ mod tests {
     #[test]
     fn operation_builder_security() {
         let security_requirement1 =
-            SecurityRequirement::new("api_oauth2_flow", ["edit:items", "read:items"]);
-        let security_requirement2 = SecurityRequirement::new("api_oauth2_flow", ["remove:items"]);
+            SecurityRequirement::single("api_oauth2_flow", ["edit:items", "read:items"]);
+        let security_requirement2 =
+            SecurityRequirement::single("api_oauth2_flow", ["remove:items"]);
         let operation = OperationBuilder::new()
-            .security(security_requirement1)
-            .security(security_requirement2)
+            .security(security_requirement1.into())
+            .security(security_requirement2.into())
             .build();
 
         assert!(operation.security.is_some());

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -771,9 +771,8 @@ mod tests {
     #[test]
     fn operation_builder_security() {
         let security_requirement1 =
-            SecurityRequirement::single("api_oauth2_flow", ["edit:items", "read:items"]);
-        let security_requirement2 =
-            SecurityRequirement::single("api_oauth2_flow", ["remove:items"]);
+            SecurityRequirement::new("api_oauth2_flow", ["edit:items", "read:items"]);
+        let security_requirement2 = SecurityRequirement::new("api_oauth2_flow", ["remove:items"]);
         let operation = OperationBuilder::new()
             .security(security_requirement1.into())
             .security(security_requirement2.into())

--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -45,7 +45,7 @@ impl SecurityRequirement {
     /// Create new security requirement with scopes.
     /// ```rust
     /// # use utoipa::openapi::security::SecurityRequirement;
-    /// SecurityRequirement::new("api_oauth2_flow", ["edit:items", "read:items"]);
+    /// SecurityRequirement::single("api_oauth2_flow", ["edit:items", "read:items"]);
     /// ```
     ///
     /// You can also create an empty security requirement with `Default::default()`.
@@ -53,7 +53,7 @@ impl SecurityRequirement {
     /// # use utoipa::openapi::security::SecurityRequirement;
     /// SecurityRequirement::default();
     /// ```
-    pub fn new<N: Into<String>, S: IntoIterator<Item = I>, I: Into<String>>(
+    pub fn single<N: Into<String>, S: IntoIterator<Item = I>, I: Into<String>>(
         name: N,
         scopes: S,
     ) -> Self {
@@ -68,6 +68,23 @@ impl SecurityRequirement {
                 )
             })),
         }
+    }
+
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add<N: Into<String>, S: IntoIterator<Item = I>, I: Into<String>>(
+        mut self,
+        name: N,
+        scopes: S,
+    ) -> Self {
+        self.value.insert(
+            Into::<String>::into(name),
+            scopes.into_iter().map(Into::<String>::into).collect(),
+        );
+
+        self
     }
 }
 

--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -45,7 +45,7 @@ impl SecurityRequirement {
     /// Create new security requirement with scopes.
     /// ```rust
     /// # use utoipa::openapi::security::SecurityRequirement;
-    /// SecurityRequirement::single("api_oauth2_flow", ["edit:items", "read:items"]);
+    /// SecurityRequirement::new("api_oauth2_flow", ["edit:items", "read:items"]);
     /// ```
     ///
     /// You can also create an empty security requirement with `Default::default()`.
@@ -53,7 +53,7 @@ impl SecurityRequirement {
     /// # use utoipa::openapi::security::SecurityRequirement;
     /// SecurityRequirement::default();
     /// ```
-    pub fn single<N: Into<String>, S: IntoIterator<Item = I>, I: Into<String>>(
+    pub fn new<N: Into<String>, S: IntoIterator<Item = I>, I: Into<String>>(
         name: N,
         scopes: S,
     ) -> Self {
@@ -70,10 +70,21 @@ impl SecurityRequirement {
         }
     }
 
-    pub fn new() -> Self {
-        Self::default()
-    }
-
+    /// Allows to add multiple security requirements.
+    ///
+    /// Accepts name for the security requirement which must match to the name of available [`SecurityScheme`].
+    /// Second parameter is [`IntoIterator`] of [`Into<String>`] scopes needed by the [`SecurityRequirement`].
+    /// Scopes must match to the ones defined in [`SecurityScheme`].
+    ///
+    /// # Examples
+    ///
+    /// Make both API keys required:
+    /// ```rust
+    /// # use utoipa::openapi::security::SecurityRequirement;
+    /// SecurityRequirement::default()
+    ///     .add("refresh_token", ["edit:accounts"])
+    ///     .add("access_token", ["edit:accounts"]);
+    /// ```
     pub fn add<N: Into<String>, S: IntoIterator<Item = I>, I: Into<String>>(
         mut self,
         name: N,


### PR DESCRIPTION
Hi! The first contribution to this repo, so I may have missed some things.

I use `utoipa` in my project and I faced a problem of not being able to use multiple security requirement keys. 

As described in [Swagger docs](https://swagger.io/docs/specification/authentication/): Some REST APIs support several authentication types. The security section lets you combine the security requirements using logical OR and AND to achieve the desired result. 

I made an [issue](https://github.com/juhaku/utoipa/issues/803). Then, I resolved it myself. Now you can use multiple security requirements separated by a comma in `#[utoipa::path]`. Example:
```rs
#[utoipa::path(
      delete,
      path = "/todo/{id}",
      responses(
          (status = 200, description = "Todo marked done successfully"),
          (status = 401, description = "Unauthorized to delete Todo", body = TodoError, example = json!(TodoError::Unauthorized(String::from("missing api key")))),
          (status = 404, description = "Todo not found", body = TodoError, example = json!(TodoError::NotFound(String::from("id = 1"))))
      ),
      params(
          ("id" = i32, Path, description = "Todo database id")
      ),
      security(
          // literally means (api_key and api_key2) or api_key3
          ("api_key" = [], "api_key2" = []),
          ("api_key3" = []),
      )
  )]
```

Also, now you can construct those with `add()` method:

```rs
SecurityRequirement::default()
  .add("api_key", ["test"])
  .add("api_key2", ["test"])
```

I didn't change the names of already existing methods and types. Additionally, as you can see new `security(...)` syntax is compatible with the old one. So it isn't really a breaking change.

Resolves https://github.com/juhaku/utoipa/issues/803.
