### PR TITLE
Fix openapi serialized twice when Rapidoc is served with Rocket

### DIFF
--- a/utoipa-rapidoc/src/lib.rs
+++ b/utoipa-rapidoc/src/lib.rs
@@ -361,7 +361,7 @@ mod rocket {
                 routes.push(Route::new(
                     Method::Get,
                     value.spec_url.as_ref(),
-                    OpenApiHandler(openapi.to_json().expect("Should serialize to JSON")),
+                    OpenApiHandler(openapi),
                 ));
             }
 
@@ -380,7 +380,7 @@ mod rocket {
     }
 
     #[derive(Clone)]
-    struct OpenApiHandler(String);
+    struct OpenApiHandler(utoipa::openapi::OpenApi);
 
     #[rocket::async_trait]
     impl Handler for OpenApiHandler {


### PR DESCRIPTION
Hello,

When Rocket serves a Rapidoc built using `with_openapi`, the served `openapi.json` is the result of an `ApiDoc` serialized twice.

```rust
rocket::build()
    .mount(
        "/",
        RapiDoc::with_openapi("/api-docs/openapi.json", ApiDoc::openapi()).path("/rapidoc"),
    )
```

As a result, Rapidoc fails to load the spec:

![image](https://github.com/user-attachments/assets/d81494ca-a03b-4295-99e4-ec045a570e1b)

Inspecting the request response for `/api-docs/openapi.json` shows a "string of a json":

![image](https://github.com/user-attachments/assets/cc428271-d0b1-4c78-ab1f-1cddec388c16)

This PR is a fix proposal that resolves the double serialization.
After the fix, the spec now loads correctly and the `/api-docs/openapi.json` request response inspection shows "just a json":

![image](https://github.com/user-attachments/assets/307994db-588c-4fb9-bf67-949e5251f57a)

![image](https://github.com/user-attachments/assets/c30f2200-16d0-4012-93b2-27bd9f4df245)


