### PR TITLE
Fix respect `required` attribute

### DIFF
--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -477,13 +477,14 @@ impl ToTokensDiagnostics for NamedStructSchema<'_> {
                     object_tokens.extend(quote! {
                         .property(#name, #field_schema)
                     });
+                    let component_required =
+                        !is_option && super::is_required(field_rules, &container_rules);
+                    let required = match (required, component_required) {
+                        (Some(required), _) => required.is_true(),
+                        (None, component_required) => component_required,
+                    };
 
-                    if (!is_option && super::is_required(field_rules, &container_rules))
-                        || required
-                            .as_ref()
-                            .map(super::features::Required::is_true)
-                            .unwrap_or(false)
-                    {
+                    if required {
                         object_tokens.extend(quote! {
                             .required(#name)
                         })

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5497,3 +5497,74 @@ fn content_media_type_named_field() {
         })
     )
 }
+
+#[test]
+fn derive_schema_required_custom_type_required() {
+    #[allow(unused)]
+    struct Param<T>(T);
+
+    let value = api_doc! {
+        #[allow(unused)]
+        struct Params {
+            /// Maximum number of results to return.
+            #[schema(required = false, value_type = u32, example = 12)]
+            limit: Param<u32>,
+            /// Maximum number of results to return.
+            #[schema(required = true, value_type = u32, example = 12)]
+            limit_explisit_required: Param<u32>,
+            /// Maximum number of results to return.
+            #[schema(value_type = Option<u32>, example = 12)]
+            not_required: Param<u32>,
+            /// Maximum number of results to return.
+            #[schema(required = true, value_type = Option<u32>, example = 12)]
+            option_required: Param<u32>,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "limit": {
+                    "description": "Maximum number of results to return.",
+                    "example": 12,
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "limit_explisit_required": {
+                    "description": "Maximum number of results to return.",
+                    "example": 12,
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": "integer"
+                },
+                "not_required": {
+                    "description": "Maximum number of results to return.",
+                    "example": 12,
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "option_required": {
+                    "description": "Maximum number of results to return.",
+                    "example": 12,
+                    "format": "int32",
+                    "minimum": 0,
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            },
+            "type": "object",
+            "required": [
+                "limit_explisit_required",
+                "option_required"
+            ]
+        })
+    );
+}

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -657,7 +657,6 @@ mod tests {
         );
         let serialized = serde_json::to_string_pretty(&openapi)?;
 
-        dbg!(&raw_json);
         assert_eq!(
             serialized, raw_json,
             "expected serialized json to match raw: \nserialized: \n{serialized} \nraw: \n{raw_json}"


### PR DESCRIPTION
Prior to this PR the `required` attribute was not correctly respected in all cases. This was due to the fact that the `required` attribute had the same weight with the default rule that is checked from the option and some other serde attributes. Even this works in most cases but lacks control over explicitly defining `required` to false when type is not optional.

This PR fixes this by making clear separation between the default rule and the manual `required` attribute with preference on the manually defined `required` attribute.

Fixes #882