### PR TITLE
Feature openapi 31

### DIFF
--- a/scripts/doc.sh
+++ b/scripts/doc.sh
@@ -3,5 +3,5 @@
 # Generate utoipa workspace docs
 
 cargo +nightly doc -Z unstable-options --workspace --no-deps \
-    --features actix_extras,openapi_extensions,yaml,uuid,ulid,url,actix-web,axum,rocket \
+    --features actix_extras,openapi_extensions,yaml,uuid,ulid,url,non_strict_integers,actix-web,axum,rocket \
     --config 'build.rustdocflags = ["--cfg", "doc_cfg"]'

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -6,13 +6,13 @@ use syn::spanned::Spanned;
 use syn::{Attribute, GenericArgument, Path, PathArguments, PathSegment, Type, TypePath};
 
 use crate::doc_comment::CommentAttributes;
-use crate::schema_type::SchemaFormat;
+use crate::schema_type::{SchemaFormat, SchemaTypeInner};
 use crate::{as_tokens_or_diagnostics, Diagnostics, OptionExt, ToTokensDiagnostics};
 use crate::{schema_type::SchemaType, Deprecated};
 
 use self::features::{
-    pop_feature, Description, Feature, FeaturesExt, IsInline, Minimum, Nullable, ToTokensExt,
-    Validatable,
+    pop_feature, Description, Feature, FeaturesExt, IntoInner, IsInline, Minimum, Nullable,
+    ToTokensExt, Validatable,
 };
 use self::schema::format_path_ref;
 use self::serde::{RenameRule, SerdeContainer, SerdeValue};
@@ -265,7 +265,10 @@ impl<'t> TypeTree<'t> {
 
     fn convert(path: &'t Path, last_segment: &'t PathSegment) -> TypeTree<'t> {
         let generic_type = Self::get_generic_type(last_segment);
-        let schema_type = SchemaType(path);
+        let schema_type = SchemaType {
+            path,
+            nullable: matches!(generic_type, Some(GenericType::Option)),
+        };
 
         Self {
             path: Some(Cow::Borrowed(path)),
@@ -641,6 +644,27 @@ impl<'c> ComponentSchema {
         Ok(Self { tokens })
     }
 
+    /// Create `.schema_type(...)` override token stream if nullable is true from given [`SchemaTypeInner`].
+    fn get_schema_type_override(
+        nullable: Option<Nullable>,
+        schema_type_inner: SchemaTypeInner,
+    ) -> Option<TokenStream> {
+        if let Some(nullable) = nullable {
+            let nullable_schema_type = nullable.into_schema_type_token_stream();
+            let schema_type = if nullable.value() && !nullable_schema_type.is_empty() {
+                Some(
+                    quote! { utoipa::openapi::schema::SchemaType::from_iter([#schema_type_inner, #nullable_schema_type]) },
+                )
+            } else {
+                None
+            };
+
+            schema_type.map(|schema_type| quote! { .schema_type(#schema_type) })
+        } else {
+            None
+        }
+    }
+
     fn map_to_tokens(
         tokens: &mut TokenStream,
         mut features: Vec<Feature>,
@@ -651,7 +675,8 @@ impl<'c> ComponentSchema {
     ) -> Result<(), Diagnostics> {
         let example = features.pop_by(|feature| matches!(feature, Feature::Example(_)));
         let additional_properties = pop_feature!(features => Feature::AdditionalProperties(_));
-        let nullable = pop_feature!(features => Feature::Nullable(_));
+        let nullable: Option<Nullable> =
+            pop_feature!(features => Feature::Nullable(_)).into_inner();
         let default = pop_feature!(features => Feature::Default(_));
         let default_tokens = as_tokens_or_diagnostics!(&default);
 
@@ -668,8 +693,7 @@ impl<'c> ComponentSchema {
                         .children
                         .as_ref()
                         .expect("ComponentSchema Map type should have children")
-                        .iter()
-                        .nth(1)
+                        .get(1)
                         .expect("ComponentSchema Map type should have 2 child"),
                     features: Some(features),
                     description: None,
@@ -683,16 +707,35 @@ impl<'c> ComponentSchema {
                 ))
             })?;
 
+        // let nullable: Option<Nullable> = nullable.into_inner();
+        // let schema_type = if let Some(nullable) = nullable {
+        //     let nullable_schema_type = nullable.into_schema_type_token_stream();
+        //     let schema_type = if nullable_schema_type.is_empty() {
+        //         None
+        //     } else {
+        //         Some(
+        //             quote! { utoipa::openapi::schema::SchemaType::from_iter([utoipa::openapi::schema::Type::Object, #nullable_schema_type]) },
+        //         )
+        //     };
+        //
+        //     schema_type.map(|schema_type| quote! { .schema_type(#schema_type) })
+        // } else {
+        //     None
+        // };
+        let schema_type =
+            ComponentSchema::get_schema_type_override(nullable, SchemaTypeInner::Object);
+
         tokens.extend(quote! {
             utoipa::openapi::ObjectBuilder::new()
+                #schema_type
                 #additional_properties
                 #description_stream
                 #deprecated_stream
                 #default_tokens
         });
 
-        example.to_tokens(tokens)?;
-        nullable.to_tokens(tokens)
+        example.to_tokens(tokens)
+        // nullable.to_tokens(tokens)
     }
 
     fn vec_to_tokens(
@@ -707,7 +750,8 @@ impl<'c> ComponentSchema {
         let xml = features.extract_vec_xml_feature(type_tree)?;
         let max_items = pop_feature!(features => Feature::MaxItems(_));
         let min_items = pop_feature!(features => Feature::MinItems(_));
-        let nullable = pop_feature!(features => Feature::Nullable(_));
+        let nullable: Option<Nullable> =
+            pop_feature!(features => Feature::Nullable(_)).into_inner();
         let default = pop_feature!(features => Feature::Default(_));
 
         let child = type_tree
@@ -737,12 +781,22 @@ impl<'c> ComponentSchema {
         let schema = if child
             .path
             .as_ref()
-            .map(|path| SchemaType(path).is_byte())
+            .map(|path| {
+                SchemaType {
+                    path,
+                    nullable: nullable
+                        .map(|nullable| nullable.value())
+                        .unwrap_or_default(),
+                }
+                .is_byte()
+            })
             .unwrap_or(false)
         {
+            // TODO what to do here with the octet-stream??????????? I gues this needs some
+            // changes.
             quote! {
                 utoipa::openapi::ObjectBuilder::new()
-                    .schema_type(utoipa::openapi::schema::SchemaType::String)
+                    .schema_type(utoipa::openapi::schema::Type::String)
                     .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Binary)))
             }
         } else {
@@ -761,9 +815,12 @@ impl<'c> ComponentSchema {
                 },
                 false => quote! {},
             };
+            let schema_type =
+                ComponentSchema::get_schema_type_override(nullable, SchemaTypeInner::Array);
 
             quote! {
                 utoipa::openapi::schema::ArrayBuilder::new()
+                    #schema_type
                     .items(#component_schema_tokens)
                     #unique
             }
@@ -771,7 +828,12 @@ impl<'c> ComponentSchema {
 
         let validate = |feature: &Feature| {
             let type_path = &**type_tree.path.as_ref().unwrap();
-            let schema_type = SchemaType(type_path);
+            let schema_type = SchemaType {
+                path: type_path,
+                nullable: nullable
+                    .map(|nullable| nullable.value())
+                    .unwrap_or_default(),
+            };
             feature.validate(&schema_type, type_tree);
         };
 
@@ -797,7 +859,7 @@ impl<'c> ComponentSchema {
 
         example.to_tokens(tokens)?;
         xml.to_tokens(tokens)?;
-        nullable.to_tokens(tokens)?;
+        // nullable.to_tokens(tokens)?;
 
         Ok(())
     }
