### PR TITLE
Fix tuple params missing features

### DIFF
--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -76,12 +76,12 @@ impl<'p> PathAttr<'p> {
     ) {
         let ext_params = ext_parameters.into_iter();
 
-        let (existing_params, new_params): (Vec<Parameter>, Vec<Parameter>) =
+        let (existing_incoming_params, new_params): (Vec<Parameter>, Vec<Parameter>) =
             ext_params.partition(|param| self.params.iter().any(|p| p == param));
 
-        for existing in existing_params {
-            if let Some(param) = self.params.iter_mut().find(|p| **p == existing) {
-                param.merge(existing);
+        for existing_incoming in existing_incoming_params {
+            if let Some(param) = self.params.iter_mut().find(|p| **p == existing_incoming) {
+                param.merge(existing_incoming);
             }
         }
 

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -52,7 +52,12 @@ impl<'p> Parameter<'p> {
     pub fn merge(&mut self, other: Parameter<'p>) {
         match (self, other) {
             (Self::Value(value), Parameter::Value(other)) => {
+                let (schema_features, _) = &value.features;
                 value.parameter_schema = other.parameter_schema;
+
+                if let Some(parameter_schema) = &mut value.parameter_schema {
+                    parameter_schema.features.clone_from(schema_features);
+                }
             }
             (Self::IntoParamsIdent(into_params), Parameter::IntoParamsIdent(other)) => {
                 *into_params = other;
@@ -157,7 +162,7 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
             ParameterType::External(type_tree) => {
                 let required: Required = (!type_tree.is_option()).into();
 
-                Ok(to_tokens(
+                to_tokens(
                     ComponentSchema::new(component::ComponentSchemaProps {
                         type_tree,
                         features: Some(self.features.clone()),
@@ -166,7 +171,8 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                         object_name: "",
                     }),
                     required,
-                ))
+                );
+                Ok(())
             }
             ParameterType::Parsed(inline_type) => {
                 let type_tree = inline_type.as_type_tree()?;
@@ -175,7 +181,7 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                 schema_features.clone_from(&self.features);
                 schema_features.push(Feature::Inline(inline_type.is_inline.into()));
 
-                Ok(to_tokens(
+                to_tokens(
                     ComponentSchema::new(component::ComponentSchemaProps {
                         type_tree: &type_tree,
                         features: Some(schema_features),
@@ -184,7 +190,8 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                         object_name: "",
                     }),
                     required,
-                ))
+                );
+                Ok(())
             }
         }
     }

--- a/utoipa-gen/tests/path_parameter_derive_actix.rs
+++ b/utoipa-gen/tests/path_parameter_derive_actix.rs
@@ -166,7 +166,8 @@ fn derive_params_from_method_args_actix_success() {
 }
 
 #[test]
-fn derive_path_with_date_params_implicit() {
+#[cfg(feature = "chrono")]
+fn derive_path_with_date_params_chrono_implicit() {
     mod mod_derive_path_with_date_params {
         use actix_web::{get, web, HttpResponse, Responder};
         use chrono::{DateTime, Utc};
@@ -221,7 +222,8 @@ fn derive_path_with_date_params_implicit() {
 }
 
 #[test]
-fn derive_path_with_date_params_explicit_ignored() {
+#[cfg(feature = "time")]
+fn derive_path_with_date_params_explicit_ignored_time() {
     mod mod_derive_path_with_date_params {
         use actix_web::{get, web, HttpResponse, Responder};
         use serde_json::json;
@@ -270,6 +272,6 @@ fn derive_path_with_date_params_explicit_ignored() {
         "[1].required" = r#"true"#, "Parameter required"
         "[1].deprecated" = r#"null"#, "Parameter deprecated"
         "[1].schema.type" = r#""string""#, "Parameter schema type"
-        "[1].schema.format" = r#"null"#, "Parameter schema format"
+        "[1].schema.format" = r#""date-time""#, "Parameter schema format"
     };
 }


### PR DESCRIPTION
When `axum_extras`,`actix_extras` or `rocket_extras` was enabled the udpate of existing parameters did not take in account the features that was defined in the tuple style arguments and was overridden with empty features. This PR fixes this behavior where features will be also updated accordingly.

Resolves #804 Fixes #693