### PR TITLE
Refactor `ReDoc` to take `Cow<'static, str>` instead of borrowed `str`

### DIFF
--- a/utoipa-redoc/src/actix.rs
+++ b/utoipa-redoc/src/actix.rs
@@ -7,7 +7,7 @@ use actix_web::{HttpResponse, Resource, Responder};
 
 use crate::{Redoc, Spec};
 
-impl<'s, 'u, S: Spec> HttpServiceFactory for Redoc<'s, 'u, S> {
+impl<S: Spec> HttpServiceFactory for Redoc<S> {
     fn register(self, config: &mut actix_web::dev::AppService) {
         let html = self.to_html();
 
@@ -17,7 +17,7 @@ impl<'s, 'u, S: Spec> HttpServiceFactory for Redoc<'s, 'u, S> {
                 .body(redoc.to_string())
         }
 
-        Resource::new(self.url)
+        Resource::new(self.url.as_ref())
             .guard(Get())
             .app_data(Data::new(html))
             .to(serve_redoc)

--- a/utoipa-redoc/src/axum.rs
+++ b/utoipa-redoc/src/axum.rs
@@ -5,13 +5,15 @@ use axum::{routing, Router};
 
 use crate::{Redoc, Spec};
 
-impl<'s, 'u, S: Spec, R> From<Redoc<'s, 'u, S>> for Router<R>
+impl<S: Spec, R> From<Redoc<S>> for Router<R>
 where
     R: Clone + Send + Sync + 'static,
-    's: 'static,
 {
-    fn from(value: Redoc<'s, 'u, S>) -> Self {
+    fn from(value: Redoc<S>) -> Self {
         let html = value.to_html();
-        Router::<R>::new().route(value.url, routing::get(move || async { Html(html) }))
+        Router::<R>::new().route(
+            value.url.as_ref(),
+            routing::get(move || async { Html(html) }),
+        )
     }
 }

--- a/utoipa-redoc/src/rocket.rs
+++ b/utoipa-redoc/src/rocket.rs
@@ -7,11 +7,11 @@ use rocket::{Data, Request, Route};
 
 use crate::{Redoc, Spec};
 
-impl<'s, 'u, S: Spec> From<Redoc<'s, 'u, S>> for Vec<Route> {
-    fn from(value: Redoc<'s, 'u, S>) -> Self {
+impl<S: Spec> From<Redoc<S>> for Vec<Route> {
+    fn from(value: Redoc<S>) -> Self {
         vec![Route::new(
             Method::Get,
-            value.url,
+            value.url.as_ref(),
             RedocHandler(value.to_html()),
         )]
     }


### PR DESCRIPTION
Same thing as #867, except I modified `ReDoc` this time. 

### Breaking changes
Just like #867: I think the removal of the two lifetime parameters on `ReDoc` can break some code (e.g. when implementing custom traits for `ReDoc`). As far as the method parameters are concerned, I don't think there are any breaking changes due to the `Into<Cow<'static, str>` generic.