### PR TITLE
Add support for addtional tags via `tags`

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -690,6 +690,9 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///   this is derived from the handler that is given to [`OpenApi`][openapi]. If derive results empty str
 ///   then default value _`crate`_ is used instead.
 ///
+/// * `tags = ["tag1", ...]` Can be used to group operations. Operations with same tag are grouped
+///   toghether. Tags attribute can be used to add addtional _tags_ for the operation.
+///
 /// * `request_body = ... | request_body(...)` Defining request body indicates that the request is expecting request body within
 ///   the performed request.
 ///
@@ -2845,7 +2848,7 @@ mod parse_utils {
     }
 
     pub fn parse_next_literal_str_or_include_str(input: ParseStream) -> syn::Result<Str> {
-        Ok(parse_next(input, || input.parse::<Str>())?)
+        parse_next(input, || input.parse::<Str>())
     }
 
     pub fn parse_next_literal_str_or_expr(input: ParseStream) -> syn::Result<Value> {

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -2038,3 +2038,43 @@ fn derive_path_with_tag_constant() {
         })
     );
 }
+
+#[test]
+fn derive_path_with_multiple_tags() {
+    const TAG: &str = "mytag";
+    const ANOTHER: &str = "another";
+
+    #[utoipa::path(
+        get,
+        tag = TAG,
+        tags = ["one", "two", ANOTHER],
+        path = "/items",
+        responses(
+            (status = 200, description = "success response")
+        ),
+    )]
+    #[allow(unused)]
+    fn get_items() -> String {
+        "".to_string()
+    }
+
+    let operation = test_api_fn_doc! {
+        get_items,
+        operation: get,
+        path: "/items"
+    };
+
+    assert_ne!(operation, Value::Null);
+    assert_json_eq!(
+        &operation,
+        json!({
+            "operationId": "get_items",
+            "responses": {
+                "200": {
+                    "description": "success response",
+                },
+            },
+            "tags": ["one", "two","another","mytag"]
+        })
+    );
+}

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -336,8 +336,8 @@ impl Operation {
 
 impl OperationBuilder {
     /// Add or change tags of the [`Operation`].
-    pub fn tags<I: IntoIterator<Item = String>>(mut self, tags: Option<I>) -> Self {
-        set_value!(self tags tags.map(|tags| tags.into_iter().collect()))
+    pub fn tags<I: IntoIterator<Item = V>, V: Into<String>>(mut self, tags: Option<I>) -> Self {
+        set_value!(self tags tags.map(|tags| tags.into_iter().map(Into::into).collect()))
     }
 
     /// Append tag to [`Operation`] tags.


### PR DESCRIPTION
Add support for additonal tags via `tags` attribute on `utoipa::path` macro. All the tags will be appended to the tags will be appended to the tags of the operation. This means that the default tag (the handler function name by default) will be added if not overridden with the `tag` attribute.

```rust
 #[utoipa::path(
    get,
    tag = "some_tag",
    tags = ["addtional tag 1", "another one"]
 )]
 fn handler() {}
```

Resolves #880, Resolve #792