@@ -810,13 +872,20 @@ impl<'c> ComponentSchema {
         description_stream: Option<&ComponentDescription<'_>>,
         deprecated_stream: Option<TokenStream>,
     ) -> Result<(), Diagnostics> {
-        let nullable = pop_feature!(features => Feature::Nullable(_));
-        let nullable_tokens = as_tokens_or_diagnostics!(&nullable);
+        let nullable_feat: Option<Nullable> =
+            pop_feature!(features => Feature::Nullable(_)).into_inner();
+        let nullable = nullable_feat
+            .map(|nullable| nullable.value())
+            .unwrap_or_default();
+        // let nullable_tokens = as_tokens_or_diagnostics!(&nullable);
 
         match type_tree.value_type {
             ValueType::Primitive => {
                 let type_path = &**type_tree.path.as_ref().unwrap();
-                let schema_type = SchemaType(type_path);
+                let schema_type = SchemaType {
+                    path: type_path,
+                    nullable,
+                };
                 if schema_type.is_unsigned_integer() {
                     // add default minimum feature only when there is no explicit minimum
                     // provided
@@ -846,14 +915,16 @@ impl<'c> ComponentSchema {
                     feature.validate(&schema_type, type_tree);
                 }
                 tokens.extend(features.to_token_stream()?);
-                nullable.to_tokens(tokens)?;
+                // nullable.to_tokens(tokens)?;
             }
             ValueType::Value => {
+                // since OpenAPI 3.1 the type is an array, thus nullable should not be necessary
+                // for value type that is going to allow all types of content.
                 if type_tree.is_value() {
                     tokens.extend(quote! {
                         utoipa::openapi::ObjectBuilder::new()
-                            .schema_type(utoipa::openapi::schema::SchemaType::Value)
-                            #description_stream #deprecated_stream #nullable_tokens
+                            .schema_type(utoipa::openapi::schema::SchemaType::AnyValue)
+                            #description_stream #deprecated_stream
                     })
                 }
             }
@@ -861,19 +932,35 @@ impl<'c> ComponentSchema {
                 let is_inline = features.is_inline();
 
                 if type_tree.is_object() {
+                    let nullable_schema_type = ComponentSchema::get_schema_type_override(
+                        nullable_feat,
+                        SchemaTypeInner::Object,
+                    );
                     tokens.extend(quote! {
                         utoipa::openapi::ObjectBuilder::new()
-                            #description_stream #deprecated_stream #nullable_tokens
+                            #nullable_schema_type
+                            #description_stream #deprecated_stream
                     })
                 } else {
+                    fn nullable_all_of_item(nullable: bool) -> Option<TokenStream> {
+                        if nullable {
+                            Some(
+                                quote! { .item(utoipa::openapi::schema::ObjectBuilder::new().schema_type(utoipa::openapi::schema::Type::Null)) },
+                            )
+                        } else {
+                            None
+                        }
+                    }
                     let type_path = &**type_tree.path.as_ref().unwrap();
+                    let nullable_item = nullable_all_of_item(nullable);
+
                     if is_inline {
                         let default = pop_feature!(features => Feature::Default(_));
                         let default_tokens = as_tokens_or_diagnostics!(&default);
-                        let schema = if default.is_some() || nullable.is_some() {
+                        let schema = if default.is_some() || nullable {
                             quote_spanned! {type_path.span()=>
                                 utoipa::openapi::schema::AllOfBuilder::new()
-                                    #nullable_tokens
+                                    #nullable_item
                                     .item(<#type_path as utoipa::ToSchema>::schema().1)
                                     #default_tokens
                             }
@@ -893,16 +980,24 @@ impl<'c> ComponentSchema {
                         let default = pop_feature!(features => Feature::Default(_));
                         let default_tokens = as_tokens_or_diagnostics!(&default);
 
-                        let schema = if default.is_some() || nullable.is_some() {
+                        // TODO: refs support `summary` field but currently there is no such field
+                        // on schemas more over there is no way to distinct the `summary` from
+                        // `description` of the ref. Should we consider supporting the summary?
+                        let schema = if default.is_some() || nullable {
                             quote! {
                                 utoipa::openapi::schema::AllOfBuilder::new()
-                                    #nullable_tokens
-                                    .item(utoipa::openapi::Ref::from_schema_name(#name))
+                                    #nullable_item
+                                    .item(utoipa::openapi::schema::RefBuilder::new()
+                                        #description_stream
+                                        .ref_location_from_schema_name(#name)
+                                    )
                                     #default_tokens
                             }
                         } else {
                             quote! {
-                                utoipa::openapi::Ref::from_schema_name(#name)
+                                utoipa::openapi::schema::RefBuilder::new()
+                                    #description_stream
+                                    .ref_location_from_schema_name(#name)
                             }
                         };
 
@@ -946,15 +1041,20 @@ impl<'c> ComponentSchema {
                                 },
                             );
 
+                        let nullable_schema_type = ComponentSchema::get_schema_type_override(
+                            nullable_feat,
+                            SchemaTypeInner::Array,
+                        );
                         Result::<TokenStream, Diagnostics>::Ok(quote! {
                             utoipa::openapi::schema::ArrayBuilder::new()
+                                #nullable_schema_type
                                 .items(#all_of)
-                            #nullable_tokens
-                            #description_stream
-                            #deprecated_stream
+                                #description_stream
+                                #deprecated_stream
                         })
                     })?
-                    .unwrap_or_else(|| quote!(utoipa::openapi::schema::empty()))
+                    .unwrap_or_else(|| quote!(utoipa::openapi::schema::empty())) // TODO should
+                    // this bee type "null"?
                     .to_tokens(tokens);
                 tokens.extend(features.to_token_stream());
             }
@@ -1007,8 +1107,7 @@ impl FlattenedMapSchema {
                 .children
                 .as_ref()
                 .expect("ComponentSchema Map type should have children")
-                .iter()
-                .nth(1)
+                .get(1)
                 .expect("ComponentSchema Map type should have 2 child"),
             features: Some(features),
             description: None,

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -541,30 +541,16 @@ impl<'c> ComponentSchema {
                 description,
                 deprecated_stream,
             )?,
-            Some(GenericType::Vec) => ComponentSchema::vec_to_tokens(
-                &mut tokens,
-                features,
-                type_tree,
-                object_name,
-                description,
-                deprecated_stream,
-            )?,
-            Some(GenericType::LinkedList) => ComponentSchema::vec_to_tokens(
-                &mut tokens,
-                features,
-                type_tree,
-                object_name,
-                description,
-                deprecated_stream,
-            )?,
-            Some(GenericType::Set) => ComponentSchema::vec_to_tokens(
-                &mut tokens,
-                features,
-                type_tree,
-                object_name,
-                description,
-                deprecated_stream,
-            )?,
+            Some(GenericType::Vec | GenericType::LinkedList | GenericType::Set) => {
+                ComponentSchema::vec_to_tokens(
+                    &mut tokens,
+                    features,
+                    type_tree,
+                    object_name,
+                    description,
+                    deprecated_stream,
+                )?
+            }
             #[cfg(feature = "smallvec")]
             Some(GenericType::SmallVec) => ComponentSchema::vec_to_tokens(
                 &mut tokens,
@@ -598,7 +584,7 @@ impl<'c> ComponentSchema {
                 })?
                 .to_tokens(&mut tokens)?;
             }
-            Some(GenericType::Cow) | Some(GenericType::Box) | Some(GenericType::RefCell) => {
+            Some(GenericType::Cow | GenericType::Box | GenericType::RefCell) => {
                 ComponentSchema::new(ComponentSchemaProps {
                     type_tree: type_tree
                         .children

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -180,7 +180,7 @@ impl ToTokensDiagnostics for Feature {
                 Feature::WriteOnly(write_only) => quote! { .write_only(Some(#write_only)) },
                 Feature::ReadOnly(read_only) => quote! { .read_only(Some(#read_only)) },
                 Feature::Title(title) => quote! { .title(Some(#title)) },
-                Feature::Nullable(nullable) => quote! { .nullable(#nullable) },
+                Feature::Nullable(_nullable) => return Err(Diagnostics::new("Nullable does not support `ToTokens`")),
                 Feature::Rename(rename) => rename.to_token_stream(),
                 Feature::Style(style) => quote! { .style(Some(#style)) },
                 Feature::ParameterIn(parameter_in) => quote! { .parameter_in(#parameter_in) },
@@ -665,6 +665,18 @@ pub struct Nullable(bool);
 impl Nullable {
     pub fn new() -> Self {
         Self(true)
+    }
+
+    pub fn value(&self) -> bool {
+        self.0
+    }
+
+    pub fn into_schema_type_token_stream(self) -> proc_macro2::TokenStream {
+        if self.0 {
+            quote! {utoipa::openapi::schema::Type::Null}
+        } else {
+            proc_macro2::TokenStream::new()
+        }
     }
 }
 

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -122,6 +122,8 @@ pub enum Feature {
     As(As),
     AdditionalProperties(AdditionalProperties),
     Required(Required),
+    ContentEncoding(ContentEncoding),
+    ContentMediaType(ContentMediaType),
 }
 
 impl Feature {
@@ -219,6 +221,8 @@ impl ToTokensDiagnostics for Feature {
                 Feature::AdditionalProperties(additional_properties) => {
                     quote! { .additional_properties(Some(#additional_properties)) }
                 }
+                Feature::ContentEncoding(content_encoding) => quote! { .content_encoding(#content_encoding) },
+                Feature::ContentMediaType(content_media_type) => quote! { .content_media_type(#content_media_type) },
                 Feature::RenameAll(_) => {
                     return Err(Diagnostics::new("RenameAll feature does not support `ToTokens`"))
                 }
@@ -298,6 +302,8 @@ impl Display for Feature {
             Feature::As(as_feature) => as_feature.fmt(f),
             Feature::AdditionalProperties(additional_properties) => additional_properties.fmt(f),
             Feature::Required(required) => required.fmt(f),
+            Feature::ContentEncoding(content_encoding) => content_encoding.fmt(f),
+            Feature::ContentMediaType(content_media_type) => content_media_type.fmt(f),
         }
     }
 }
@@ -343,6 +349,8 @@ impl Validatable for Feature {
                 additional_properties.is_validatable()
             }
             Feature::Required(required) => required.is_validatable(),
+            Feature::ContentEncoding(content_encoding) => content_encoding.is_validatable(),
+            Feature::ContentMediaType(content_media_type) => content_media_type.is_validatable(),
         }
     }
 }
@@ -395,7 +403,9 @@ is_validatable! {
     Deprecated => false,
     As => false,
     AdditionalProperties => false,
-    Required => false
+    Required => false,
+    ContentEncoding => false,
+    ContentMediaType => false
 }
 
 #[derive(Clone)]
@@ -1564,6 +1574,60 @@ impl From<Required> for Feature {
 }
 
 name!(Required = "required");
+
+#[derive(Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct ContentEncoding(String);
+
+impl Parse for ContentEncoding {
+    fn parse(input: ParseStream, _: Ident) -> syn::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        parse_utils::parse_next_literal_str(input).map(Self)
+    }
+}
+
+impl ToTokens for ContentEncoding {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.to_tokens(tokens);
+    }
+}
+
+name!(ContentEncoding = "content_encoding");
+
+impl From<ContentEncoding> for Feature {
+    fn from(value: ContentEncoding) -> Self {
+        Self::ContentEncoding(value)
+    }
+}
+
+#[derive(Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct ContentMediaType(String);
+
+impl Parse for ContentMediaType {
+    fn parse(input: ParseStream, _: Ident) -> syn::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        parse_utils::parse_next_literal_str(input).map(Self)
+    }
+}
+
+impl ToTokens for ContentMediaType {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.to_tokens(tokens);
+    }
+}
+
+impl From<ContentMediaType> for Feature {
+    fn from(value: ContentMediaType) -> Self {
+        Self::ContentMediaType(value)
+    }
+}
+
+name!(ContentMediaType = "content_media_type");
 
 pub trait Validator {
     fn is_valid(&self) -> Result<(), &'static str>;

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -725,6 +725,7 @@ impl<'e> EnumSchema<'e> {
                             features::parse_schema_features_with(attributes, |input| {
                                 Ok(parse_features!(
                                     input as super::features::Example,
+                                    super::features::Examples,
                                     super::features::Default,
                                     super::features::Title,
                                     As

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -1345,7 +1345,7 @@ impl ComplexEnum<'_> {
                                 #title
                                 .item(#unnamed_enum_tokens)
                                 .item(utoipa::openapi::schema::ObjectBuilder::new()
-                                    .schema_type(utoipa::openapi::schema::SchemaType::Object)
+                                    .schema_type(utoipa::openapi::schema::Type::Object)
                                     .property(#tag, #variant_name_tokens)
                                     .required(#tag)
                                 )
@@ -1354,7 +1354,7 @@ impl ComplexEnum<'_> {
                         Ok(quote! {
                             #unnamed_enum_tokens
                                 #title
-                                .schema_type(utoipa::openapi::schema::SchemaType::Object)
+                                .schema_type(utoipa::openapi::schema::Type::Object)
                                 .property(#tag, #variant_name_tokens)
                                 .required(#tag)
                         })
@@ -1453,7 +1453,7 @@ impl ComplexEnum<'_> {
                 Ok(quote! {
                     utoipa::openapi::schema::ObjectBuilder::new()
                         #title
-                        .schema_type(utoipa::openapi::schema::SchemaType::Object)
+                        .schema_type(utoipa::openapi::schema::Type::Object)
                         .property(#tag, #variant_name_tokens)
                         .required(#tag)
                         .property(#content, #named_enum_tokens)
@@ -1498,7 +1498,7 @@ impl ComplexEnum<'_> {
                     Ok(quote! {
                         utoipa::openapi::schema::ObjectBuilder::new()
                             #title
-                            .schema_type(utoipa::openapi::schema::SchemaType::Object)
+                            .schema_type(utoipa::openapi::schema::Type::Object)
                             .property(#tag, #variant_name_tokens)
                             .required(#tag)
                             .property(#content, #unnamed_enum_tokens)

--- a/utoipa-gen/src/component/schema/enum_variant.rs
+++ b/utoipa-gen/src/component/schema/enum_variant.rs
@@ -16,7 +16,11 @@ pub trait Variant {
     /// Get enum variant type. By default enum variant is `string`
     fn get_type(&self) -> (TokenStream, TokenStream) {
         (
-            SchemaType(&parse_quote!(str)).to_token_stream(),
+            SchemaType {
+                path: &parse_quote!(str),
+                nullable: false,
+            }
+            .to_token_stream(),
             quote! {&str},
         )
     }
@@ -50,7 +54,11 @@ where
 
     fn get_type(&self) -> (TokenStream, TokenStream) {
         (
-            SchemaType(&self.type_path.path).to_token_stream(),
+            SchemaType {
+                path: &self.type_path.path,
+                nullable: false,
+            }
+            .to_token_stream(),
             self.type_path.to_token_stream(),
         )
     }
@@ -255,7 +263,7 @@ impl ToTokensDiagnostics for UntaggedEnum {
 
         tokens.extend(quote! {
             utoipa::openapi::schema::ObjectBuilder::new()
-                .nullable(true)
+                .schema_type(utoipa::openapi::schema::Type::Null)
                 .default(Some(serde_json::Value::Null))
                 #title
         });

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -5,11 +5,11 @@ use syn::{
 
 use crate::{
     component::features::{
-        impl_into_inner, impl_merge, parse_features, AdditionalProperties, As, Default, Deprecated,
-        Description, Example, Examples, ExclusiveMaximum, ExclusiveMinimum, Feature, Format,
-        Inline, IntoInner, MaxItems, MaxLength, MaxProperties, Maximum, Merge, MinItems, MinLength,
-        MinProperties, Minimum, MultipleOf, Nullable, Pattern, ReadOnly, Rename, RenameAll,
-        Required, SchemaWith, Title, ValueType, WriteOnly, XmlAttr,
+        impl_into_inner, impl_merge, parse_features, AdditionalProperties, As, ContentEncoding,
+        ContentMediaType, Default, Deprecated, Description, Example, Examples, ExclusiveMaximum,
+        ExclusiveMinimum, Feature, Format, Inline, IntoInner, MaxItems, MaxLength, MaxProperties,
+        Maximum, Merge, MinItems, MinLength, MinProperties, Minimum, MultipleOf, Nullable, Pattern,
+        ReadOnly, Rename, RenameAll, Required, SchemaWith, Title, ValueType, WriteOnly, XmlAttr,
     },
     Diagnostics,
 };
@@ -124,7 +124,9 @@ impl Parse for NamedFieldFeatures {
             SchemaWith,
             AdditionalProperties,
             Required,
-            Deprecated
+            Deprecated,
+            ContentEncoding,
+            ContentMediaType
         )))
     }
 }

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -6,8 +6,8 @@ use syn::{
 use crate::{
     component::features::{
         impl_into_inner, impl_merge, parse_features, AdditionalProperties, As, Default, Deprecated,
-        Description, Example, ExclusiveMaximum, ExclusiveMinimum, Feature, Format, Inline,
-        IntoInner, MaxItems, MaxLength, MaxProperties, Maximum, Merge, MinItems, MinLength,
+        Description, Example, Examples, ExclusiveMaximum, ExclusiveMinimum, Feature, Format,
+        Inline, IntoInner, MaxItems, MaxLength, MaxProperties, Maximum, Merge, MinItems, MinLength,
         MinProperties, Minimum, MultipleOf, Nullable, Pattern, ReadOnly, Rename, RenameAll,
         Required, SchemaWith, Title, ValueType, WriteOnly, XmlAttr,
     },
@@ -21,6 +21,7 @@ impl Parse for NamedFieldStructFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(NamedFieldStructFeatures(parse_features!(
             input as Example,
+            Examples,
             XmlAttr,
             Title,
             RenameAll,
@@ -43,6 +44,7 @@ impl Parse for UnnamedFieldStructFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(UnnamedFieldStructFeatures(parse_features!(
             input as Example,
+            Examples,
             Default,
             Title,
             Format,
@@ -62,6 +64,7 @@ impl Parse for EnumFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(EnumFeatures(parse_features!(
             input as Example,
+            Examples,
             Default,
             Title,
             RenameAll,
@@ -80,6 +83,7 @@ impl Parse for ComplexEnumFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(ComplexEnumFeatures(parse_features!(
             input as Example,
+            Examples,
             Default,
             RenameAll,
             As,
@@ -97,6 +101,7 @@ impl Parse for NamedFieldFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(NamedFieldFeatures(parse_features!(
             input as Example,
+            Examples,
             ValueType,
             Format,
             Default,
@@ -132,6 +137,7 @@ impl Parse for EnumNamedFieldVariantFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(EnumNamedFieldVariantFeatures(parse_features!(
             input as Example,
+            Examples,
             XmlAttr,
             Title,
             Rename,
@@ -149,6 +155,7 @@ impl Parse for EnumUnnamedFieldVariantFeatures {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(EnumUnnamedFieldVariantFeatures(parse_features!(
             input as Example,
+            Examples,
             Default,
             Title,
             Format,

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -628,7 +628,7 @@ use self::{
 /// # use utoipa::openapi::schema::{Object, ObjectBuilder};
 /// fn custom_type() -> Object {
 ///     ObjectBuilder::new()
-///         .schema_type(utoipa::openapi::SchemaType::String)
+///         .schema_type(utoipa::openapi::schema::Type::String)
 ///         .format(Some(utoipa::openapi::SchemaFormat::Custom(
 ///             "email".to_string(),
 ///         )))
@@ -2035,7 +2035,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// # use utoipa::openapi::schema::{Object, ObjectBuilder};
 /// fn custom_type() -> Object {
 ///     ObjectBuilder::new()
-///         .schema_type(utoipa::openapi::SchemaType::String)
+///         .schema_type(utoipa::openapi::schema::Type::String)
 ///         .format(Some(utoipa::openapi::SchemaFormat::Custom(
 ///             "email".to_string(),
 ///         )))
@@ -2511,7 +2511,7 @@ pub fn into_responses(input: TokenStream) -> TokenStream {
 /// _**Create vec of pets schema.**_
 /// ```rust
 /// # use utoipa::openapi::schema::{Schema, Array, Object, ObjectBuilder, SchemaFormat,
-/// # KnownFormat, SchemaType};
+/// # KnownFormat, Type};
 /// # use utoipa::openapi::RefOr;
 /// #[derive(utoipa::ToSchema)]
 /// struct Pet {
@@ -2525,11 +2525,11 @@ pub fn into_responses(input: TokenStream) -> TokenStream {
 ///     Array::new(
 ///         ObjectBuilder::new()
 ///             .property("id", ObjectBuilder::new()
-///                 .schema_type(SchemaType::Integer)
+///                 .schema_type(Type::Integer)
 ///                 .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
 ///                 .build())
 ///             .required("id")
-///             .property("name", Object::with_type(SchemaType::String))
+///             .property("name", Object::with_type(Type::String))
 ///             .required("name")
 ///     )
 /// ));

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -2777,15 +2777,9 @@ impl AnyValue {
 
     fn parse_any(input: ParseStream) -> syn::Result<Self> {
         if input.peek(Lit) {
-            if input.peek(LitStr) {
-                let lit_str = input.parse::<LitStr>().unwrap().to_token_stream();
+            let lit = input.parse::<Lit>().unwrap().to_token_stream();
 
-                Ok(AnyValue::Json(lit_str))
-            } else {
-                let lit = input.parse::<Lit>().unwrap().to_token_stream();
-
-                Ok(AnyValue::Json(lit))
-            }
+            Ok(AnyValue::Json(lit))
         } else {
             let fork = input.fork();
             let is_json = if fork.peek(syn::Ident) && fork.peek2(Token![!]) {

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -684,8 +684,8 @@ impl PathTypeTree for TypeTree<'_> {
                 .map(|children| {
                     children
                         .iter()
-                        .flat_map(|child| &child.path)
-                        .any(|path| SchemaType(path).is_byte())
+                        .flat_map(|child| child.path.as_ref().zip(Some(child.is_option())))
+                        .any(|(path, nullable)| SchemaType { path, nullable }.is_byte())
                 })
                 .unwrap_or(false)
         {
@@ -693,7 +693,10 @@ impl PathTypeTree for TypeTree<'_> {
         } else if self
             .path
             .as_ref()
-            .map(|path| SchemaType(path.deref()))
+            .map(|path| SchemaType {
+                path: path.deref(),
+                nullable: self.is_option(),
+            })
             .map(|schema_type| schema_type.is_primitive())
             .unwrap_or(false)
         {

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -5,12 +5,49 @@ use syn::{parse::Parse, Error, Ident, LitStr, Path};
 
 use crate::{Diagnostics, ToTokensDiagnostics};
 
+/// Represents data type of [`Schema`].
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub enum SchemaTypeInner {
+    /// Generic schema type allows "properties" with custom types
+    Object,
+    /// Indicates string type of content.
+    String,
+    /// Indicates integer type of content.    
+    Integer,
+    /// Indicates floating point number type of content.
+    Number,
+    /// Indicates boolean type of content.
+    Boolean,
+    /// Indicates array type of content.
+    Array,
+    /// Null type. Used together with other type to indicate nullable values.
+    Null,
+}
+
+impl ToTokens for SchemaTypeInner {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let ty = match self {
+            Self::Object => quote! { utoipa::openapi::schema::Type::Object },
+            Self::String => quote! { utoipa::openapi::schema::Type::String },
+            Self::Integer => quote! { utoipa::openapi::schema::Type::Integer },
+            Self::Number => quote! { utoipa::openapi::schema::Type::Number },
+            Self::Boolean => quote! { utoipa::openapi::schema::Type::Boolean },
+            Self::Array => quote! { utoipa::openapi::schema::Type::Array },
+            Self::Null => quote! { utoipa::openapi::schema::Type::Null },
+        };
+        tokens.extend(ty)
+    }
+}
+
 /// Tokenizes OpenAPI data type correctly according to the Rust type
-pub struct SchemaType<'a>(pub &'a syn::Path);
+pub struct SchemaType<'a> {
+    pub path: &'a syn::Path,
+    pub nullable: bool,
+}
 
 impl SchemaType<'_> {
     fn last_segment_to_string(&self) -> String {
-        self.0
+        self.path
             .segments
             .last()
             .expect("Expected at least one segment is_integer")
@@ -24,7 +61,7 @@ impl SchemaType<'_> {
 
     /// Check whether type is known to be primitive in which case returns true.
     pub fn is_primitive(&self) -> bool {
-        let SchemaType(path) = self;
+        let SchemaType { path, .. } = self;
         let last_segment = match path.segments.last() {
             Some(segment) => segment,
             None => return false,
@@ -183,56 +220,75 @@ fn is_primitive_rust_decimal(name: &str) -> bool {
 
 impl ToTokensDiagnostics for SchemaType<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) -> Result<(), Diagnostics> {
-        let last_segment = self.0.segments.last().ok_or_else(|| {
+        let last_segment = self.path.segments.last().ok_or_else(|| {
             Diagnostics::with_span(
-                self.0.span(),
+                self.path.span(),
                 "schema type should have at least one segment in the path",
             )
         })?;
         let name = &*last_segment.ident.to_string();
 
+        fn schema_type_tokens(
+            tokens: &mut TokenStream,
+            schema_type: SchemaTypeInner,
+            nullable: bool,
+        ) {
+            if nullable {
+                tokens.extend(quote! { utoipa::openapi::schema::SchemaType::from_iter([
+                    #schema_type,
+                    utoipa::openapi::schema::Type::Null
+                ])})
+            } else {
+                tokens.extend(quote! { utoipa::openapi::schema::SchemaType::new(#schema_type)});
+            }
+        }
+
         match name {
             "String" | "str" | "char" => {
-                tokens.extend(quote! {utoipa::openapi::SchemaType::String})
+                schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable)
             }
 
-            "bool" => tokens.extend(quote! { utoipa::openapi::SchemaType::Boolean }),
+            "bool" => schema_type_tokens(tokens, SchemaTypeInner::Boolean, self.nullable),
 
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize" => tokens.extend(quote! { utoipa::openapi::SchemaType::Integer }),
-            "f32" | "f64" => tokens.extend(quote! { utoipa::openapi::SchemaType::Number }),
+            | "u128" | "usize" => {
+                schema_type_tokens(tokens, SchemaTypeInner::Integer, self.nullable)
+            }
+            "f32" | "f64" => schema_type_tokens(tokens, SchemaTypeInner::Number, self.nullable),
 
             #[cfg(feature = "chrono")]
             "DateTime" | "NaiveDateTime" | "NaiveDate" | "NaiveTime" => {
-                tokens.extend(quote! { utoipa::openapi::SchemaType::String })
+                schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable)
             }
 
             #[cfg(any(feature = "chrono", feature = "time"))]
-            "Date" | "Duration" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
+            "Date" | "Duration" => {
+                schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable)
+            }
 
             #[cfg(feature = "decimal")]
-            "Decimal" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
+            "Decimal" => schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable),
 
             #[cfg(feature = "decimal_float")]
-            "Decimal" => tokens.extend(quote! { utoipa::openapi::SchemaType::Number }),
+            "Decimal" => schema_type_tokens(tokens, SchemaTypeInner::Number, self.nullable),
 
             #[cfg(feature = "rocket_extras")]
-            "PathBuf" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
+            "PathBuf" => schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable),
 
             #[cfg(feature = "uuid")]
-            "Uuid" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
+            "Uuid" => schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable),
 
             #[cfg(feature = "ulid")]
-            "Ulid" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
+            "Ulid" => schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable),
 
             #[cfg(feature = "url")]
-            "Url" => tokens.extend(quote! { utoipa::openapi::SchemaType::String }),
+            "Url" => schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable),
 
             #[cfg(feature = "time")]
             "PrimitiveDateTime" | "OffsetDateTime" => {
-                tokens.extend(quote! { utoipa::openapi::SchemaType::String })
+                schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable)
             }
-            _ => tokens.extend(quote! { utoipa::openapi::SchemaType::Object }),
+            _ => schema_type_tokens(tokens, SchemaTypeInner::Object, self.nullable),
         };
 
         Ok(())

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -7,6 +7,7 @@ use crate::{Diagnostics, ToTokensDiagnostics};
 
 /// Represents data type of [`Schema`].
 #[cfg_attr(feature = "debug", derive(Debug))]
+#[allow(dead_code)]
 pub enum SchemaTypeInner {
     /// Generic schema type allows "properties" with custom types
     Object,

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -478,10 +478,12 @@ fn derive_path_with_parameter_schema() {
                 "schema": {
                     "allOf": [
                         {
+                            "type": "null"
+                        },
+                        {
                             "$ref": "#/components/schemas/Since"
                         }
                     ],
-                    "nullable": true,
                 }
             }
         ])
@@ -548,6 +550,9 @@ fn derive_path_with_parameter_inline_schema() {
                 "schema": {
                     "allOf": [
                         {
+                            "type": "null"
+                        },
+                        {
                             "properties": {
                                 "date": {
                                     "description": "Some date",
@@ -565,7 +570,6 @@ fn derive_path_with_parameter_inline_schema() {
                             "type": "object"
                         }
                     ],
-                    "nullable": true,
                 }
             }
         ])
@@ -733,10 +737,9 @@ fn derive_path_query_params_with_schema_features() {
             "required": false,
             "schema": {
                 "default": "value",
-                "type": "string",
+                "type": ["string", "null"],
                 "readOnly": true,
                 "writeOnly": true,
-                "nullable": true,
                 "xml": {
                     "name": "xml_value"
                 }
@@ -818,8 +821,7 @@ fn derive_required_path_params() {
                 "name": "vec_default",
                 "required": false,
                 "schema": {
-                    "type": "array",
-                    "nullable": true,
+                    "type": ["array", "null"],
                     "items": {
                         "type": "string"
                     }
@@ -830,8 +832,7 @@ fn derive_required_path_params() {
                 "name": "string_default",
                 "required": false,
                 "schema": {
-                    "nullable": true,
-                    "type": "string"
+                    "type": ["string", "null"]
                 }
             },
             {
@@ -858,11 +859,10 @@ fn derive_required_path_params() {
                 "name": "vec_option",
                 "required": false,
                 "schema": {
-                    "nullable": true,
                     "items": {
                         "type": "string"
                     },
-                    "type": "array",
+                    "type": ["array", "null"],
                 },
             },
             {
@@ -870,8 +870,7 @@ fn derive_required_path_params() {
                 "name": "string_option",
                 "required": false,
                 "schema": {
-                    "nullable": true,
-                    "type": "string"
+                    "type": ["string", "null"]
                 }
             },
             {
@@ -929,8 +928,7 @@ fn derive_path_params_with_serde_and_custom_rename() {
                 "name": "vecDefault",
                 "required": false,
                 "schema": {
-                    "type": "array",
-                    "nullable": true,
+                    "type": ["array", "null"],
                     "items": {
                         "type": "string"
                     }
@@ -941,8 +939,7 @@ fn derive_path_params_with_serde_and_custom_rename() {
                 "name": "STRING",
                 "required": false,
                 "schema": {
-                    "nullable": true,
-                    "type": "string"
+                    "type": ["string", "null"]
                 }
             },
             {
@@ -994,8 +991,7 @@ fn derive_path_params_custom_rename_all() {
                 "name": "vecDefault",
                 "required": false,
                 "schema": {
-                    "type": "array",
-                    "nullable": true,
+                    "type": ["array", "null"],
                     "items": {
                         "type": "string"
                     }
@@ -1024,8 +1020,7 @@ fn derive_path_params_custom_rename_all_serde_will_override() {
                 "name": "VEC_DEFAULT",
                 "required": false,
                 "schema": {
-                    "type": "array",
-                    "nullable": true,
+                    "type": ["array", "null"],
                     "items": {
                         "type": "string"
                     }
@@ -1158,8 +1153,7 @@ fn derive_path_params_intoparams() {
                 "name": "since",
                 "required": false,
                 "schema": {
-                    "nullable": true,
-                    "type": "string"
+                    "type": ["string", "null"]
                 },
                 "style": "form"
             },
@@ -1194,13 +1188,15 @@ fn derive_path_params_intoparams() {
                 "schema": {
                     "allOf": [
                         {
+                            "type": "null",
+                        },
+                        {
                             "default": "foo1",
                             "example": "foo1",
                             "enum": ["foo1", "foo2"],
                             "type": "string",
                         }
                     ],
-                    "nullable": true,
                 },
                 "style": "form"
             },
@@ -1337,8 +1333,7 @@ fn derive_path_params_into_params_with_value_type() {
             "name": "value3",
             "required": false,
             "schema": {
-                "nullable": true,
-                "type": "string"
+                "type": ["string", "null"]
             }
         },
         {
@@ -1346,8 +1341,7 @@ fn derive_path_params_into_params_with_value_type() {
             "name": "value4",
             "required": false,
             "schema": {
-                "nullable": true,
-                "type": "object"
+                "type": ["object", "null"]
             }
         },
         {
@@ -1454,7 +1448,6 @@ fn derive_path_params_into_params_with_unit_type() {
             "required": true,
             "schema": {
                 "default": null,
-                "nullable": true
             }
         }])
     )
@@ -1679,7 +1672,7 @@ fn derive_path_with_ulid() {
 fn derive_path_with_into_params_custom_schema() {
     fn custom_type() -> Object {
         ObjectBuilder::new()
-            .schema_type(utoipa::openapi::SchemaType::String)
+            .schema_type(utoipa::openapi::Type::String)
             .format(Some(utoipa::openapi::SchemaFormat::Custom(
                 "email".to_string(),
             )))
@@ -1773,8 +1766,7 @@ fn derive_into_params_required() {
               "name": "name2",
               "required": false,
               "schema": {
-                  "type": "string",
-                  "nullable": true,
+                  "type": ["string", "null"],
               },
           },
           {
@@ -1782,8 +1774,7 @@ fn derive_into_params_required() {
               "name": "name3",
               "required": true,
               "schema": {
-                  "type": "string",
-                  "nullable": true,
+                  "type": ["string", "null"],
               },
           },
         ])
@@ -1829,13 +1820,14 @@ fn derive_into_params_with_serde_skip() {
               "name": "name2",
               "required": false,
               "schema": {
-                  "type": "string",
-                  "nullable": true,
+                  "type": ["string", "null"],
               },
           },
         ])
     )
 }
+
+// TODO: IntoParams seems not to follow Option<T> is automatically nullable rule!
 
 #[test]
 fn derive_into_params_with_serde_skip_deserializing() {
@@ -1876,8 +1868,7 @@ fn derive_into_params_with_serde_skip_deserializing() {
               "name": "name2",
               "required": false,
               "schema": {
-                  "type": "string",
-                  "nullable": true,
+                  "type": ["string", "null"],
               },
           },
         ])
@@ -1923,8 +1914,7 @@ fn derive_into_params_with_serde_skip_serializing() {
               "name": "name2",
               "required": false,
               "schema": {
-                  "type": "string",
-                  "nullable": true,
+                  "type": ["string", "null"],
               },
           },
         ])

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -358,7 +358,7 @@ fn path_with_struct_variables_with_into_params() {
                 ParameterBuilder::new()
                     .name("name")
                     .schema(Some(
-                        ObjectBuilder::new().schema_type(utoipa::openapi::SchemaType::String),
+                        ObjectBuilder::new().schema_type(utoipa::openapi::schema::Type::String),
                     ))
                     .parameter_in(ParameterIn::Path)
                     .build(),
@@ -366,7 +366,7 @@ fn path_with_struct_variables_with_into_params() {
                     .name("id")
                     .schema(Some(
                         ObjectBuilder::new()
-                            .schema_type(utoipa::openapi::SchemaType::Integer)
+                            .schema_type(utoipa::openapi::schema::Type::Integer)
                             .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64))),
                     ))
                     .parameter_in(ParameterIn::Path)
@@ -388,7 +388,7 @@ fn path_with_struct_variables_with_into_params() {
             vec![ParameterBuilder::new()
                 .name("age")
                 .schema(Some(Array::new(
-                    ObjectBuilder::new().schema_type(utoipa::openapi::SchemaType::String),
+                    ObjectBuilder::new().schema_type(utoipa::openapi::schema::Type::String),
                 )))
                 .parameter_in(ParameterIn::Query)
                 .build()]
@@ -510,7 +510,7 @@ fn derive_path_with_struct_variables_with_into_params() {
         "[2].description" = r#""Age filter for user""#, "Parameter description"
         "[2].required" = r#"false"#, "Parameter required"
         "[2].deprecated" = r#"true"#, "Parameter deprecated"
-        "[2].schema.type" = r#""array""#, "Parameter schema type"
+        "[2].schema.type" = r#"["array","null"]"#, "Parameter schema type"
         "[2].schema.items.type" = r#""string""#, "Parameter items schema type"
     }
 }
@@ -712,7 +712,7 @@ fn derive_into_params_with_custom_attributes() {
         "[2].example" = r#"["10"]"#, "Parameter example"
         "[2].allowReserved" = r#"true"#, "Parameter allowReserved"
         "[2].explode" = r#"true"#, "Parameter explode"
-        "[2].schema.type" = r#""array""#, "Parameter schema type"
+        "[2].schema.type" = r#"["array","null"]"#, "Parameter schema type"
         "[2].schema.items.type" = r#""string""#, "Parameter items schema type"
 
         "[3].in" = r#""query""#, "Parameter in"

--- a/utoipa-gen/tests/path_derive_axum_test.rs
+++ b/utoipa-gen/tests/path_derive_axum_test.rs
@@ -86,8 +86,7 @@ fn derive_path_params_into_params_axum() {
                     "items": {
                         "type": "string",
                     },
-                    "nullable": true,
-                    "type": "array",
+                    "type": ["array", "null"],
                 }
             },
         ])
@@ -709,8 +708,7 @@ fn derive_path_with_validation_attributes_axum() {
             },
             {
                 "schema": {
-                    "type": "string",
-                    "nullable": true,
+                    "type": ["string", "null"],
                     "minLength": 3,
                 },
                 "required": true,
@@ -731,8 +729,7 @@ fn derive_path_with_validation_attributes_axum() {
             },
             {
                 "schema": {
-                    "type": "string",
-                    "nullable": true,
+                    "type": ["string", "null"],
                     "minLength": 3,
                 },
                 "required": false,

--- a/utoipa-gen/tests/path_derive_rocket.rs
+++ b/utoipa-gen/tests/path_derive_rocket.rs
@@ -137,8 +137,7 @@ fn resolve_get_with_optional_query_args() {
                     "items": {
                         "type": "string",
                     },
-                    "type": "array",
-                    "nullable": true,
+                    "type": ["array", "null"],
                 }
             }
         ])

--- a/utoipa-gen/tests/path_parameter_derive_test.rs
+++ b/utoipa-gen/tests/path_parameter_derive_test.rs
@@ -194,7 +194,7 @@ fn derive_parameters_with_all_types() {
         "[2].description" = r#""Foo numbers list""#, "Parameter description"
         "[2].required" = r#"false"#, "Parameter required"
         "[2].deprecated" = r#"null"#, "Parameter deprecated"
-        "[2].schema.type" = r#""array""#, "Parameter schema type"
+        "[2].schema.type" = r#"["array","null"]"#, "Parameter schema type"
         "[2].schema.format" = r#"null"#, "Parameter schema format"
         "[2].schema.items.type" = r#""integer""#, "Parameter schema items type"
         "[2].schema.items.format" = r#""int64""#, "Parameter schema items format"
@@ -286,7 +286,7 @@ fn derive_params_with_params_ext() {
         "[0].description" = r#""Foo value description""#, "Parameter description"
         "[0].required" = r#"false"#, "Parameter required"
         "[0].deprecated" = r#"true"#, "Parameter deprecated"
-        "[0].schema.type" = r#""array""#, "Parameter schema type"
+        "[0].schema.type" = r#"["array","null"]"#, "Parameter schema type"
         "[0].schema.items.type" = r#""string""#, "Parameter schema items type"
         "[0].style" = r#""form""#, "Parameter style"
         "[0].allowReserved" = r#"true"#, "Parameter allowReserved"
@@ -330,14 +330,13 @@ fn derive_path_params_with_parameter_type_args() {
                   "deprecated": true,
                   "description": "Foo value description",
                   "schema": {
-                      "type": "array",
+                      "type": ["array", "null"],
                       "items": {
                           "maxLength": 20,
                           "pattern": r"\w",
                           "type": "string"
                       },
                       "maxItems": 1,
-                      "nullable": true,
                   },
                   "style": "form",
                   "allowReserved": true,

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -245,8 +245,8 @@ response_no_body_with_complex_header_with_description => headers: (
     "responses.200.headers.random-digits.schema.items.type" = r###""integer""###, "random-digits header items type"
     "responses.200.headers.random-digits.schema.items.format" = r###""int64""###, "random-digits header items format"
 binary_octet_stream => body: [u8], assert:
-    "responses.200.content.application~1octet-stream.schema.type" = r#""string""#, "Response content type"
-    "responses.200.content.application~1octet-stream.schema.format" = r#""binary""#, "Response content format"
+    "responses.200.content.application~1octet-stream.schema.type" = r#""array""#, "Response content type"
+    "responses.200.content.application~1octet-stream.schema.format" = r#"null"#, "Response content format"
     "responses.200.headers" = r###"null"###, "Response headers"
 }
 

--- a/utoipa-gen/tests/request_body_derive_test.rs
+++ b/utoipa-gen/tests/request_body_derive_test.rs
@@ -630,13 +630,18 @@ fn request_body_with_binary() {
     let content = doc
         .pointer("/paths/~1item/get/requestBody/content")
         .unwrap();
+
     assert_json_eq!(
         content,
         json!(
             {"application/octet-stream": {
                 "schema": {
-                    "type": "string",
-                    "format": "binary"
+                    "type": "array",
+                    "items": {
+                        "format": "int32",
+                        "minimum": 0,
+                        "type": "integer"
+                    }
                 }
             }
         })

--- a/utoipa-gen/tests/request_body_derive_test.rs
+++ b/utoipa-gen/tests/request_body_derive_test.rs
@@ -95,8 +95,7 @@ fn derive_request_body_option_array_success() {
                         "items": {
                             "$ref": "#/components/schemas/Foo"
                         },
-                        "nullable": true,
-                        "type": "array",
+                        "type": ["array", "null"],
                     },
                 }
             },
@@ -408,11 +407,13 @@ fn derive_request_body_complex_required_explicit_false_success() {
                 "text/xml": {
                     "schema": {
                         "allOf": [
-                        {
-                            "$ref": "#/components/schemas/Foo"
-                        }
+                            {
+                                "type": "null"
+                            },
+                            {
+                                "$ref": "#/components/schemas/Foo"
+                            }
                         ],
-                        "nullable": true,
                     }
                 }
             },
@@ -516,7 +517,6 @@ fn unit_type_request_body() {
                 "application/json": {
                     "schema": {
                         "default": null,
-                        "nullable": true,
                     }
                 }
             },

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5445,3 +5445,55 @@ fn derive_complex_enum_description_override() {
         })
     )
 }
+
+#[test]
+fn content_encofing_named_field() {
+    let item = api_doc! {
+        struct PersonRequest {
+            #[schema(content_encoding = "bas64", value_type = String)]
+            picture: Vec<u8>
+        }
+    };
+
+    assert_json_eq!(
+        item,
+        json!({
+            "properties": {
+                "picture": {
+                    "type": "string",
+                    "contentEncoding": "bas64"
+                }
+            },
+            "required": [
+                "picture"
+            ],
+            "type": "object"
+        })
+    )
+}
+
+#[test]
+fn content_media_type_named_field() {
+    let item = api_doc! {
+        struct PersonRequest {
+            #[schema(content_media_type = "application/octet-stream", value_type = String)]
+            doc: Vec<u8>
+        }
+    };
+
+    assert_json_eq!(
+        item,
+        json!({
+            "properties": {
+                "doc": {
+                    "type": "string",
+                    "contentMediaType": "application/octet-stream"
+                }
+            },
+            "required": [
+                "doc"
+            ],
+            "type": "object"
+        })
+    )
+}

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -360,13 +360,15 @@ fn derive_struct_with_default_attr_field() {
                 "authored": {
                     "allOf": [
                         {
+                            "type": "null"
+                        },
+                        {
                             "$ref": "#/components/schemas/Book",
                         },
                     ],
                     "default": {
                         "name": "My Book",
-                    },
-                    "nullable": true,
+                    }
                 },
             },
             "required": [
@@ -436,26 +438,25 @@ fn derive_struct_with_optional_properties() {
                     "default": 1,
                 },
                 "enabled": {
-                    "type": "boolean",
-                    "nullable": true,
+                    "type": ["boolean", "null"],
                 },
                 "books": {
                     "items": {
                         "$ref": "#/components/schemas/Book",
                     },
-                    "nullable": true,
-                    "type": "array"
+                    "type": ["array", "null"]
                 },
                 "metadata": {
-                    "type": "object",
-                    "nullable": true,
+                    "type": ["object", "null"],
                     "additionalProperties": {
                         "type": "string"
                     }
                 },
                 "optional_book": {
-                    "nullable": true,
                     "allOf": [
+                        {
+                            "type": "null"
+                        },
                         {
                             "$ref": "#/components/schemas/Book"
                         }
@@ -608,7 +609,7 @@ fn derive_struct_unnamed_field_with_generic_types_success() {
     };
 
     assert_value! {point=>
-        "type" = r#""string""#, "Wrapper type"
+        "type" = r#"["string","null"]"#, "Wrapper type"
     }
 }
 
@@ -620,7 +621,7 @@ fn derive_struct_unnamed_field_with_nested_generic_type_success() {
     };
 
     assert_value! {point=>
-        "type" = r#""array""#, "Wrapper type"
+        "type" = r#"["array","null"]"#, "Wrapper type"
         "items.type" = r#""integer""#, "Wrapper items type"
         "items.format" = r#""int32""#, "Wrapper items format"
         "description" = r#""Some description""#, "Wrapper description"
@@ -961,8 +962,10 @@ fn derive_struct_with_inline() {
                     "type": "object"
                 },
                 "foo2": {
-                    "nullable": true,
                     "allOf": [
+                    {
+                        "type": "null"
+                    },
                      {
                          "properties": {
                              "name": {
@@ -977,8 +980,10 @@ fn derive_struct_with_inline() {
                     ]
                 },
                 "foo3": {
-                    "nullable": true,
                     "allOf": [
+                    {
+                        "type": "null"
+                    },
                     {
                         "properties": {
                             "name": {
@@ -1117,8 +1122,7 @@ fn derive_simple_enum_serde_untagged() {
     assert_json_eq!(
         value,
         json!({
-            "type": "object",
-            "nullable": true,
+            "type": "null",
             "default": null,
         })
     );
@@ -1133,14 +1137,15 @@ fn derive_struct_unnamed_field_reference_with_comment() {
 
     let value = api_doc! {
         #[derive(Serialize)]
-        /// Description should not apply to $ref that is created for inner type Bar
+        /// Since OpenAPI 3.1 the description can be applied to Ref types
         struct Foo(Bar);
     };
 
     assert_json_eq!(
         value,
         json!({
-          "$ref": "#/components/schemas/Bar"
+            "$ref": "#/components/schemas/Bar",
+            "description": "Since OpenAPI 3.1 the description can be applied to Ref types"
         })
     );
 }
@@ -1154,8 +1159,7 @@ fn derive_complex_unnamed_field_reference_with_comment() {
     let value: Value = api_doc! {
         #[derive(Serialize)]
         enum EnumWithReference {
-            /// This is comment which will not be added to the document
-            /// since $ref cannot have comments
+            /// Since OpenAPI 3.1 the comments can be added to the Ref types as well
             UnnamedFieldWithCommentReference(CommentedReference),
         }
     };
@@ -1169,6 +1173,7 @@ fn derive_complex_unnamed_field_reference_with_comment() {
                     "properties": {
                         "UnnamedFieldWithCommentReference": {
                             "$ref": "#/components/schemas/CommentedReference",
+                            "description": "Since OpenAPI 3.1 the comments can be added to the Ref types as well"
                         },
                     },
                     "required": ["UnnamedFieldWithCommentReference"],
@@ -1443,8 +1448,7 @@ fn derive_complex_enum() {
                                     "type": "string",
                                 },
                                 "names": {
-                                    "type": "array",
-                                    "nullable": true,
+                                    "type": ["array", "null"],
                                     "items": {
                                         "type": "string",
                                     },
@@ -1637,8 +1641,7 @@ fn derive_complex_enum_serde_rename_all() {
                                     "type": "string",
                                 },
                                 "names": {
-                                    "type": "array",
-                                    "nullable": true,
+                                    "type": ["array", "null"],
                                     "items": {
                                         "type": "string",
                                     },
@@ -1707,8 +1710,7 @@ fn derive_complex_enum_serde_rename_variant() {
                                     "type": "string",
                                 },
                                 "renamed_names": {
-                                    "type": "array",
-                                    "nullable": true,
+                                    "type": [ "array", "null" ],
                                     "items": {
                                         "type": "string",
                                     },
@@ -2053,8 +2055,7 @@ fn derive_complex_enum_serde_tag() {
                             "type": "string",
                         },
                         "names": {
-                            "type": "array",
-                            "nullable": true,
+                            "type": ["array", "null"],
                             "items": {
                                 "type": "string",
                             },
@@ -2745,12 +2746,10 @@ fn derive_struct_with_nullable_and_required() {
         json!({
             "properties": {
                 "fax": {
-                    "type": "string",
-                    "nullable": true,
+                    "type": ["string", "null"],
                 },
                 "phone": {
-                    "type": "string",
-                    "nullable": true,
+                    "type": ["string", "null"],
                 },
                 "email": {
                     "type": "string",
@@ -2759,22 +2758,19 @@ fn derive_struct_with_nullable_and_required() {
                     "type": "string",
                 },
                 "edit_history": {
-                    "type": "array",
+                    "type": ["array", "null"],
                     "items": {
                         "type": "string"
                     },
-                    "nullable": true,
                 },
                 "friends": {
                     "type": "array",
                     "items": {
-                        "type": "string",
-                        "nullable": true,
+                        "type": ["string", "null"],
                     },
                 },
                 "updated": {
-                    "type": "string",
-                    "nullable": true,
+                    "type": ["string", "null"],
                 }
             },
             "required": [
@@ -2945,14 +2941,13 @@ fn derive_struct_xml_with_optional_vec() {
                     }
                 },
                 "links": {
-                    "type": "array",
+                    "type": ["array", "null"],
                     "items": {
                         "type": "string",
                         "xml": {
                             "name": "link"
                         }
                     },
-                    "nullable": true,
                     "xml": {
                         "name": "linkList",
                         "wrapped": true,
@@ -3431,7 +3426,7 @@ fn derive_parse_serde_complex_enum() {
         "oneOf.[0].type" = r#""string""#, "Unit value type"
 
         "oneOf.[1].properties.namedFields.properties.id.type" = r#""string""#, "Named fields id type"
-        "oneOf.[1].properties.namedFields.properties.nameList.type" = r#""array""#, "Named fields nameList type"
+        "oneOf.[1].properties.namedFields.properties.nameList.type" = r#"["array","null"]"#, "Named fields nameList type"
         "oneOf.[1].properties.namedFields.properties.nameList.items.type" = r#""string""#, "Named fields nameList items type"
         "oneOf.[1].properties.namedFields.required" = r#"["id"]"#, "Named fields required"
 
@@ -3648,12 +3643,10 @@ fn derive_component_with_to_schema_value_type() {
                     "type": "array"
                 },
                 "value3": {
-                    "type": "string",
-                    "nullable": true,
+                    "type": ["string", "null"],
                 },
                 "value4": {
-                    "type": "object",
-                    "nullable": true,
+                    "type": ["object", "null"],
                 },
                 "value5": {
                     "items": {
@@ -4401,7 +4394,7 @@ fn derive_schema_multiple_serde_definitions() {
 fn derive_schema_with_custom_field_with_schema() {
     fn custom_type() -> Object {
         ObjectBuilder::new()
-            .schema_type(utoipa::openapi::SchemaType::String)
+            .schema_type(utoipa::openapi::Type::String)
             .format(Some(utoipa::openapi::SchemaFormat::Custom(
                 "email".to_string(),
             )))
@@ -4447,7 +4440,6 @@ fn derive_unit_type() {
             "properties": {
                 "unit_type": {
                     "default": null,
-                    "nullable": true
                 }
             }
         })
@@ -4463,7 +4455,6 @@ fn derive_unit_struct_schema() {
     assert_json_eq!(
         value,
         json!({
-            "nullable": true,
             "default": null,
         })
     )
@@ -4525,12 +4516,10 @@ fn derive_schema_with_generics_and_lifetimes() {
                             }
                     },
                     "next": {
-                        "type": "string",
-                        "nullable": true,
+                        "type": ["string", "null"],
                     },
                     "prev": {
-                        "type": "string",
-                        "nullable": true,
+                        "type": ["string", "null"],
                     },
                     "total": {
                         "type": "integer",
@@ -4555,12 +4544,10 @@ fn derive_schema_with_generics_and_lifetimes() {
                             }
                         },
                         "next": {
-                            "type": "string",
-                            "nullable": true,
+                            "type": ["string", "null"],
                         },
                         "prev": {
-                            "type": "string",
-                            "nullable": true,
+                            "type": ["string", "null"],
                         },
                         "total": {
                             "type": "integer",
@@ -4622,7 +4609,6 @@ fn derive_struct_with_unit_alias() {
         unit,
         json!({
             "default": null,
-            "nullable": true,
         })
     );
 }
@@ -4885,8 +4871,7 @@ fn derive_nullable_tuple() {
                             },
                         ]
                     },
-                    "type": "array",
-                    "nullable": true,
+                    "type": ["array", "null"],
                     "deprecated": true,
                     "description": "This is description",
                 }
@@ -4918,8 +4903,7 @@ fn derive_unit_type_untagged_enum() {
                     "$ref": "#/components/schemas/AggregationRequest"
                 },
                 {
-                    "type": "object",
-                    "nullable": true,
+                    "type": "null",
                     "default": null,
                 }
             ]
@@ -4943,7 +4927,6 @@ fn derive_schema_with_unit_hashmap() {
                     "additionalProperties": {
                         "additionalProperties": {
                             "default": null,
-                            "nullable": true,
                         },
                         "type": "object"
                     },
@@ -5211,8 +5194,7 @@ fn derive_schema_with_docstring_on_tuple_variant_first_element_option() {
                       ],
                       "properties": {
                         "TupleVariantWithOptionFirst": {
-                          "type": "string",
-                          "nullable": true,
+                          "type": ["string", "null"],
                           "description": "doc for tuple variant with Option as first element - I now produce a description"
                         }
                       }

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5447,7 +5447,7 @@ fn derive_complex_enum_description_override() {
 }
 
 #[test]
-fn content_encofing_named_field() {
+fn content_encoding_named_field() {
     let item = api_doc! {
         struct PersonRequest {
             #[schema(content_encoding = "bas64", value_type = String)]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -358,7 +358,7 @@ pub trait OpenApi {
 ///                 .property(
 ///                     "id",
 ///                     utoipa::openapi::ObjectBuilder::new()
-///                         .schema_type(utoipa::openapi::SchemaType::Integer)
+///                         .schema_type(utoipa::openapi::schema::Type::Integer)
 ///                         .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
 ///                             utoipa::openapi::KnownFormat::Int64,
 ///                         ))),
@@ -367,13 +367,13 @@ pub trait OpenApi {
 ///                 .property(
 ///                     "name",
 ///                     utoipa::openapi::ObjectBuilder::new()
-///                         .schema_type(utoipa::openapi::SchemaType::String),
+///                         .schema_type(utoipa::openapi::schema::Type::String),
 ///                 )
 ///                 .required("name")
 ///                 .property(
 ///                     "age",
 ///                     utoipa::openapi::ObjectBuilder::new()
-///                         .schema_type(utoipa::openapi::SchemaType::Integer)
+///                         .schema_type(utoipa::openapi::schema::Type::Integer)
 ///                         .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(
 ///                             utoipa::openapi::KnownFormat::Int32,
 ///                         ))),
@@ -475,16 +475,16 @@ mod utoipa {
 /// _**Create number schema from u64.**_
 /// ```rust
 /// # use utoipa::PartialSchema;
-/// # use utoipa::openapi::schema::{SchemaType, KnownFormat, SchemaFormat, ObjectBuilder, Schema};
+/// # use utoipa::openapi::schema::{Type, KnownFormat, SchemaFormat, ObjectBuilder, Schema};
 /// # use utoipa::openapi::RefOr;
 /// #
 /// let number: RefOr<Schema> = i64::schema().into();
 ///
-/// // would be equal to manual implementation
+// // would be equal to manual implementation
 /// let number2 = RefOr::T(
 ///     Schema::Object(
 ///         ObjectBuilder::new()
-///             .schema_type(SchemaType::Integer)
+///             .schema_type(Type::Integer)
 ///             .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int64)))
 ///             .build()
 ///         )
@@ -704,7 +704,7 @@ impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for Option<HashMap
 ///                         .description(Some("Pet database id to get Pet for"))
 ///                         .schema(
 ///                             Some(utoipa::openapi::ObjectBuilder::new()
-///                                 .schema_type(utoipa::openapi::SchemaType::Integer)
+///                                 .schema_type(utoipa::openapi::schema::Type::Integer)
 ///                                 .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int64)))),
 ///                         ),
 ///                 )
@@ -829,7 +829,7 @@ pub trait Modify {
 ///                 .description(Some("Id of pet"))
 ///                 .schema(Some(
 ///                     utoipa::openapi::ObjectBuilder::new()
-///                         .schema_type(utoipa::openapi::SchemaType::Integer)
+///                         .schema_type(utoipa::openapi::schema::Type::Integer)
 ///                         .format(Some(utoipa::openapi::SchemaFormat::KnownFormat(utoipa::openapi::KnownFormat::Int64))),
 ///                 ))
 ///                 .build(),
@@ -840,7 +840,7 @@ pub trait Modify {
 ///                 .description(Some("Name of pet"))
 ///                 .schema(Some(
 ///                     utoipa::openapi::ObjectBuilder::new()
-///                         .schema_type(utoipa::openapi::SchemaType::String),
+///                         .schema_type(utoipa::openapi::schema::Type::String),
 ///                 ))
 ///                 .build(),
 ///         ]

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -1,4 +1,4 @@
-//! Rust implementation of Openapi Spec V3.
+//! Rust implementation of Openapi Spec V3.1.
 
 use serde::{
     de::{Error, Expected, Visitor},
@@ -119,7 +119,7 @@ builder! {
         pub external_docs: Option<ExternalDocs>,
 
         /// Schema keyword can be used to override default _`$schema`_ dialect which is by default
-        /// “https://spec.openapis.org/oas/3.1/dialect/base”.
+        /// “<https://spec.openapis.org/oas/3.1/dialect/base>”.
         ///
         /// All the references and invidual files could use their own schema dialect.
         #[serde(rename = "$schema", default, skip_serializing_if = "String::is_empty")]

--- a/utoipa/src/openapi/header.rs
+++ b/utoipa/src/openapi/header.rs
@@ -4,7 +4,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::{builder, set_value, Object, RefOr, Schema, SchemaType};
+use super::{builder, set_value, Object, RefOr, Schema, Type};
 
 builder! {
     HeaderBuilder;
@@ -34,8 +34,8 @@ impl Header {
     /// Create new [`Header`] with integer type.
     /// ```rust
     /// # use utoipa::openapi::header::Header;
-    /// # use utoipa::openapi::{Object, SchemaType};
-    /// let header = Header::new(Object::with_type(SchemaType::Integer));
+    /// # use utoipa::openapi::{Object, Type};
+    /// let header = Header::new(Object::with_type(Type::Integer));
     /// ```
     ///
     /// Create a new [`Header`] with default type `String`
@@ -55,7 +55,7 @@ impl Default for Header {
     fn default() -> Self {
         Self {
             description: Default::default(),
-            schema: Object::with_type(SchemaType::String).into(),
+            schema: Object::with_type(Type::String).into(),
         }
     }
 }

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -1160,14 +1160,14 @@ impl ObjectBuilder {
 
     /// Set of change [`Object::content_encoding`]. Typically left empty but could be `base64` for
     /// example.
-    pub fn content_encoding(mut self, content_encoding: String) -> Self {
-        set_value!(self content_encoding content_encoding)
+    pub fn content_encoding<S: Into<String>>(mut self, content_encoding: S) -> Self {
+        set_value!(self content_encoding content_encoding.into())
     }
 
     /// Set of change [`Object::content_media_type`]. Value must be valid MIME type e.g.
     /// `application/json`.
-    pub fn content_media_type(mut self, content_media_type: String) -> Self {
-        set_value!(self content_media_type content_media_type)
+    pub fn content_media_type<S: Into<String>>(mut self, content_media_type: S) -> Self {
+        set_value!(self content_media_type content_media_type.into())
     }
 
     to_array_builder!();

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -345,8 +345,14 @@ builder! {
         pub default: Option<Value>,
 
         /// Example shown in UI of the value for richer documentation.
+        ///
+        /// **Deprecated since 3.0.x. Prefer [`OneOf::examples`] instead**
         #[serde(skip_serializing_if = "Option::is_none")]
         pub example: Option<Value>,
+
+        /// Examples shown in UI of the value for richer documentation.
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        pub examples: Vec<Value>,
 
         /// Optional discriminator field can be used to aid deserialization, serialization and validation of a
         /// specific schema.
@@ -396,6 +402,7 @@ impl Default for OneOf {
             description: Default::default(),
             default: Default::default(),
             example: Default::default(),
+            examples: Default::default(),
             discriminator: Default::default(),
             extensions: Default::default(),
         }
@@ -434,8 +441,15 @@ impl OneOfBuilder {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
+    ///
+    /// **Deprecated since 3.0.x. Prefer [`OneOfBuilder::examples`] instead**
     pub fn example(mut self, example: Option<Value>) -> Self {
         set_value!(self example example)
+    }
+
+    /// Add or change examples shown in UI of the value for richer documentation.
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
+        set_value!(self examples examples.into_iter().map(Into::into).collect())
     }
 
     /// Add or change discriminator field of the composite [`OneOf`] type.
@@ -501,8 +515,14 @@ builder! {
         pub default: Option<Value>,
 
         /// Example shown in UI of the value for richer documentation.
+        ///
+        /// **Deprecated since 3.0.x. Prefer [`AllOf::examples`] instead**
         #[serde(skip_serializing_if = "Option::is_none")]
         pub example: Option<Value>,
+
+        /// Examples shown in UI of the value for richer documentation.
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        pub examples: Vec<Value>,
 
         /// Optional discriminator field can be used to aid deserialization, serialization and validation of a
         /// specific schema.
@@ -552,6 +572,7 @@ impl Default for AllOf {
             description: Default::default(),
             default: Default::default(),
             example: Default::default(),
+            examples: Default::default(),
             discriminator: Default::default(),
             extensions: Default::default(),
         }
@@ -590,8 +611,15 @@ impl AllOfBuilder {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
+    ///
+    /// **Deprecated since 3.0.x. Prefer [`AllOfBuilder::examples`] instead**
     pub fn example(mut self, example: Option<Value>) -> Self {
         set_value!(self example example)
+    }
+
+    /// Add or change examples shown in UI of the value for richer documentation.
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
+        set_value!(self examples examples.into_iter().map(Into::into).collect())
     }
 
     /// Add or change discriminator field of the composite [`AllOf`] type.
@@ -653,8 +681,14 @@ builder! {
         pub default: Option<Value>,
 
         /// Example shown in UI of the value for richer documentation.
+        ///
+        /// **Deprecated since 3.0.x. Prefer [`AnyOf::examples`] instead**
         #[serde(skip_serializing_if = "Option::is_none")]
         pub example: Option<Value>,
+
+        /// Examples shown in UI of the value for richer documentation.
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        pub examples: Vec<Value>,
 
         /// Optional discriminator field can be used to aid deserialization, serialization and validation of a
         /// specific schema.
@@ -703,6 +737,7 @@ impl Default for AnyOf {
             description: Default::default(),
             default: Default::default(),
             example: Default::default(),
+            examples: Default::default(),
             discriminator: Default::default(),
             extensions: Default::default(),
         }
@@ -736,8 +771,15 @@ impl AnyOfBuilder {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
+    ///
+    /// **Deprecated since 3.0.x. Prefer [`AllOfBuilder::examples`] instead**
     pub fn example(mut self, example: Option<Value>) -> Self {
         set_value!(self example example)
+    }
+
+    /// Add or change examples shown in UI of the value for richer documentation.
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
+        set_value!(self examples examples.into_iter().map(Into::into).collect())
     }
 
     /// Add or change discriminator field of the composite [`AnyOf`] type.
@@ -834,8 +876,14 @@ builder! {
         pub deprecated: Option<Deprecated>,
 
         /// Example shown in UI of the value for richer documentation.
+        ///
+        /// **Deprecated since 3.0.x. Prefer [`Object::examples`] instead**
         #[serde(skip_serializing_if = "Option::is_none")]
         pub example: Option<Value>,
+
+        /// Examples shown in UI of the value for richer documentation.
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        pub examples: Vec<Value>,
 
         /// Write only property will be only sent in _write_ requests like _POST, PUT_.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -1029,8 +1077,15 @@ impl ObjectBuilder {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
+    ///
+    /// **Deprecated since 3.0.x. Prefer [`Object::examples`] instead**
     pub fn example(mut self, example: Option<Value>) -> Self {
         set_value!(self example example)
+    }
+
+    /// Add or change examples shown in UI of the value for richer documentation.
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
+        set_value!(self examples examples.into_iter().map(Into::into).collect())
     }
 
     /// Add or change write only flag for [`Object`].
@@ -1340,8 +1395,14 @@ builder! {
         pub deprecated: Option<Deprecated>,
 
         /// Example shown in UI of the value for richer documentation.
+        ///
+        /// **Deprecated since 3.0.x. Prefer [`Array::examples`] instead**
         #[serde(skip_serializing_if = "Option::is_none")]
         pub example: Option<Value>,
+
+        /// Examples shown in UI of the value for richer documentation.
+        #[serde(skip_serializing_if = "Vec::is_empty", default)]
+        pub examples: Vec<Value>,
 
         /// Default value which is provided when user has not provided the input in Swagger UI.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -1380,6 +1441,7 @@ impl Default for Array {
             description: Default::default(),
             deprecated: Default::default(),
             example: Default::default(),
+            examples: Default::default(),
             default: Default::default(),
             max_items: Default::default(),
             min_items: Default::default(),
@@ -1463,8 +1525,15 @@ impl ArrayBuilder {
     }
 
     /// Add or change example shown in UI of the value for richer documentation.
+    ///
+    /// **Deprecated since 3.0.x. Prefer [`Array::examples`] instead**
     pub fn example(mut self, example: Option<Value>) -> Self {
         set_value!(self example example)
+    }
+
+    /// Add or change examples shown in UI of the value for richer documentation.
+    pub fn examples<I: IntoIterator<Item = V>, V: Into<Value>>(mut self, examples: I) -> Self {
+        set_value!(self examples examples.into_iter().map(Into::into).collect())
     }
 
     /// Add or change default value for the object which is provided when user has not provided the input in Swagger UI.

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -37,8 +37,7 @@ macro_rules! to_array_builder {
 pub fn empty() -> Schema {
     Schema::Object(
         ObjectBuilder::new()
-            .schema_type(SchemaType::Value)
-            .nullable(true)
+            .schema_type(SchemaType::AnyValue)
             .default(Some(serde_json::Value::Null))
             .into(),
     )
@@ -155,14 +154,14 @@ impl ComponentsBuilder {
     /// # Examples
     /// ```rust
     /// # use utoipa::openapi::schema::{ComponentsBuilder, ObjectBuilder,
-    /// #    SchemaType, Schema};
+    /// #    Type, Schema};
     /// ComponentsBuilder::new().schemas_from_iter([(
     ///     "Pet",
     ///     Schema::from(
     ///         ObjectBuilder::new()
     ///             .property(
     ///                 "name",
-    ///                 ObjectBuilder::new().schema_type(SchemaType::String),
+    ///                 ObjectBuilder::new().schema_type(Type::String),
     ///             )
     ///             .required("name")
     ///     ),
@@ -319,12 +318,19 @@ builder! {
     /// See [`Schema::OneOf`] for more details.
     ///
     /// [oneof]: https://spec.openapis.org/oas/latest.html#components-object
-    #[derive(Serialize, Deserialize, Clone, Default, PartialEq)]
+    #[derive(Serialize, Deserialize, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct OneOf {
         /// Components of _OneOf_ component.
         #[serde(rename = "oneOf")]
         pub items: Vec<RefOr<Schema>>,
+
+        /// Type of [`OneOf`] e.g. `SchemaType::new(Type::Object)` for `object`.
+        ///
+        /// By default this is [`SchemaType::AnyValue`] as the type is defined by items
+        /// themselves.
+        #[serde(rename = "type", default = "SchemaType::any", skip_serializing_if = "SchemaType::is_any_value")]
+        pub schema_type: SchemaType,
 
         /// Changes the [`OneOf`] title.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -346,10 +352,6 @@ builder! {
         /// specific schema.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub discriminator: Option<Discriminator>,
-
-        /// Set `true` to allow `"null"` to be used as value for given type.
-        #[serde(default, skip_serializing_if = "is_false")]
-        pub nullable: bool,
 
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
@@ -385,6 +387,21 @@ impl OneOf {
     }
 }
 
+impl Default for OneOf {
+    fn default() -> Self {
+        Self {
+            items: Default::default(),
+            schema_type: SchemaType::AnyValue,
+            title: Default::default(),
+            description: Default::default(),
+            default: Default::default(),
+            example: Default::default(),
+            discriminator: Default::default(),
+            extensions: Default::default(),
+        }
+    }
+}
+
 impl OneOfBuilder {
     /// Adds a given [`Schema`] to [`OneOf`] [Composite Object][composite].
     ///
@@ -393,6 +410,12 @@ impl OneOfBuilder {
         self.items.push(component.into());
 
         self
+    }
+
+    /// Add or change type of the object e.g. to change type to _`string`_
+    /// use value `SchemaType::Type(Type::String)`.
+    pub fn schema_type<T: Into<SchemaType>>(mut self, schema_type: T) -> Self {
+        set_value!(self schema_type schema_type.into())
     }
 
     /// Add or change the title of the [`OneOf`].
@@ -418,11 +441,6 @@ impl OneOfBuilder {
     /// Add or change discriminator field of the composite [`OneOf`] type.
     pub fn discriminator(mut self, discriminator: Option<Discriminator>) -> Self {
         set_value!(self discriminator discriminator)
-    }
-
-    /// Add or change nullable flag for [`Object`].
-    pub fn nullable(mut self, nullable: bool) -> Self {
-        set_value!(self nullable nullable)
     }
 
     /// Add openapi extensions (`x-something`) for [`OneOf`].
@@ -456,12 +474,19 @@ builder! {
     /// See [`Schema::AllOf`] for more details.
     ///
     /// [allof]: https://spec.openapis.org/oas/latest.html#components-object
-    #[derive(Serialize, Deserialize, Clone, Default, PartialEq)]
+    #[derive(Serialize, Deserialize, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct AllOf {
         /// Components of _AllOf_ component.
         #[serde(rename = "allOf")]
         pub items: Vec<RefOr<Schema>>,
+
+        /// Type of [`AllOf`] e.g. `SchemaType::new(Type::Object)` for `object`.
+        ///
+        /// By default this is [`SchemaType::AnyValue`] as the type is defined by items
+        /// themselves.
+        #[serde(rename = "type", default = "SchemaType::any", skip_serializing_if = "SchemaType::is_any_value")]
+        pub schema_type: SchemaType,
 
         /// Changes the [`AllOf`] title.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -483,10 +508,6 @@ builder! {
         /// specific schema.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub discriminator: Option<Discriminator>,
-
-        /// Set `true` to allow `"null"` to be used as value for given type.
-        #[serde(default, skip_serializing_if = "is_false")]
-        pub nullable: bool,
 
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
@@ -522,6 +543,21 @@ impl AllOf {
     }
 }
 
+impl Default for AllOf {
+    fn default() -> Self {
+        Self {
+            items: Default::default(),
+            schema_type: SchemaType::AnyValue,
+            title: Default::default(),
+            description: Default::default(),
+            default: Default::default(),
+            example: Default::default(),
+            discriminator: Default::default(),
+            extensions: Default::default(),
+        }
+    }
+}
+
 impl AllOfBuilder {
     /// Adds a given [`Schema`] to [`AllOf`] [Composite Object][composite].
     ///
@@ -530,6 +566,12 @@ impl AllOfBuilder {
         self.items.push(component.into());
 
         self
+    }
+
+    /// Add or change type of the object e.g. to change type to _`string`_
+    /// use value `SchemaType::Type(Type::String)`.
+    pub fn schema_type<T: Into<SchemaType>>(mut self, schema_type: T) -> Self {
+        set_value!(self schema_type schema_type.into())
     }
 
     /// Add or change the title of the [`AllOf`].
@@ -555,11 +597,6 @@ impl AllOfBuilder {
     /// Add or change discriminator field of the composite [`AllOf`] type.
     pub fn discriminator(mut self, discriminator: Option<Discriminator>) -> Self {
         set_value!(self discriminator discriminator)
-    }
-
-    /// Add or change nullable flag for [`Object`].
-    pub fn nullable(mut self, nullable: bool) -> Self {
-        set_value!(self nullable nullable)
     }
 
     /// Add openapi extensions (`x-something`) for [`AllOf`].
@@ -593,12 +630,19 @@ builder! {
     /// See [`Schema::AnyOf`] for more details.
     ///
     /// [anyof]: https://spec.openapis.org/oas/latest.html#components-object
-    #[derive(Serialize, Deserialize, Clone, Default, PartialEq)]
+    #[derive(Serialize, Deserialize, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct AnyOf {
         /// Components of _AnyOf component.
         #[serde(rename = "anyOf")]
         pub items: Vec<RefOr<Schema>>,
+
+        /// Type of [`AnyOf`] e.g. `SchemaType::new(Type::Object)` for `object`.
+        ///
+        /// By default this is [`SchemaType::AnyValue`] as the type is defined by items
+        /// themselves.
+        #[serde(rename = "type", default = "SchemaType::any", skip_serializing_if = "SchemaType::is_any_value")]
+        pub schema_type: SchemaType,
 
         /// Description of the [`AnyOf`]. Markdown syntax is supported.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -616,10 +660,6 @@ builder! {
         /// specific schema.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub discriminator: Option<Discriminator>,
-
-        /// Set `true` to allow `"null"` to be used as value for given type.
-        #[serde(default, skip_serializing_if = "is_false")]
-        pub nullable: bool,
 
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
@@ -655,6 +695,20 @@ impl AnyOf {
     }
 }
 
+impl Default for AnyOf {
+    fn default() -> Self {
+        Self {
+            items: Default::default(),
+            schema_type: SchemaType::AnyValue,
+            description: Default::default(),
+            default: Default::default(),
+            example: Default::default(),
+            discriminator: Default::default(),
+            extensions: Default::default(),
+        }
+    }
+}
+
 impl AnyOfBuilder {
     /// Adds a given [`Schema`] to [`AnyOf`] [Composite Object][composite].
     ///
@@ -663,6 +717,12 @@ impl AnyOfBuilder {
         self.items.push(component.into());
 
         self
+    }
+
+    /// Add or change type of the object e.g. to change type to _`string`_
+    /// use value `SchemaType::Type(Type::String)`.
+    pub fn schema_type<T: Into<SchemaType>>(mut self, schema_type: T) -> Self {
+        set_value!(self schema_type schema_type.into())
     }
 
     /// Add or change optional description for `AnyOf` component.
@@ -683,11 +743,6 @@ impl AnyOfBuilder {
     /// Add or change discriminator field of the composite [`AnyOf`] type.
     pub fn discriminator(mut self, discriminator: Option<Discriminator>) -> Self {
         set_value!(self discriminator discriminator)
-    }
-
-    /// Add or change nullable flag for [`AnyOf`].
-    pub fn nullable(mut self, nullable: bool) -> Self {
-        set_value!(self nullable nullable)
     }
 
     /// Add openapi extensions (`x-something`) for [`AnyOf`].
@@ -731,9 +786,9 @@ builder! {
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[serde(rename_all = "camelCase")]
     pub struct Object {
-        /// Type of [`Object`] e.g. [`SchemaType::Object`] for `object` and [`SchemaType::String`] for
+        /// Type of [`Object`] e.g. [`Type::Object`] for `object` and [`Type::String`] for
         /// `string` types.
-        #[serde(rename = "type", skip_serializing_if="SchemaType::is_value")]
+        #[serde(rename = "type", skip_serializing_if="SchemaType::is_any_value")]
         pub schema_type: SchemaType,
 
         /// Changes the [`Object`] title.
@@ -794,10 +849,6 @@ builder! {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub xml: Option<Xml>,
 
-        /// Set `true` to allow `"null"` to be used as value for given type.
-        #[serde(default, skip_serializing_if = "is_false")]
-        pub nullable: bool,
-
         /// Must be a number strictly greater than `0`. Numeric value is considered valid if value
         /// divided by the _`multiple_of`_ value results an integer.
         #[serde(skip_serializing_if = "Option::is_none", serialize_with = "omit_decimal_zero")]
@@ -851,6 +902,24 @@ builder! {
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
         pub extensions: Option<HashMap<String, serde_json::Value>>,
+
+        /// The `content_encoding` keyword specifies the encoding used to store the contents, as specified in
+        /// [RFC 2054, part 6.1](https://tools.ietf.org/html/rfc2045) and [RFC 4648](RFC 2054, part 6.1).
+        ///
+        /// Typically this is either unset for _`string`_ content types which then uses the content
+        /// encoding of the underying JSON document. If the content is in _`binary`_ format such as an image or an audio
+        /// set it to `base64` to encode it as _`Base64`_.
+        ///
+        /// See more details at <https://json-schema.org/understanding-json-schema/reference/non_json_data#contentencoding>
+        #[serde(skip_serializing_if = "String::is_empty", default)]
+        pub content_encoding: String,
+
+        /// The _`content_media_type`_ keyword specifies the MIME type of the contents of a string,
+        /// as described in [RFC 2046](https://tools.ietf.org/html/rfc2046).
+        ///
+        /// See more details at <https://json-schema.org/understanding-json-schema/reference/non_json_data#contentmediatype>
+        #[serde(skip_serializing_if = "String::is_empty", default)]
+        pub content_media_type: String,
     }
 }
 
@@ -871,12 +940,12 @@ impl Object {
     ///
     /// Create [`std::string`] object type which can be used to define `string` field of an object.
     /// ```rust
-    /// # use utoipa::openapi::schema::{Object, SchemaType};
-    /// let object = Object::with_type(SchemaType::String);
+    /// # use utoipa::openapi::schema::{Object, Type};
+    /// let object = Object::with_type(Type::String);
     /// ```
-    pub fn with_type(schema_type: SchemaType) -> Self {
+    pub fn with_type<T: Into<SchemaType>>(schema_type: T) -> Self {
         Self {
-            schema_type,
+            schema_type: schema_type.into(),
             ..Default::default()
         }
     }
@@ -891,9 +960,10 @@ impl From<Object> for Schema {
 impl ToArray for Object {}
 
 impl ObjectBuilder {
-    /// Add or change type of the object e.g [`SchemaType::String`].
-    pub fn schema_type(mut self, schema_type: SchemaType) -> Self {
-        set_value!(self schema_type schema_type)
+    /// Add or change type of the object e.g. to change type to _`string`_
+    /// use value `SchemaType::Type(Type::String)`.
+    pub fn schema_type<T: Into<SchemaType>>(mut self, schema_type: T) -> Self {
+        set_value!(self schema_type schema_type.into())
     }
 
     /// Add or change additional format for detailing the schema type.
@@ -978,11 +1048,6 @@ impl ObjectBuilder {
         set_value!(self xml xml)
     }
 
-    /// Add or change nullable flag for [`Object`].
-    pub fn nullable(mut self, nullable: bool) -> Self {
-        set_value!(self nullable nullable)
-    }
-
     /// Set or change _`multiple_of`_ validation flag for `number` and `integer` type values.
     pub fn multiple_of(mut self, multiple_of: Option<f64>) -> Self {
         set_value!(self multiple_of multiple_of)
@@ -1038,6 +1103,18 @@ impl ObjectBuilder {
         set_value!(self extensions extensions)
     }
 
+    /// Set of change [`Object::content_encoding`]. Typically left empty but could be `base64` for
+    /// example.
+    pub fn content_encoding(mut self, content_encoding: String) -> Self {
+        set_value!(self content_encoding content_encoding)
+    }
+
+    /// Set of change [`Object::content_media_type`]. Value must be valid MIME type e.g.
+    /// `application/json`.
+    pub fn content_media_type(mut self, content_media_type: String) -> Self {
+        set_value!(self content_media_type content_media_type)
+    }
+
     to_array_builder!();
 }
 
@@ -1086,23 +1163,44 @@ impl From<Ref> for AdditionalProperties<Schema> {
     }
 }
 
+impl From<RefBuilder> for AdditionalProperties<Schema> {
+    fn from(value: RefBuilder) -> Self {
+        Self::RefOr(RefOr::Ref(value.build()))
+    }
+}
+
 impl From<Schema> for AdditionalProperties<Schema> {
     fn from(value: Schema) -> Self {
         Self::RefOr(RefOr::T(value))
     }
 }
 
-/// Implements [OpenAPI Reference Object][reference] that can be used to reference
-/// reusable components such as [`Schema`]s or [`Response`]s.
-///
-/// [reference]: https://spec.openapis.org/oas/latest.html#reference-object
-#[non_exhaustive]
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
-#[cfg_attr(feature = "debug", derive(Debug))]
-pub struct Ref {
-    /// Reference location of the actual component.
-    #[serde(rename = "$ref")]
-    pub ref_location: String,
+builder! {
+    RefBuilder;
+
+    /// Implements [OpenAPI Reference Object][reference] that can be used to reference
+    /// reusable components such as [`Schema`]s or [`Response`]s.
+    ///
+    /// [reference]: https://spec.openapis.org/oas/latest.html#reference-object
+    #[non_exhaustive]
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct Ref {
+        /// Reference location of the actual component.
+        #[serde(rename = "$ref")]
+        pub ref_location: String,
+
+        /// A description which by default should override that of the referenced component.
+        /// Description supports markdown syntax. If referenced object type does not support
+        /// description this field does not have effect.
+        #[serde(skip_serializing_if = "String::is_empty", default)]
+        pub description: String,
+
+        /// A short summary which by default should override that of the referenced component. If
+        /// referenced component does not support summary field this does not have effect.
+        #[serde(skip_serializing_if = "String::is_empty", default)]
+        pub summary: String,
+    }
 }
 
 impl Ref {
@@ -1111,6 +1209,7 @@ impl Ref {
     pub fn new<I: Into<String>>(ref_location: I) -> Self {
         Self {
             ref_location: ref_location.into(),
+            ..Default::default()
         }
     }
 
@@ -1127,6 +1226,40 @@ impl Ref {
     }
 
     to_array_builder!();
+}
+
+impl RefBuilder {
+    /// Add or change reference location of the actual component.
+    pub fn ref_location(mut self, ref_location: String) -> Self {
+        set_value!(self ref_location ref_location)
+    }
+
+    /// Add or change reference location of the actual component automatically formatting the $ref
+    /// to `#/components/schemas/...` format.
+    pub fn ref_location_from_schema_name<S: Into<String>>(mut self, schema_name: S) -> Self {
+        set_value!(self ref_location format!("#/components/schemas/{}", schema_name.into()))
+    }
+
+    // TODO: REMOVE THE unnecesary description Option wrapping.
+
+    /// Add or change description which by default should override that of the referenced component.
+    /// Description supports markdown syntax. If referenced object type does not support
+    /// description this field does not have effect.
+    pub fn description<S: Into<String>>(mut self, description: Option<S>) -> Self {
+        set_value!(self description description.map(Into::into).unwrap_or_default())
+    }
+
+    /// Add or change short summary which by default should override that of the referenced component. If
+    /// referenced component does not support summary field this does not have effect.
+    pub fn summary<S: Into<String>>(mut self, summary: S) -> Self {
+        set_value!(self summary summary.into())
+    }
+}
+
+impl From<RefBuilder> for RefOr<Schema> {
+    fn from(builder: RefBuilder) -> Self {
+        Self::Ref(builder.build())
+    }
 }
 
 impl From<Ref> for RefOr<Schema> {
@@ -1231,10 +1364,6 @@ builder! {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub xml: Option<Xml>,
 
-        /// Set `true` to allow `"null"` to be used as value for given type.
-        #[serde(default, skip_serializing_if = "is_false")]
-        pub nullable: bool,
-
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
         pub extensions: Option<HashMap<String, serde_json::Value>>,
@@ -1245,7 +1374,7 @@ impl Default for Array {
     fn default() -> Self {
         Self {
             title: Default::default(),
-            schema_type: SchemaType::Array,
+            schema_type: Type::Array.into(),
             unique_items: bool::default(),
             items: Default::default(),
             description: Default::default(),
@@ -1255,7 +1384,6 @@ impl Default for Array {
             max_items: Default::default(),
             min_items: Default::default(),
             xml: Default::default(),
-            nullable: Default::default(),
             extensions: Default::default(),
         }
     }
@@ -1266,14 +1394,31 @@ impl Array {
     ///
     /// # Examples
     ///
-    /// Create a `String` array component.
+    /// _**Create a `String` array component**_.
     /// ```rust
-    /// # use utoipa::openapi::schema::{Schema, Array, SchemaType, Object};
-    /// let string_array = Array::new(Object::with_type(SchemaType::String));
+    /// # use utoipa::openapi::schema::{Schema, Array, Type, Object};
+    /// let string_array = Array::new(Object::with_type(Type::String));
     /// ```
     pub fn new<I: Into<RefOr<Schema>>>(component: I) -> Self {
         Self {
             items: Box::new(component.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Construct a new nullable [`Array`] component from given [`Schema`].
+    ///
+    /// # Examples
+    ///
+    /// _**Create a nullable `String` array component**_.
+    /// ```rust
+    /// # use utoipa::openapi::schema::{Schema, Array, Type, Object};
+    /// let string_array = Array::new_nullable(Object::with_type(Type::String));
+    /// ```
+    pub fn new_nullable<I: Into<RefOr<Schema>>>(component: I) -> Self {
+        Self {
+            items: Box::new(component.into()),
+            schema_type: SchemaType::from_iter([Type::Array, Type::Null]),
             ..Default::default()
         }
     }
@@ -1283,6 +1428,23 @@ impl ArrayBuilder {
     /// Set [`Schema`] type for the [`Array`].
     pub fn items<I: Into<RefOr<Schema>>>(mut self, component: I) -> Self {
         set_value!(self items Box::new(component.into()))
+    }
+
+    /// Change type of the array e.g. to change type to _`string`_
+    /// use value `SchemaType::Type(Type::String)`.
+    ///
+    /// # Examples
+    ///
+    /// _**Make nullable string array.**_
+    /// ```rust
+    /// # use utoipa::openapi::schema::{ArrayBuilder, SchemaType, Type, Object};
+    /// let _ = ArrayBuilder::new()
+    ///     .schema_type(SchemaType::from_iter([Type::Array, Type::Null]))
+    ///     .items(Object::with_type(Type::String))
+    ///     .build();
+    /// ```
+    pub fn schema_type<T: Into<SchemaType>>(mut self, schema_type: T) -> Self {
+        set_value!(self schema_type schema_type.into())
     }
 
     /// Add or change the title of the [`Array`].
@@ -1330,11 +1492,6 @@ impl ArrayBuilder {
         set_value!(self xml xml)
     }
 
-    /// Add or change nullable flag for [`Object`].
-    pub fn nullable(mut self, nullable: bool) -> Self {
-        set_value!(self nullable nullable)
-    }
-
     /// Add openapi extensions (`x-something`) for [`Array`].
     pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
         set_value!(self extensions extensions)
@@ -1369,17 +1526,97 @@ where
     }
 }
 
-/// Represents data type of [`Schema`].
+/// Represents type of [`Schema`].
+///
+/// This is a collection type for [`Type`] that can be represented as a single value
+/// or as [`slice`] of [`Type`]s.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
-#[serde(rename_all = "lowercase")]
+#[serde(untagged)]
 pub enum SchemaType {
+    /// Single type known from OpenAPI spec 3.0
+    Type(Type),
+    /// Multiple types rendered as [`slice`]
+    Array(Vec<Type>),
+    /// Type that is considred typeless. _`AnyValue`_ will omit the type definition from the schema
+    /// making it to accept any type possible.
+    AnyValue,
+}
+
+impl Default for SchemaType {
+    fn default() -> Self {
+        Self::Type(Type::default())
+    }
+}
+
+impl From<Type> for SchemaType {
+    fn from(value: Type) -> Self {
+        SchemaType::new(value)
+    }
+}
+
+impl FromIterator<Type> for SchemaType {
+    fn from_iter<T: IntoIterator<Item = Type>>(iter: T) -> Self {
+        Self::Array(iter.into_iter().collect())
+    }
+}
+
+impl SchemaType {
+    /// Instantiate new [`SchemaType`] of given [`Type`]
+    ///
+    /// Method accpets one argument `type` to create [`SchemaType`] for.
+    ///
+    /// # Examples
+    ///
+    /// _**Create string [`SchemaType`]**_
+    /// ```rust
+    /// # use utoipa::openapi::schema::{SchemaType, Type};
+    /// let ty = SchemaType::new(Type::String);
+    /// ```
+    pub fn new(r#type: Type) -> Self {
+        Self::Type(r#type)
+    }
+
+    //// Instantiate new [`SchemaType::AnyValue`].
+    ///
+    /// This is same as calling [`SchemaType::AnyValue`] but in a function form `() -> SchemaType`
+    /// allowing it to be used as argument for _serde's_ _`default = "..."`_.
+    pub fn any() -> Self {
+        SchemaType::AnyValue
+    }
+
+    // /// Instantiate new [`SchemaType`] from interator of [`Type`]s. This will create multi type
+    // /// [`SchemaType`] from iterator of types.
+    // ///
+    // /// Method accepts one argument `types` an iterator of [`Type`]s to create _SchemaType_ for.
+    // ///
+    // /// # Examples
+    // ///
+    // /// _**Create nullable string [`SchemaType`]**_
+    // /// ```rust
+    // /// # use utoipa::openapi::schema::{SchemaType, Type};
+    // /// let ty = SchemaType::from_iter([Type::String, Type::Null]);
+    // /// ```
+    // pub fn from_iter<I: IntoIterator<Item = Type>>(types: I) -> Self {
+    //     Self::Array(types.into_iter().collect())
+    // }
+
+    /// Check whether this [`SchemaType`] is any value _(typeless)_ returning true on any value
+    /// schema type.
+    pub fn is_any_value(&self) -> bool {
+        matches!(self, Self::AnyValue)
+    }
+}
+
+/// Represents data type of [`Schema`].
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[serde(rename_all = "lowercase")]
+pub enum Type {
     /// Used with [`Object`] and [`ObjectBuilder`]. Objects always have
     /// _schema_type_ [`SchemaType::Object`].
+    #[default]
     Object,
-    /// Indicates generic JSON content. Used with [`Object`] and [`ObjectBuilder`] on a field
-    /// of any valid JSON type.
-    Value,
     /// Indicates string type of content. Used with [`Object`] and [`ObjectBuilder`] on a `string`
     /// field.
     String,
@@ -1394,17 +1631,8 @@ pub enum SchemaType {
     Boolean,
     /// Used with [`Array`] and [`ArrayBuilder`]. Indicates array type of content.
     Array,
-}
-impl SchemaType {
-    fn is_value(type_: &SchemaType) -> bool {
-        *type_ == SchemaType::Value
-    }
-}
-
-impl Default for SchemaType {
-    fn default() -> Self {
-        Self::Object
-    }
+    /// Null type. Used together with other type to indicate nullable values.
+    Null,
 }
 
 /// Additional format for [`SchemaType`] to fine tune the data type used. If the **format** is not
@@ -1513,7 +1741,7 @@ mod tests {
                                 .property(
                                     "id",
                                     ObjectBuilder::new()
-                                        .schema_type(SchemaType::Integer)
+                                        .schema_type(Type::Integer)
                                         .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                                         .description(Some("Id of credential"))
                                         .default(Some(json!(1i32))),
@@ -1521,13 +1749,13 @@ mod tests {
                                 .property(
                                     "name",
                                     ObjectBuilder::new()
-                                        .schema_type(SchemaType::String)
+                                        .schema_type(Type::String)
                                         .description(Some("Name of credential")),
                                 )
                                 .property(
                                     "status",
                                     ObjectBuilder::new()
-                                        .schema_type(SchemaType::String)
+                                        .schema_type(Type::String)
                                         .default(Some(json!("Active")))
                                         .description(Some("Credential status"))
                                         .enum_values(Some([
@@ -1541,7 +1769,7 @@ mod tests {
                                     "history",
                                     Array::new(Ref::from_schema_name("UpdateHistory")),
                                 )
-                                .property("tags", Object::with_type(SchemaType::String).to_array()),
+                                .property("tags", Object::with_type(Type::String).to_array()),
                         ),
                     )
                     .build(),
@@ -1619,7 +1847,7 @@ mod tests {
             .property(
                 "id",
                 ObjectBuilder::new()
-                    .schema_type(SchemaType::Integer)
+                    .schema_type(Type::Integer)
                     .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                     .description(Some("Id of credential"))
                     .default(Some(json!(1i32))),
@@ -1627,13 +1855,13 @@ mod tests {
             .property(
                 "name",
                 ObjectBuilder::new()
-                    .schema_type(SchemaType::String)
+                    .schema_type(Type::String)
                     .description(Some("Name of credential")),
             )
             .property(
                 "status",
                 ObjectBuilder::new()
-                    .schema_type(SchemaType::String)
+                    .schema_type(Type::String)
                     .default(Some(json!("Active")))
                     .description(Some("Credential status"))
                     .enum_values(Some(["Active", "NotActive", "Locked", "Expired"])),
@@ -1642,7 +1870,7 @@ mod tests {
                 "history",
                 Array::new(Ref::from_schema_name("UpdateHistory")),
             )
-            .property("tags", Object::with_type(SchemaType::String).to_array())
+            .property("tags", Object::with_type(Type::String).to_array())
             .build();
 
         #[cfg(not(feature = "preserve_order"))]
@@ -1662,7 +1890,7 @@ mod tests {
     #[test]
     fn test_additional_properties() {
         let json_value = ObjectBuilder::new()
-            .additional_properties(Some(ObjectBuilder::new().schema_type(SchemaType::String)))
+            .additional_properties(Some(ObjectBuilder::new().schema_type(Type::String)))
             .build();
         assert_json_eq!(
             json_value,
@@ -1676,7 +1904,7 @@ mod tests {
 
         let json_value = ObjectBuilder::new()
             .additional_properties(Some(
-                ArrayBuilder::new().items(ObjectBuilder::new().schema_type(SchemaType::Number)),
+                ArrayBuilder::new().items(ObjectBuilder::new().schema_type(Type::Number)),
             ))
             .build();
         assert_json_eq!(
@@ -1744,14 +1972,14 @@ mod tests {
             ObjectBuilder::new().property(
                 "id",
                 ObjectBuilder::new()
-                    .schema_type(SchemaType::Integer)
+                    .schema_type(Type::Integer)
                     .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                     .description(Some("Id of credential"))
                     .default(Some(json!(1i32))),
             ),
         );
 
-        assert!(matches!(array.schema_type, SchemaType::Array));
+        assert!(matches!(array.schema_type, SchemaType::Type(Type::Array)));
     }
 
     #[test]
@@ -1761,7 +1989,7 @@ mod tests {
                 ObjectBuilder::new().property(
                     "id",
                     ObjectBuilder::new()
-                        .schema_type(SchemaType::Integer)
+                        .schema_type(Type::Integer)
                         .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                         .description(Some("Id of credential"))
                         .default(Some(json!(1i32))),
@@ -1769,7 +1997,7 @@ mod tests {
             )
             .build();
 
-        assert!(matches!(array.schema_type, SchemaType::Array));
+        assert!(matches!(array.schema_type, SchemaType::Type(Type::Array)));
     }
 
     #[test]
@@ -1779,7 +2007,7 @@ mod tests {
                 "Comp",
                 Schema::from(
                     ObjectBuilder::new()
-                        .property("name", ObjectBuilder::new().schema_type(SchemaType::String))
+                        .property("name", ObjectBuilder::new().schema_type(Type::String))
                         .required("name"),
                 ),
             )])
@@ -1804,7 +2032,7 @@ mod tests {
     #[test]
     fn reserialize_deserialized_object_component() {
         let prop = ObjectBuilder::new()
-            .property("name", ObjectBuilder::new().schema_type(SchemaType::String))
+            .property("name", ObjectBuilder::new().schema_type(Type::String))
             .required("name")
             .build();
 
@@ -1820,7 +2048,7 @@ mod tests {
 
     #[test]
     fn reserialize_deserialized_property() {
-        let prop = ObjectBuilder::new().schema_type(SchemaType::String).build();
+        let prop = ObjectBuilder::new().schema_type(Type::String).build();
 
         let serialized_components = serde_json::to_string(&prop).unwrap();
         let deserialized_components: Object =
@@ -1951,6 +2179,38 @@ mod tests {
     }
 
     #[test]
+    fn deserialize_reserialize_one_of_default_type() {
+        let a = OneOfBuilder::new()
+            .item(Schema::Array(
+                ArrayBuilder::new()
+                    .items(RefOr::T(Schema::Object(
+                        ObjectBuilder::new()
+                            .property("element", RefOr::Ref(Ref::new("#/test")))
+                            .build(),
+                    )))
+                    .build(),
+            ))
+            .item(Schema::Array(
+                ArrayBuilder::new()
+                    .items(RefOr::T(Schema::Object(
+                        ObjectBuilder::new()
+                            .property("foobar", RefOr::Ref(Ref::new("#/foobar")))
+                            .build(),
+                    )))
+                    .build(),
+            ))
+            .build();
+
+        let serialized_json = serde_json::to_string(&a).expect("should serialize to json");
+        let b: OneOf = serde_json::from_str(&serialized_json).expect("should deserialize OneOf");
+        let reserialized_json = serde_json::to_string(&b).expect("reserialized json");
+
+        println!("{serialized_json}");
+        println!("{reserialized_json}",);
+        assert_eq!(serialized_json, reserialized_json);
+    }
+
+    #[test]
     fn serialize_deserialize_any_of_of_within_ref_or_t_object_builder() {
         let ref_or_schema = RefOr::T(Schema::Object(
             ObjectBuilder::new()
@@ -2071,8 +2331,7 @@ mod tests {
                 .property(
                     "map",
                     ObjectBuilder::new().additional_properties(Some(
-                        ObjectBuilder::new()
-                            .property("name", Object::with_type(SchemaType::String)),
+                        ObjectBuilder::new().property("name", Object::with_type(Type::String)),
                     )),
                 )
                 .build(),
@@ -2119,6 +2378,25 @@ mod tests {
                 }
             })
         );
+    }
+
+    #[test]
+    fn serialize_deserialize_object_with_multiple_schema_types() {
+        let object = ObjectBuilder::new()
+            .schema_type(SchemaType::from_iter([Type::Object, Type::Null]))
+            .build();
+
+        let json_str = serde_json::to_string(&object).unwrap();
+        println!("----------------------------");
+        println!("{json_str}");
+
+        let deserialized: Object = serde_json::from_str(&json_str).unwrap();
+
+        let json_de_str = serde_json::to_string(&deserialized).unwrap();
+        println!("----------------------------");
+        println!("{json_de_str}");
+
+        assert_eq!(json_str, json_de_str);
     }
 
     #[test]

--- a/utoipa/src/openapi/testdata/expected_openapi_minimal.json
+++ b/utoipa/src/openapi/testdata/expected_openapi_minimal.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "info": {
     "title": "My api",
     "description": "My api description",

--- a/utoipa/src/openapi/testdata/expected_openapi_with_paths.json
+++ b/utoipa/src/openapi/testdata/expected_openapi_with_paths.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.0.3",
+  "openapi": "3.1.0",
   "info": {
     "title": "My big api",
     "version": "1.1.0"


### PR DESCRIPTION
Add support for OpenAPI 3.1 version. **This is a breaking change** and will remove the support for OpenAPI 3.0 version. Maintaining both support for 3.1 and 3.0 would be too much of work. The fundamental change here is how the type is being rendered in the documentation. 

More details of changes to the OpenAPI spec can be found from here: https://www.openapis.org/blog/2021/02/16/migrating-from-openapi-3-0-to-3-1-0.

Resolves #531 