### PR TITLE
Add `merge_from` method for chainable merge

### DIFF
--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -154,6 +154,15 @@ impl OpenApi {
         serde_yaml::to_string(self)
     }
 
+    /// Merge `other` [`OpenApi`] moving `self` and returning combined [`OpenApi`].
+    ///
+    /// In functionality wise this is exactly same as calling [`OpenApi::merge`] but but provides
+    /// leaner API for chaining method calls.
+    pub fn merge_from(mut self, other: OpenApi) -> OpenApi {
+        self.merge(other);
+        self
+    }
+
     /// Merge `other` [`OpenApi`] consuming it and resuming it's content.
     ///
     /// Merge function will take all `self` nonexistent _`servers`, `paths`, `schemas`, `responses`,


### PR DESCRIPTION
Add new method `merge_from` for `OpenApi` to provide better chainability when merging multiple `OpenApi`s to a single one.

Resolves #776 