### PR TITLE
fix syntax: change pub(super) enum to pub enum

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -2984,7 +2984,7 @@ mod parse_utils {
 
     #[derive(Clone)]
     #[cfg_attr(feature = "debug", derive(Debug))]
-    pub(super) enum Str {
+    pub enum Str {
         String(String),
         IncludeStr(TokenStream),
     }


### PR DESCRIPTION
When I was using utoipa, I found a syntax error that prevented me from completing the cargo build. pub(super) enum str will cause the function parse_next_literal_str_or_include_str error on L.2913 in this file. As shown in the figure below:
![image](https://github.com/juhaku/utoipa/assets/107397001/697a7d65-3192-41c0-9a38-79c9cabfa55d)

Therefore, the deletion (super) is consistent with the `pub enum Value`  on L.2856 in this file.
![image](https://github.com/juhaku/utoipa/assets/107397001/1137401c-ae2a-4985-8398-5c355205b7e9)
