### PR TITLE
Enhance OpenApi nesting with tags support

### DIFF
--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -213,7 +213,9 @@ impl<'r> ResponseValue<'r> {
         description: parse_utils::Value,
     ) -> Self {
         Self {
-            description: if derive_value.description.is_empty() && !description.is_empty() {
+            description: if derive_value.description.is_empty_litstr()
+                && !description.is_empty_litstr()
+            {
                 description
             } else {
                 derive_value.description
@@ -231,7 +233,9 @@ impl<'r> ResponseValue<'r> {
         description: parse_utils::Value,
     ) -> Self {
         ResponseValue {
-            description: if response_value.description.is_empty() && !description.is_empty() {
+            description: if response_value.description.is_empty_litstr()
+                && !description.is_empty_litstr()
+            {
                 description
             } else {
                 response_value.description
@@ -418,7 +422,7 @@ impl DeriveResponseValue for DeriveToResponseValue {
         if !other.headers.is_empty() {
             self.headers = other.headers;
         }
-        if !other.description.is_empty() {
+        if !other.description.is_empty_litstr() {
             self.description = other.description;
         }
         if other.example.is_some() {
@@ -493,7 +497,7 @@ impl DeriveResponseValue for DeriveIntoResponsesValue {
         if !other.headers.is_empty() {
             self.headers = other.headers;
         }
-        if !other.description.is_empty() {
+        if !other.description.is_empty_litstr() {
             self.description = other.description;
         }
         if other.example.is_some() {

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -2042,6 +2042,7 @@ fn derive_path_with_tag_constant() {
 
 #[test]
 fn derive_path_with_multiple_tags() {
+    #[allow(dead_code)]
     const TAG: &str = "mytag";
     const ANOTHER: &str = "another";
 
@@ -2075,7 +2076,7 @@ fn derive_path_with_multiple_tags() {
                     "description": "success response",
                 },
             },
-            "tags": ["one", "two","another","mytag"]
+            "tags": ["one", "two","another"]
         })
     );
 }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -717,7 +717,7 @@ impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for Option<HashMap
 pub trait Path {
     fn path() -> String;
 
-    fn path_item(default_tag: Option<&str>) -> openapi::path::PathItem;
+    fn path_item() -> openapi::path::PathItem;
 }
 
 /// Trait that allows OpenApi modification at runtime.
@@ -934,6 +934,78 @@ impl IntoResponses for () {
 pub trait ToResponse<'__r> {
     /// Returns a tuple of response component name (to be referenced) to a response.
     fn response() -> (&'__r str, openapi::RefOr<openapi::response::Response>);
+}
+
+/// Internal dev module used internally by utoipa-gen
+#[doc(hidden)]
+pub mod __dev {
+
+    use crate::{utoipa, OpenApi};
+
+    pub trait PathConfig {
+        fn config() -> (String, Vec<&'static str>, utoipa::openapi::path::PathItem);
+    }
+
+    pub trait Tags<'t> {
+        fn tags() -> Vec<&'t str>;
+    }
+
+    const DEFAULT_TAG: &str = "crate";
+
+    impl<T: PathConfig> utoipa::Path for T {
+        fn path() -> String {
+            <Self as PathConfig>::config().0.to_string()
+        }
+
+        fn path_item() -> crate::openapi::path::PathItem {
+            let (_, tags, mut item) = <Self as PathConfig>::config();
+
+            for (_, operation) in item.operations.iter_mut() {
+                let operation_tags = operation.tags.get_or_insert(Vec::new());
+                operation_tags.extend(tags.iter().map(ToString::to_string));
+                // add deault tag if no tags is defined
+                if operation_tags.is_empty() {
+                    operation_tags.push(DEFAULT_TAG.to_string());
+                }
+            }
+
+            item
+        }
+    }
+
+    pub trait NestedApiConfig {
+        fn config() -> (utoipa::openapi::OpenApi, Vec<&'static str>);
+    }
+
+    impl<T: NestedApiConfig> OpenApi for T {
+        fn openapi() -> crate::openapi::OpenApi {
+            let (mut api, tags) = T::config();
+
+            api.paths
+                .paths
+                .iter_mut()
+                .flat_map(|(_, item)| &mut item.operations)
+                .for_each(|(_, operation)| {
+                    let operation_tags = operation.tags.get_or_insert(Vec::new());
+                    operation_tags.extend(tags.iter().map(ToString::to_string));
+                    // remove defualt tag if found and there are more than 1 tag
+                    if operation_tags.len() > 1 {
+                        let index = operation_tags.iter().enumerate().find_map(|(index, tag)| {
+                            if tag == DEFAULT_TAG {
+                                Some(index)
+                            } else {
+                                None
+                            }
+                        });
+                        if let Some(index) = index {
+                            operation_tags.remove(index);
+                        };
+                    }
+                });
+
+            api
+        }
+    }
 }
 
 #[cfg(test)]

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -234,6 +234,8 @@ impl OpenApi {
     /// `path` and then appended to _`paths`_ of this [`OpenApi`] instance. Rest of the  `other`
     /// [`OpenApi`] instance is merged to this [`OpenApi`] with [`OpenApi::merge_from`] method.
     ///
+    /// **If multiple** APIs are being nested with same `path` only the **last** one will be retained.
+    ///
     /// Method accpets two arguments, first is the path to prepend .e.g. _`/user`_. Second argument
     /// is the [`OpenApi`] to prepend paths for.
     ///

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -111,7 +111,7 @@ impl PathsBuilder {
     /// Appends a [`Path`] to map of paths. By calling [`path`](PathsBuilder::path) method.
     /// None will be passed into [Path::path_item] method.
     pub fn path_from<P: Path>(self) -> Self {
-        self.path(P::path(), P::path_item(None))
+        self.path(P::path(), P::path_item())
     }
 }
 


### PR DESCRIPTION
This commits enhances the `OpenApi` nesting support by adding possiblity to define `tags [...]` for the nested OpenApi endpoints. By default the fully qualified path to the nested `OpenApi` will become the tag for the endpoints if provided.

This commit also makes it necessary to define the argument names within the nest tuple to be constant across the utoipa macros and more readable. `Path` and `api` arguments are necesary.

Supported nesting syntax:
```rust
(path = "/path/to/nest/api", api = path::to:NestableApi, tags = [...])
```

**Breaking!** This is breaking change as this changes the `utoipa::Path` trait syntax to following. Prior this commit the  `path_item` function took `Option<&str>`parameter to define default `tag` for the path operation but this is no longer necessary.
```rust
trait Path {
    fn path() -> String;
    fn path_item() -> PathItem;
}
```

Follow up PR for #930

Resolves #445 Resolves #872