### PR TITLE
Add example: simple-axum

### DIFF
--- a/examples/simple-axum/Cargo.toml
+++ b/examples/simple-axum/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "simple-axum"
+description = "Very short Axum example that exposes OpenAPI json file"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1.17", features = ["full"] }
+utoipa = { path = "../../utoipa", features = ["axum_extras"] }
+
+[workspace]

--- a/examples/simple-axum/src/main.rs
+++ b/examples/simple-axum/src/main.rs
@@ -1,0 +1,32 @@
+use std::net::SocketAddr;
+
+use axum::{routing::get, Json};
+use utoipa::OpenApi;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(openapi),
+)]
+struct ApiDoc;
+
+/// Return JSON version of an OpenAPI schema
+#[utoipa::path(
+    get,
+    path = "/api-docs/openapi.json",
+    responses(
+        (status = 200, description = "JSON file", body = ())
+    )
+)]
+async fn openapi() -> Json<utoipa::openapi::OpenApi> {
+    Json(ApiDoc::openapi())
+}
+
+#[tokio::main]
+async fn main() {
+    let sa : SocketAddr = "127.0.0.1:8080".parse().unwrap();
+    let l = tokio::net::TcpListener::bind(sa).await.unwrap();
+    let app = axum::Router::new()
+       .route("/api-docs/openapi.json", get(openapi))
+    ;
+    axum::serve(l, app.into_make_service()).await.unwrap()
+}


### PR DESCRIPTION
There is already "todo-axum" example, but it is rather long and includes UI and other advanced things.

I think an additional, short and simple example should useful.