### PR TITLE
Generate embed code instead of using interpolation

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -15,7 +15,7 @@ debug = []
 debug-embed = ["rust-embed/debug-embed"]
 
 [dependencies]
-rust-embed = { version = "8", features = ["interpolate-folder-path"] }
+rust-embed = { version = "8" }
 mime_guess = { version = "2.0" }
 actix-web = { version = "4", optional = true, default-features = false }
 rocket = { version = "0.5.0-rc.3", features = ["json"], optional = true }

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -120,9 +120,7 @@ use serde::Serialize;
 #[cfg(any(feature = "actix-web", feature = "rocket", feature = "axum"))]
 use utoipa::openapi::OpenApi;
 
-#[derive(RustEmbed)]
-#[folder = "$UTOIPA_SWAGGER_DIR/$UTOIPA_SWAGGER_UI_VERSION/dist/"]
-struct SwaggerUiDist;
+include!(concat!(env!("OUT_DIR"), "/embed.rs"));
 
 /// Entry point for serving Swagger UI and api docs in application. It provides
 /// builder style chainable configuration methods for configuring api doc urls.


### PR DESCRIPTION
Because the output path of the embedded files changes per machine, the interpolate-folder-path feature of rust-embed was used to set the correct embed path. This feature however creates a rather large dependency tree (shell_expand -> dirs -> dirs-sys -> option-ext)

By generating a small file with the correct folder already filled in, then including it in lib.rs we can remove this feature and reduce the amount of dependencies that are used.

Implementation was inspired by how the "built" crate recommends people to use it.