### PR TITLE
Replace `zip` with `zip_next`

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -32,6 +32,6 @@ features = ["actix-web", "axum", "rocket"]
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [build-dependencies]
-zip = { version = "0.6", default-features = false, features = ["deflate"] }
+zip_next = { version = "1.0", default-features = false, features = ["deflate"] }
 regex = "1.7"
 reqwest = { version = "0.11", features = ["blocking"] }

--- a/utoipa-swagger-ui/build.rs
+++ b/utoipa-swagger-ui/build.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use regex::Regex;
-use zip::{result::ZipError, ZipArchive};
+use zip_next::{result::ZipError, ZipArchive};
 
 /// the following env variables control the build process:
 /// 1. SWAGGER_UI_DOWNLOAD_URL:


### PR DESCRIPTION
The `zip` crate hasn't been updated in almost a year, and has a number of bugs that can cause panics when trying to process an invalid zip file. This PR replaces it with `zip_next`, a fork I actively maintain.