### PR TITLE
Use `minreq` instead of `reqwest`

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -32,6 +32,6 @@ features = ["actix-web", "axum", "rocket"]
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [build-dependencies]
-zip = { version = "1", default-features = false, features = ["deflate"] }
+minreq = { version = "2.11.2", features = ["https-rustls"] }
 regex = "1.7"
-reqwest = { version = "0.12", features = ["blocking", "rustls-tls"], default-features = false }
+zip = { version = "1", default-features = false, features = ["deflate"] }

--- a/utoipa-swagger-ui/build.rs
+++ b/utoipa-swagger-ui/build.rs
@@ -160,9 +160,8 @@ struct SwaggerUiDist;
 }
 
 fn download_file(url: &str, path: PathBuf) -> Result<(), Box<dyn Error>> {
-    let mut response = reqwest::blocking::get(url)?;
-    let mut file = File::create(path)?;
-    io::copy(&mut response, &mut file)?;
+    let response = minreq::get(url).send()?;
+    fs::write(path, response.into_bytes())?;
     Ok(())
 }
 


### PR DESCRIPTION
The latest version of `utoipa-swagger-ui` introduced a dependence on `reqwest` at build-time just to download a single file.  

That feels unnecessarily heavy, considering it's intended to be a one-off download thing, and `reqwest` pulls in the entirety of hyper, tokio, mio, and all supporting libraries of that.

This PR replaces it with `minreq` which has a smaller dependency tree.  
The difference here is that `minreq` buffers the entire body into memory, but I checked the size of the archive and 4MB seem like a fine amount to buffer in memory.

If it isn't, then we can switch to `ureq` which offers an `io::Read` based interface, so it streams the response (but it is *a little* heavier on dependencies than `minreq`, but not by much).