### PR TITLE
Add nest `OpenApi` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[workspace.package]
+rust-version = "1.75"
+
 [workspace]
 resolver = "2"
 members = [

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 keywords = ["openapi", "codegen", "proc-macro", "documentation", "compile-time"]
 repository = "https://github.com/juhaku/utoipa"
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/utoipa-gen/src/component/serde.rs
+++ b/utoipa-gen/src/component/serde.rs
@@ -87,10 +87,11 @@ impl SerdeValue {
 
 /// The [Serde Enum representation](https://serde.rs/enum-representations.html) being used
 /// The default case (when no serde attributes are present) is `ExternallyTagged`.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub enum SerdeEnumRepr {
+    #[default]
     ExternallyTagged,
     InternallyTagged {
         tag: String,
@@ -106,12 +107,6 @@ pub enum SerdeEnumRepr {
     UnfinishedAdjacentlyTagged {
         content: String,
     },
-}
-
-impl Default for SerdeEnumRepr {
-    fn default() -> SerdeEnumRepr {
-        SerdeEnumRepr::ExternallyTagged
-    }
 }
 
 /// Attributes defined within a `#[serde(...)]` container attribute.

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -98,7 +98,7 @@ use self::{
 ///   the OpenAPI. E.g _`as = path::to::Pet`_. This would make the schema appear in the generated
 ///   OpenAPI spec as _`path.to.Pet`_.
 /// * `default` Can be used to populate default values on all fields using the struct's
-///   [`Default`](std::default::Default) implementation.
+///   [`Default`] implementation.
 /// * `deprecated` Can be used to mark all fields as deprecated in the generated OpenAPI spec but
 ///   not in the code. If you'd like to mark the fields as deprecated in the code as well use
 ///   Rust's own `#[deprecated]` attribute instead.
@@ -131,7 +131,7 @@ use self::{
 /// * `example = ...` Can be method reference or _`json!(...)`_.
 /// * `default = ...` Can be method reference or _`json!(...)`_. If no value is specified, and the struct has
 ///   only one field, the field's default value in the schema will be set from the struct's
-///   [`Default`](std::default::Default) implementation.
+///   [`Default`] implementation.
 /// * `format = ...` May either be variant of the [`KnownFormat`][known_format] enum, or otherwise
 ///   an open value as a string. By default the format is derived from the type of the property
 ///   according OpenApi spec.
@@ -1456,6 +1456,18 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   whole attribute from generated values of Cargo environment variables. E.g. defining
 ///   `contact(name = ...)` will ultimately override whole contact of info and not just partially
 ///   the name.
+/// * `nest(...)` Allows nesting [`OpenApi`][openapi_struct]s to this _`OpenApi`_ instance. Nest
+///   takes comma separated list of tuples that define comma separated key values of nest path and
+///   _`OpenApi`_ instance to nest. _`OpenApi`_ instance must implement [`OpenApi`][openapi] trait.
+///
+///     _**Nest syntax example.**_
+///
+///     ```text
+///     nest(
+///         ("/path/to/nest", ApiToNest),
+///         ("/another", AnotherApi)
+///     )
+///     ```
 ///
 /// OpenApi derive macro will also derive [`Info`][info] for OpenApi specification using Cargo
 /// environment variables.
@@ -1608,6 +1620,32 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     )
 /// )]
 /// struct ApiDoc;
+/// ```
+///
+/// _**Nest _`UserApi`_ to the current api doc instance.**_
+/// ```rust
+/// # use utoipa::OpenApi;
+/// #
+///  #[utoipa::path(get, path = "/api/v1/status")]
+///  fn test_path_status() {}
+///
+///  #[utoipa::path(get, path = "/test")]
+///  fn user_test_path() {}
+///
+///  #[derive(OpenApi)]
+///  #[openapi(paths(user_test_path))]
+///  struct UserApi;
+///
+///  #[derive(OpenApi)]
+///  #[openapi(
+///      paths(
+///          test_path_status
+///      ),
+///      nest(
+///          ("/api/v1/user", UserApi),
+///      )
+///  )]
+///  struct ApiDoc;
 /// ```
 ///
 /// [openapi]: trait.OpenApi.html

--- a/utoipa-rapidoc/Cargo.toml
+++ b/utoipa-rapidoc/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["rapidoc", "openapi", "documentation"]
 repository = "https://github.com/juhaku/utoipa"
 categories = ["web-programming"]
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["actix-web", "axum", "rocket"]

--- a/utoipa-redoc/Cargo.toml
+++ b/utoipa-redoc/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["redoc", "openapi", "documentation"]
 repository = "https://github.com/juhaku/utoipa"
 categories = ["web-programming"]
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["actix-web", "axum", "rocket"]

--- a/utoipa-scalar/Cargo.toml
+++ b/utoipa-scalar/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["scalar", "openapi", "documentation"]
 repository = "https://github.com/juhaku/utoipa"
 categories = ["web-programming"]
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
+rust-version.workspace = true
 
 [package.metadata.docs.rs]
 features = ["actix-web", "axum", "rocket"]

--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["swagger-ui", "openapi", "documentation"]
 repository = "https://github.com/juhaku/utoipa"
 categories = ["web-programming"]
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
+rust-version.workspace = true
 
 [features]
 debug = []

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -17,6 +17,7 @@ keywords = [
 repository = "https://github.com/juhaku/utoipa"
 categories = ["web-programming"]
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
+rust-version.workspace = true
 
 [features]
 # See README.md for list and explanations of features

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -16,9 +16,9 @@ use super::{
 };
 
 #[cfg(not(feature = "preserve_path_order"))]
-type PathsMap<K, V> = std::collections::BTreeMap<K, V>;
+pub(super) type PathsMap<K, V> = std::collections::BTreeMap<K, V>;
 #[cfg(feature = "preserve_path_order")]
-type PathsMap<K, V> = indexmap::IndexMap<K, V>;
+pub(super) type PathsMap<K, V> = indexmap::IndexMap<K, V>;
 
 builder! {
     PathsBuilder;


### PR DESCRIPTION
This PR implements API nesting support to enable modular OpenAPI specification declaration. This functionality is implemented at OpenApi type itself as well as at OpenApi derive trait. Prior to this PR there was no simple way to modularize the OpenApi definition and one way to do this was to use `context_path` attribute on `#[utoipa::path]` macro but this functionality undoes the need for `context_path` in most cases.

Add `nest(...)` method to `OpenApi` to allow nesting of other `OpenApi` instances to the current `OpenApi` instance.
```rust
  let api = OpenApiBuider::new().build();
  let nested = api.nest("/nest/path", OpenApiBuilder::new().build());
```

Add `nest` attribute to `OpenApi` derive macro.
```rust
 #[derive(OpenApi)]
 #[openapi(
   paths(...),
   nest(
     ("path/to/nest", NestableApi)
   )
 )]
 struct RootApi;
```

Resolves #445 Resolves #872