### PR TITLE
Allowing utoipa/utoipa-swagger-ui successfully build on Windows and made path proc macro attribute more permissive

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -2793,6 +2793,18 @@ mod parse_utils {
         Expr(Expr),
     }
 
+    impl Value {
+        pub(crate) fn is_empty(&self) -> bool {
+            matches!(self, Self::LitStr(s) if s.value().is_empty())
+        }
+    }
+
+    impl Default for Value {
+        fn default() -> Self {
+            Self::LitStr(LitStr::new("", proc_macro2::Span::call_site()))
+        }
+    }
+
     impl Parse for Value {
         fn parse(input: ParseStream) -> syn::Result<Self> {
             if input.peek(LitStr) {
@@ -2833,10 +2845,7 @@ mod parse_utils {
     }
 
     pub fn parse_next_literal_str_or_expr(input: ParseStream) -> syn::Result<Value> {
-        parse_next(input, || {
-            Value::parse(input)
-        })
-        .map_err(|error| {
+        parse_next(input, || Value::parse(input)).map_err(|error| {
             syn::Error::new(
                 error.span(),
                 format!("expected literal string or expression argument: {error}"),

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -2793,6 +2793,16 @@ mod parse_utils {
         Expr(Expr),
     }
 
+    impl Parse for Value {
+        fn parse(input: ParseStream) -> syn::Result<Self> {
+            if input.peek(LitStr) {
+                Ok::<Value, Error>(Value::LitStr(input.parse::<LitStr>()?))
+            } else {
+                Ok(Value::Expr(input.parse::<Expr>()?))
+            }
+        }
+    }
+
     impl ToTokens for Value {
         fn to_tokens(&self, tokens: &mut TokenStream) {
             match self {
@@ -2824,11 +2834,7 @@ mod parse_utils {
 
     pub fn parse_next_literal_str_or_expr(input: ParseStream) -> syn::Result<Value> {
         parse_next(input, || {
-            if input.peek(LitStr) {
-                Ok::<Value, Error>(Value::LitStr(input.parse::<LitStr>()?))
-            } else {
-                Ok(Value::Expr(input.parse::<Expr>()?))
-            }
+            Value::parse(input)
         })
         .map_err(|error| {
             syn::Error::new(

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -123,7 +123,7 @@ impl Parse for RequestBodyAttr<'_> {
                     }
                     "example" => {
                         request_body_attr.example = Some(parse_utils::parse_next(&group, || {
-                            AnyValue::parse_json(&group)
+                            AnyValue::parse_any(&group)
                         })?)
                     }
                     "examples" => {

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -78,7 +78,7 @@ impl ToTokens for RequestBody<'_> {
 pub struct RequestBodyAttr<'r> {
     content: Option<PathType<'r>>,
     content_type: Option<String>,
-    description: Option<String>,
+    description: Option<parse_utils::Value>,
     example: Option<AnyValue>,
     examples: Option<Punctuated<Example, Comma>>,
 }
@@ -119,7 +119,7 @@ impl Parse for RequestBodyAttr<'_> {
                     }
                     "description" => {
                         request_body_attr.description =
-                            Some(parse_utils::parse_next_literal_str(&group)?)
+                            Some(parse_utils::parse_next_literal_str_or_expr(&group)?)
                     }
                     "example" => {
                         request_body_attr.example = Some(parse_utils::parse_next(&group, || {

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -77,7 +77,7 @@ impl ToTokens for RequestBody<'_> {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct RequestBodyAttr<'r> {
     content: Option<PathType<'r>>,
-    content_type: Option<String>,
+    content_type: Option<parse_utils::Value>,
     description: Option<parse_utils::Value>,
     example: Option<AnyValue>,
     examples: Option<Punctuated<Example, Comma>>,
@@ -115,7 +115,7 @@ impl Parse for RequestBodyAttr<'_> {
                     }
                     "content_type" => {
                         request_body_attr.content_type =
-                            Some(parse_utils::parse_next_literal_str(&group)?)
+                            Some(parse_utils::parse_next_literal_str_or_expr(&group)?)
                     }
                     "description" => {
                         request_body_attr.description =
@@ -210,10 +210,13 @@ impl ToTokens for RequestBodyAttr<'_> {
                 PathType::MediaType(body_type) => {
                     let type_tree = body_type.as_type_tree();
                     let required: Required = (!type_tree.is_option()).into();
-                    let content_type = self
-                        .content_type
-                        .as_deref()
-                        .unwrap_or_else(|| type_tree.get_default_content_type());
+                    let content_type = match &self.content_type {
+                        Some(content_type) => content_type.to_token_stream(),
+                        None => {
+                            let content_type = type_tree.get_default_content_type();
+                            quote!(#content_type)
+                        }
+                    };
                     tokens.extend(quote! {
                         utoipa::openapi::request_body::RequestBodyBuilder::new()
                             .content(#content_type, #content.build())

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -168,7 +168,7 @@ impl<'r> From<(ResponseStatus, ResponseValue<'r>)> for ResponseTuple<'r> {
 
 pub struct DeriveResponsesAttributes<T> {
     derive_value: T,
-    description: String,
+    description: parse_utils::Value,
 }
 
 impl<'r> From<DeriveResponsesAttributes<DeriveIntoResponsesValue>> for ResponseValue<'r> {
@@ -198,7 +198,7 @@ impl<'r> From<DeriveResponsesAttributes<Option<DeriveToResponseValue>>> for Resp
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct ResponseValue<'r> {
-    description: String,
+    description: parse_utils::Value,
     response_type: Option<PathType<'r>>,
     content_type: Option<Vec<parse_utils::Value>>,
     headers: Vec<Header>,
@@ -210,7 +210,7 @@ pub struct ResponseValue<'r> {
 impl<'r> ResponseValue<'r> {
     fn from_derive_to_response_value(
         derive_value: DeriveToResponseValue,
-        description: String,
+        description: parse_utils::Value,
     ) -> Self {
         Self {
             description: if derive_value.description.is_empty() && !description.is_empty() {
@@ -228,7 +228,7 @@ impl<'r> ResponseValue<'r> {
 
     fn from_derive_into_responses_value(
         response_value: DeriveIntoResponsesValue,
-        description: String,
+        description: parse_utils::Value,
     ) -> Self {
         ResponseValue {
             description: if response_value.description.is_empty() && !description.is_empty() {
@@ -396,7 +396,7 @@ trait DeriveResponseValue: Parse {
 struct DeriveToResponseValue {
     content_type: Option<Vec<parse_utils::Value>>,
     headers: Vec<Header>,
-    description: String,
+    description: parse_utils::Value,
     example: Option<(AnyValue, Ident)>,
     examples: Option<(Punctuated<Example, Comma>, Ident)>,
 }
@@ -469,7 +469,7 @@ struct DeriveIntoResponsesValue {
     status: ResponseStatus,
     content_type: Option<Vec<parse_utils::Value>>,
     headers: Vec<Header>,
-    description: String,
+    description: parse_utils::Value,
     example: Option<(AnyValue, Ident)>,
     examples: Option<(Punctuated<Example, Comma>, Ident)>,
 }
@@ -878,8 +878,8 @@ mod parse {
     use super::Header;
 
     #[inline]
-    pub(super) fn description(input: ParseStream) -> Result<String> {
-        parse_utils::parse_next_literal_str(input)
+    pub(super) fn description(input: ParseStream) -> Result<parse_utils::Value> {
+        parse_utils::parse_next_literal_str_or_expr(input)
     }
 
     #[inline]

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -16,7 +16,7 @@ use syn::{
 use crate::component::schema::{EnumSchema, NamedStructSchema};
 use crate::doc_comment::CommentAttributes;
 use crate::path::{InlineType, PathType};
-use crate::{Array, ResultExt};
+use crate::{parse_utils, Array, ResultExt};
 
 use super::{
     Content, DeriveIntoResponsesValue, DeriveResponseValue, DeriveResponsesAttributes,
@@ -241,7 +241,10 @@ impl<'u> UnnamedStructResponse<'u> {
         }
         let mut derive_value = DeriveIntoResponsesValue::from_attributes(attributes)
             .expect("`IntoResponses` must have `#[response(...)]` attribute");
-        let description = CommentAttributes::from_attributes(attributes).as_formatted_string();
+        let description = {
+            let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
+            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+        };
         let status_code = mem::take(&mut derive_value.status);
 
         match (ref_response, to_response) {
@@ -294,7 +297,10 @@ impl NamedStructResponse<'_> {
 
         let mut derive_value = DeriveIntoResponsesValue::from_attributes(attributes)
             .expect("`IntoResponses` must have `#[response(...)]` attribute");
-        let description = CommentAttributes::from_attributes(attributes).as_formatted_string();
+        let description = {
+            let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
+            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+        };
         let status_code = mem::take(&mut derive_value.status);
 
         let inline_schema = NamedStructSchema {
@@ -335,7 +341,10 @@ impl UnitStructResponse<'_> {
         let mut derive_value = DeriveIntoResponsesValue::from_attributes(attributes)
             .expect("`IntoResponses` must have `#[response(...)]` attribute");
         let status_code = mem::take(&mut derive_value.status);
-        let description = CommentAttributes::from_attributes(attributes).as_formatted_string();
+        let description = {
+            let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
+            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+        };
 
         Self(
             (
@@ -360,7 +369,10 @@ impl<'p> ToResponseNamedStructResponse<'p> {
         );
 
         let derive_value = DeriveToResponseValue::from_attributes(attributes);
-        let description = CommentAttributes::from_attributes(attributes).as_formatted_string();
+        let description = {
+            let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
+            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+        };
         let ty = Self::to_type(ident);
 
         let inline_schema = NamedStructSchema {
@@ -402,7 +414,10 @@ impl<'u> ToResponseUnnamedStructResponse<'u> {
             }
         });
         let derive_value = DeriveToResponseValue::from_attributes(attributes);
-        let description = CommentAttributes::from_attributes(attributes).as_formatted_string();
+        let description = {
+            let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
+            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+        };
 
         let is_inline = inner_attributes
             .iter()
@@ -444,7 +459,10 @@ impl<'r> EnumResponse<'r> {
         );
 
         let ty = Self::to_type(ident);
-        let description = CommentAttributes::from_attributes(attributes).as_formatted_string();
+        let description = {
+            let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
+            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+        };
 
         let variants_content = variants
             .into_iter()
@@ -572,7 +590,10 @@ impl ToResponseUnitStructResponse<'_> {
         Self::validate_attributes(attributes, Self::has_no_field_attributes);
 
         let derive_value = DeriveToResponseValue::from_attributes(attributes);
-        let description = CommentAttributes::from_attributes(attributes).as_formatted_string();
+        let description = {
+            let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
+            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+        };
         let response_value: ResponseValue = ResponseValue::from(DeriveResponsesAttributes {
             derive_value,
             description,

--- a/utoipa-swagger-ui/build.rs
+++ b/utoipa-swagger-ui/build.rs
@@ -102,7 +102,7 @@ fn write_embed_code(target_dir: &str, swagger_version: &str) {
         r#"
 // This file is auto-generated during compilation, do not modify
 #[derive(RustEmbed)]
-#[folder = "{}/{}/dist/"]
+#[folder = r"{}/{}/dist/"]
 struct SwaggerUiDist;
 "#,
         target_dir, swagger_version


### PR DESCRIPTION
I'm using `utoipa` for documentation of a custom binary protocol which is used for communication between a server and client applications.

P.S.

Custom content type had to be used because swagger UI does not display examples for content type `application/octet-stream`.

## Allowing  `utoipa/utoipa-swagger-ui` successfully build on Windows

On Windows, `\` is a part of path and using it in Rust string makes the following character act as an escape character. For correct behavior on Windows, raw string literal syntax must be used instead.

## Allowing any AnyValue for example field

While documenting the web server, I realized that I can use only `json!` macro an `example` (and I doubt that this restriction was necessary because the only requirement for the type is that it has to implement `serde::se::Serialize`). Even though I can use `json!` macro with a copy-pasted `u8` array, it is not ideal.

Currently, my `utoipa::path` attribute looks like this:

```rust
#[utoipa::path(
    post,
    request_body(
        content = ElasticModulesForUnidirectionalCompositeArgsMessage,
        description = "Python struct format string: \"BBxxxxxxddddd\". See <https://docs.python.org/3/library/struct.html#format-strings>.\n\n\
        See schema for the order of the fields (but not their sizes).",
        content_type = "application/x.elastic-modules-for-unidirectional-composite-args-message",
        example = ElasticModulesForUnidirectionalCompositeArgsMessage::example_as_serde_big_array,
    ),
    responses (
        (
            status = 200,
            description = "Computes elastic_modules_for_unidirectional_composite. \
            Returns the binary representation of [E1, E2, E3, nu12, nu13, nu23, G12, G13, G23] with the requested endianness.\n\n\
            Python struct format string: \"ddddddddd\". See <https://docs.python.org/3/library/struct.html#format-strings>.",
            body = ElasticModulesForUnidirectionalCompositeResponseMessage,
            content_type = "application/x.elastic-modules-for-unidirectional-composite-response-message"
        ),
    )
)]
#[post("/compute/elastic_modules_for_unidirectional_composite")]
async fn elastic_modules_for_unidirectional_composite(
    args: ElasticModulesForUnidirectionalCompositeArgsMessage,
) -> impl Responder {
    //...
}
```

and I'm planning to tinker with `utoipa` more to have less boilerplate.