### PR TITLE
Migrate out from proc macro error

### DIFF
--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -16,7 +16,6 @@ proc-macro = true
 proc-macro2 = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
-proc-macro-error = "1.0"
 regex = { version = "1.7", optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
 ulid = { version = "1", optional = true, default-features = false }

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -14,7 +14,7 @@ use quote::{format_ident, quote, quote_spanned, ToTokens};
 use crate::parse_utils::Str;
 use crate::{
     parse_utils, path::PATH_STRUCT_PREFIX, security_requirement::SecurityRequirementsAttr, Array,
-    ExternalDocs, ResultExt,
+    ExternalDocs,
 };
 
 use self::info::Info;
@@ -65,12 +65,13 @@ impl<'o> OpenApiAttr<'o> {
     }
 }
 
-pub fn parse_openapi_attrs(attrs: &[Attribute]) -> Option<OpenApiAttr> {
+pub fn parse_openapi_attrs(attrs: &[Attribute]) -> Result<Option<OpenApiAttr>, Error> {
     attrs
         .iter()
         .filter(|attribute| attribute.path().is_ident("openapi"))
-        .map(|attribute| attribute.parse_args::<OpenApiAttr>().unwrap_or_abort())
-        .reduce(|acc, item| acc.merge(item))
+        .map(|attribute| attribute.parse_args::<OpenApiAttr>())
+        .collect::<Result<Vec<_>, _>>()
+        .map(|attrs| attrs.into_iter().reduce(|acc, item| acc.merge(item)))
 }
 
 impl Parse for OpenApiAttr<'_> {

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -17,7 +17,6 @@ use utoipa::{
     },
     IntoParams, OpenApi, ToSchema,
 };
-use uuid::Uuid;
 
 mod common;
 
@@ -866,6 +865,7 @@ fn path_with_all_args() {
 }
 
 #[test]
+#[cfg(feature = "uuid")]
 fn path_with_all_args_using_uuid() {
     #[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
     struct Item(String);
@@ -926,6 +926,7 @@ fn path_with_all_args_using_uuid() {
 }
 
 #[test]
+#[cfg(feature = "uuid")]
 fn path_with_all_args_using_custom_uuid() {
     #[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
     struct Item(String);
@@ -944,7 +945,7 @@ fn path_with_all_args_using_custom_uuid() {
 
     #[derive(Serialize, Deserialize, IntoParams)]
     #[into_params(names("custom_uuid"))]
-    struct Id(Uuid);
+    struct Id(uuid::Uuid);
 
     impl FromRequest for Id {
         type Error = Error;


### PR DESCRIPTION
Implement `Result<T, E>` based proc macro error handling instead of out
of fashion `proc_macro_error` that still is in _syn_ `1.0`. This allows
us to remove the need for `proc_macro_error` crate and makes our
dependency tree leaner.

The error handling is implemented with custom `ToTokensDiagnostics` trait
that is used instead of the `ToTokens` when there is a possibility for 
error. Error is passed up in the call stack via `Diagnostics` struct
that converts to compile error token stream at root of the macro call.

The result based approach is the recommended way of handling compile 
errors in proc macros.

Resolves #854