### PR TITLE
Update default Swagger UI version

### DIFF
--- a/utoipa-swagger-ui/README.md
+++ b/utoipa-swagger-ui/README.md
@@ -56,7 +56,7 @@ The following configuration env variables are available at build time:
 * `SWAGGER_UI_DOWNLOAD_URL`:
 
   * the url from where to download the swagger-ui zip file
-  * default value: <https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.11.0.zip>
+  * default value: <https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.3.zip>
   * All versions: <https://github.com/swagger-api/swagger-ui/tags>
 
 * `SWAGGER_UI_OVERWRITE_FOLDER`:

--- a/utoipa-swagger-ui/build.rs
+++ b/utoipa-swagger-ui/build.rs
@@ -18,7 +18,7 @@ use zip_next::{result::ZipError, ZipArchive};
 /// + absolute path to a folder containing files to overwrite the default swagger-ui files
 
 const SWAGGER_UI_DOWNLOAD_URL_DEFAULT: &str =
-    "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.11.0.zip";
+    "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.3.zip";
 
 fn main() {
     let target_dir = env::var("OUT_DIR").unwrap();
@@ -28,7 +28,7 @@ fn main() {
         env::var("SWAGGER_UI_DOWNLOAD_URL").unwrap_or(SWAGGER_UI_DOWNLOAD_URL_DEFAULT.to_string());
 
     println!("SWAGGER_UI_DOWNLOAD_URL: {}", url);
-    let zip_filename = url.split("/").last().unwrap().to_string();
+    let zip_filename = url.split('/').last().unwrap().to_string();
     let zip_path = [&target_dir, &zip_filename].iter().collect::<PathBuf>();
 
     if !zip_path.exists() {
@@ -156,7 +156,7 @@ struct SwaggerUiDist;
         target_dir, zip_top_level_folder
     );
     let path = [target_dir, "embed.rs"].iter().collect::<PathBuf>();
-    fs::write(&path, &contents).unwrap();
+    fs::write(path, contents).unwrap();
 }
 
 fn download_file(url: &str, path: PathBuf) -> Result<(), Box<dyn Error>> {
@@ -178,7 +178,7 @@ fn overwrite_target_file(target_dir: &str, swagger_ui_dist_zip: &str, path_in: P
                 .iter()
                 .collect::<PathBuf>();
 
-            fs::write(&path, &content).unwrap();
+            fs::write(path, content).unwrap();
         }
         Err(_) => {
             println!("cannot read content from file: {:?}", path_in);

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -9,7 +9,7 @@
 //!
 //! * **actix-web** `version >= 4`
 //! * **rocket** `version >=0.5`
-//! * **axum** `version >=0.6`
+//! * **axum** `version >=0.7`
 //!
 //! Serving Swagger UI is framework independent thus this crate also supports serving the Swagger UI with
 //! other frameworks as well. With other frameworks there is bit more manual implementation to be done. See
@@ -33,16 +33,31 @@
 //! Use only the raw types without any boiler plate implementation.
 //! ```toml
 //! [dependencies]
-//! utoipa-swagger-ui = "3"
+//! utoipa-swagger-ui = "6"
 //! ```
 //!
 //! Enable actix-web framework with Swagger UI you could define the dependency as follows.
 //! ```toml
 //! [dependencies]
-//! utoipa-swagger-ui = { version = "3", features = ["actix-web"] }
+//! utoipa-swagger-ui = { version = "6", features = ["actix-web"] }
 //! ```
 //!
 //! **Note!** Also remember that you already have defined `utoipa` dependency in your `Cargo.toml`
+//!
+//! ## Config
+//!
+//! The following configuration env variables are available at build time:
+//!
+//! * `SWAGGER_UI_DOWNLOAD_URL`:
+//!
+//!   * the url from where to download the swagger-ui zip file
+//!   * default value: <https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.3.zip>
+//!   * All versions: <https://github.com/swagger-api/swagger-ui/tags>
+//!
+//! * `SWAGGER_UI_OVERWRITE_FOLDER`:
+//!
+//!   * absolute path to a folder containing files to overwrite the default swagger-ui files
+//!   * typically you might want to overwrite `index.html`
 //!
 //! # Examples
 //!


### PR DESCRIPTION
While users are allowed to change the Swagger UI with build time environment variable `SWAGGER_UI_DOWNLOAD_URL`. This PR updates docs and default Swagger UI to the latest version.

Resolves #888 