### PR TITLE
Fix samples in Rapidoc documentation when with_openapi is used

### DIFF
--- a/utoipa-rapidoc/README.md
+++ b/utoipa-rapidoc/README.md
@@ -76,7 +76,10 @@ _**Serve `RapiDoc` via `actix-web` framework.**_
 use actix_web::App;
 use utoipa_rapidoc::RapiDoc;
 
-App::new().service(RapiDoc::with_openapi("/rapidoc", ApiDoc::openapi()));
+App::new()
+    .service(
+        RapiDoc::with_openapi("/api-docs/openapi.json", ApiDoc::openapi()).path("/rapidoc")
+    );
 ```
 
 _**Serve `RapiDoc` via `rocket` framework.**_
@@ -86,16 +89,19 @@ use utoipa_rapidoc::RapiDoc;
 rocket::build()
     .mount(
         "/",
-        RapiDoc::with_openapi("/rapidoc", ApiDoc::openapi()),
+        RapiDoc::with_openapi("/api-docs/openapi.json", ApiDoc::openapi()).path("/rapidoc"),
     );
 ```
 
 _**Serve `RapiDoc` via `axum` framework.**_
- ```rust
- use axum::Router;
- use utoipa_rapidoc::RapiDoc;
- let app = Router::<S>::new()
-     .merge(RapiDoc::with_openapi("/rapidoc", ApiDoc::openapi()));
+```rust
+use axum::Router;
+use utoipa_rapidoc::RapiDoc;
+
+let app = Router::<S>::new()
+    .merge(
+        RapiDoc::with_openapi("/api-docs/openapi.json", ApiDoc::openapi()).path("/rapidoc")
+    );
 ```
 
 # License

--- a/utoipa-rapidoc/src/lib.rs
+++ b/utoipa-rapidoc/src/lib.rs
@@ -91,7 +91,10 @@
 //! # #[derive(OpenApi)]
 //! # #[openapi()]
 //! # struct ApiDoc;
-//! App::new().service(RapiDoc::with_openapi("/rapidoc", ApiDoc::openapi()));
+//! App::new()
+//!     .service(
+//!         RapiDoc::with_openapi("/api-docs/openapi.json", ApiDoc::openapi()).path("/rapidoc")
+//!     );
 //! ```
 //!
 //! _**Serve [`RapiDoc`] via `rocket` framework.**_
@@ -106,15 +109,15 @@
 //! rocket::build()
 //!     .mount(
 //!         "/",
-//!         RapiDoc::with_openapi("/rapidoc", ApiDoc::openapi()),
+//!         RapiDoc::with_openapi("/api-docs/openapi.json", ApiDoc::openapi()).path("/rapidoc"),
 //!     );
 //! ```
 //!
 //! _**Serve [`RapiDoc`] via `axum` framework.**_
-//!  ```no_run
-//!  use axum::Router;
-//!  use utoipa_rapidoc::RapiDoc;
-//!  # use utoipa::OpenApi;
+//! ```no_run
+//! use axum::Router;
+//! use utoipa_rapidoc::RapiDoc;
+//! # use utoipa::OpenApi;
 //! # #[derive(OpenApi)]
 //! # #[openapi()]
 //! # struct ApiDoc;
@@ -124,8 +127,10 @@
 //! #     S: Clone + Send + Sync + 'static,
 //! # {
 //!
-//!  let app = Router::<S>::new()
-//!      .merge(RapiDoc::with_openapi("/rapidoc", ApiDoc::openapi()));
+//! let app = Router::<S>::new()
+//!     .merge(
+//!         RapiDoc::with_openapi("/api-docs/openapi.json", ApiDoc::openapi()).path("/rapidoc")
+//!     );
 //! # }
 //! ```
 //!


### PR DESCRIPTION
Hello,

The examples provided in the Rapidoc readme for the `with_openapi` usage are breaking the build.
For instance, using the one for Rocket below: 

```rust
rocket::build()
    .mount(
        "/",
        RapiDoc::with_openapi("/rapidoc", ApiDoc::openapi()),
    );
```

Produce an error at build time:

```
Expected valid URIs: Error { expected: Expected::Token(Some("'/'"), None), index: 0 }
```

This PR fixes the examples by using the working examples from:
- https://github.com/juhaku/utoipa/tree/master/examples/todo-axum
- https://github.com/juhaku/utoipa/tree/master/examples/todo-actix
- https://github.com/juhaku/utoipa/tree/master/examples/rocket-todo