### PR TITLE
Enhance utoipa-swagger-ui build

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -12,15 +12,20 @@ authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
 rust-version.workspace = true
 
 [features]
+default = ["url"]
 debug = []
 debug-embed = ["rust-embed/debug-embed"]
+reqwest = ["dep:reqwest"]
+url = ["dep:url"]
 
 [dependencies]
 rust-embed = { version = "8" }
 mime_guess = { version = "2.0" }
 actix-web = { version = "4", optional = true, default-features = false }
 rocket = { version = "0.5", features = ["json"], optional = true }
-axum = { version = "0.7", default-features = false, features = ["json"], optional = true }
+axum = { version = "0.7", default-features = false, features = [
+    "json",
+], optional = true }
 utoipa = { version = "4", path = "../utoipa" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
@@ -35,4 +40,18 @@ rustdoc-args = ["--cfg", "doc_cfg"]
 [build-dependencies]
 zip = { version = "1", default-features = false, features = ["deflate"] }
 regex = "1.7"
-reqwest = { version = "0.12", features = ["blocking", "rustls-tls"], default-features = false }
+
+# enabled optionally to allow rust only build with expense of bigger dependency tree and platform
+# independant build. By default `curl` system package is tried for downloading the Swagger UI.
+reqwest = { version = "0.12", features = [
+    "blocking",
+    "rustls-tls",
+], default-features = false, optional = true }
+url = { version = "2.5", optional = true }
+
+# Windows is forced to use reqwest to download the Swagger UI.
+[target.'cfg(windows)'.build-dependencies]
+reqwest = { version = "0.12", features = [
+    "blocking",
+    "rustls-tls",
+], default-features = false }

--- a/utoipa-swagger-ui/README.md
+++ b/utoipa-swagger-ui/README.md
@@ -30,6 +30,9 @@ more details at [serve](https://docs.rs/utoipa-swagger-ui/latest/utoipa_swagger_
   hassle free.
 * **debug-embed** Enables `debug-embed` feature on `rust_embed` crate to allow embedding files in debug
   builds as well.
+* **reqwest** Use `reqwest` for downloading Swagger UI accoring to the `SWAGGER_UI_DOWNLOAD_URL` environment
+  variable. This is only enabled by default on _Windows_.
+* **url** Enabled by default for parsing and encoding the download URL.
 
 ## Install
 
@@ -49,7 +52,13 @@ utoipa-swagger-ui = { version = "7", features = ["actix-web"] }
 
 **Note!** Also remember that you already have defined `utoipa` dependency in your `Cargo.toml`
 
-## Config
+## Build Config
+
+_`utoipa-swagger-ui` crate will by default try to use system `curl` package for downloading the Swagger UI. It
+can optionally be downloaded with `reqwest` by enabling `reqwest` feature. On Windows the `reqwest` feature
+is enabled by default. Reqwest can be useful for platform independent builds however bringing quite a few 
+unnecessary dependencies just to download a file. If the `SWAGGER_UI_DOWNLOAD_URL` is a file path then no 
+downloading will happen._
 
 The following configuration env variables are available at build time:
 


### PR DESCRIPTION
Use `curl` to download Swagger UI by default and allow using `reqwest` optionally with `reqwest` feature flag. Reqwest will be automatically enabled on Windows targets.

Change the re-build parameters as follows.
* For file protocol the re-build should happen when the upstream file changes
* For http protocol the re-build should happen when the environment variable holding the downloadd URL will change.