### PR TITLE
fix(utoipa-gen): remove unnecessary allocation with to_string in expanded code

### DIFF
--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -394,7 +394,7 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
             })
             .unwrap_or_else(|| {
                 quote! {
-                    #path.to_owned().replace('"', "")
+                    #path.replace('"', "")
                 }
             });
 

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -386,8 +386,8 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
                 let context_path = context_path.to_token_stream();
                 let context_path_tokens = quote! {
                     format!("{}{}",
-                        #context_path.to_owned().replace('"', ""),
-                        #path.to_owned().replace('"', "")
+                        #context_path.replace('"', ""),
+                        #path.replace('"', "")
                     )
                 };
                 context_path_tokens

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -386,15 +386,15 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
                 let context_path = context_path.to_token_stream();
                 let context_path_tokens = quote! {
                     format!("{}{}",
-                        #context_path.to_string().replace('"', ""),
-                        #path.to_string().replace('"', "")
+                        #context_path.to_owned().replace('"', ""),
+                        #path.to_owned().replace('"', "")
                     )
                 };
                 context_path_tokens
             })
             .unwrap_or_else(|| {
                 quote! {
-                    #path.to_string().replace('"', "")
+                    #path.to_owned().replace('"', "")
                 }
             });
 


### PR DESCRIPTION
~~Taking something that is a string and converting it to a string using `to_string()` kind of misses the point of why we are doing the conversion in the first place, and also fails to document this to the reader. `to_owned()` fully captures the reason that a conversion is required at a particular spot: borrowed (`&str`) to owned (`String`).~~

~~Some people enable this clippy lint in order to enforce this style:~~

~~- https://rust-lang.github.io/rust-clippy/master/index.html#/str_to_string~~

~~Code generated by utoipa macro is triggering this lint. To avoid that, this patch is replacing the `to_string()` usages in generated code by `to_owned()`.~~

~~This patch is not changing any other `to_string()` because the utoipa project itself does not need to adhere to this style. The goal is just to reduce friction for downstream consumers.~~

Here is how it shows up without this fix:
```
warning: `to_string()` called on a `&str`
   --> devolutions-gateway/src/api/webapp.rs:271:1
    |
271 | / #[utoipa::path(
272 | |     post,
273 | |     operation_id = "SignSessionToken",
274 | |     tag = "WebApp",
...   |
286 | |     ),
287 | | )]
    | |__^
    |
    = help: consider using `.to_owned()`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#str_to_string
    = note: this warning originates in the attribute macro `utoipa::path` (in Nightly builds, run with -Z macro-backtrace for more info)
```

~~There is no lint for the opposite ("use `to_string()` instead of `to_owned()`), so it seems safe to apply this fix.~~