### PR TITLE
Implement include_str! for tags

### DIFF
--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -27,7 +27,7 @@ utoipa = { path = "../utoipa", features = ["debug", "uuid"], default-features = 
 serde_json = "1"
 serde = "1"
 actix-web = { version = "4", features = ["macros"], default-features = false }
-axum = { version = "0.7", default-features = false }
+axum = { version = "0.7", default-features = false, features = ["json", "query"] }
 paste = "1"
 rocket = { version = "0.5", features = ["json"] }
 smallvec = { version = "1.10", features = ["serde"] }

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -11,6 +11,7 @@ use syn::{
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 
+use crate::parse_utils::Str;
 use crate::{
     parse_utils, path::PATH_STRUCT_PREFIX, security_requirement::SecurityRequirementsAttr, Array,
     ExternalDocs, ResultExt,
@@ -178,7 +179,7 @@ impl Parse for Modifier {
 #[cfg_attr(feature = "debug", derive(Debug))]
 struct Tag {
     name: String,
-    description: Option<String>,
+    description: Option<Str>,
     external_docs: Option<ExternalDocs>,
 }
 
@@ -198,7 +199,8 @@ impl Parse for Tag {
             match attribute_name {
                 "name" => tag.name = parse_utils::parse_next_literal_str(input)?,
                 "description" => {
-                    tag.description = Some(parse_utils::parse_next_literal_str(input)?)
+                    tag.description =
+                        Some(parse_utils::parse_next_literal_str_or_include_str(input)?)
                 }
                 "external_docs" => {
                     let content;

--- a/utoipa-gen/src/openapi/info.rs
+++ b/utoipa-gen/src/openapi/info.rs
@@ -1,47 +1,14 @@
 use std::borrow::Cow;
 use std::io;
 
-use proc_macro2::{Group, Ident, TokenStream as TokenStream2};
+use proc_macro2::{Ident, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::parse::Parse;
 use syn::token::Comma;
-use syn::{parenthesized, Error, LitStr, Token};
+use syn::{parenthesized, Error, LitStr};
 
 use crate::parse_utils;
-
-#[derive(Clone)]
-#[cfg_attr(feature = "debug", derive(Debug))]
-pub(super) enum Str {
-    String(String),
-    IncludeStr(TokenStream2),
-}
-
-impl Parse for Str {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
-        if input.peek(LitStr) {
-            Ok(Self::String(input.parse::<LitStr>()?.value()))
-        } else {
-            let include_str = input.parse::<Ident>()?;
-            let bang = input.parse::<Option<Token![!]>>()?;
-            if include_str != "include_str" || bang.is_none() {
-                return Err(Error::new(
-                    include_str.span(),
-                    "unexpected token, expected either literal string or include_str!(...)",
-                ));
-            }
-            Ok(Self::IncludeStr(input.parse::<Group>()?.stream()))
-        }
-    }
-}
-
-impl ToTokens for Str {
-    fn to_tokens(&self, tokens: &mut TokenStream2) {
-        match self {
-            Self::String(str) => str.to_tokens(tokens),
-            Self::IncludeStr(include_str) => tokens.extend(quote! { include_str!(#include_str) }),
-        }
-    }
-}
+use crate::parse_utils::Str;
 
 #[derive(Default, Clone)]
 #[cfg_attr(feature = "debug", derive(Debug))]

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -59,6 +59,22 @@ fn derive_openapi_tags() {
 }
 
 #[test]
+fn derive_openapi_tags_include_str() {
+    #[derive(OpenApi)]
+    #[openapi(tags(
+        (name = "random::api", description = include_str!("testdata/openapi-derive-info-description")),
+    ))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+
+    assert_value! {doc=>
+        "tags.[0].name" = r###""random::api""###, "Tags random_api name"
+        "tags.[0].description" = r###""this is include description\n""###, "Tags random_api description"
+    }
+}
+
+#[test]
 fn derive_openapi_with_external_docs() {
     #[derive(OpenApi)]
     #[openapi(external_docs(


### PR DESCRIPTION
Fixes #877 

Moves the Str enum into parse_utils and wraps with parse_next_literal_str_or_include_str().

Also includes a test-case to test the new functionality