### PR TITLE
Add support to define mulitple operation methods

### DIFF
--- a/examples/axum-utoipa-nesting-vendored/src/main.rs
+++ b/examples/axum-utoipa-nesting-vendored/src/main.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Error> {
     let hello_api =
         Into::<OpenApiBuilder>::into(HelloApi::openapi()).paths(PathsBuilder::new().path(
             "",
-            PathItem::new(utoipa::openapi::PathItemType::Get, Operation::new()),
+            PathItem::new(utoipa::openapi::HttpMethod::Get, Operation::new()),
         ));
 
     let mut doc = ApiDoc::openapi();

--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -51,10 +51,8 @@
 
 pub mod router;
 
-use core::panic;
-
 use axum::routing::MethodFilter;
-use utoipa::openapi::PathItemType;
+use utoipa::openapi::HttpMethod;
 
 /// Extends [`utoipa::openapi::path::PathItem`] by providing conversion methods to convert this
 /// path item type to a [`axum::routing::MethodFilter`].
@@ -62,28 +60,20 @@ pub trait PathItemExt {
     /// Convert this path item type ot a [`axum::routing::MethodFilter`].
     ///
     /// Method filter is used with handler registration on [`axum::routing::MethodRouter`].
-    ///
-    /// # Panics
-    ///
-    /// [`utoipa::openapi::path::PathItemType::Connect`] will panic because _`axum`_ does not have
-    /// `CONNECT` type [`axum::routing::MethodFilter`].
     fn to_method_filter(&self) -> MethodFilter;
 }
 
-impl PathItemExt for PathItemType {
+impl PathItemExt for HttpMethod {
     fn to_method_filter(&self) -> MethodFilter {
         match self {
-            PathItemType::Get => MethodFilter::GET,
-            PathItemType::Put => MethodFilter::PUT,
-            PathItemType::Post => MethodFilter::POST,
-            PathItemType::Head => MethodFilter::HEAD,
-            PathItemType::Patch => MethodFilter::PATCH,
-            PathItemType::Trace => MethodFilter::TRACE,
-            PathItemType::Delete => MethodFilter::DELETE,
-            PathItemType::Options => MethodFilter::OPTIONS,
-            PathItemType::Connect => panic!(
-                "`CONNECT` not supported, axum does not have `MethodFilter` for connect requests"
-            ),
+            HttpMethod::Get => MethodFilter::GET,
+            HttpMethod::Put => MethodFilter::PUT,
+            HttpMethod::Post => MethodFilter::POST,
+            HttpMethod::Head => MethodFilter::HEAD,
+            HttpMethod::Patch => MethodFilter::PATCH,
+            HttpMethod::Trace => MethodFilter::TRACE,
+            HttpMethod::Delete => MethodFilter::DELETE,
+            HttpMethod::Options => MethodFilter::OPTIONS,
         }
     }
 }
@@ -264,14 +254,14 @@ mod tests {
             .path(
                 "/",
                 utoipa::openapi::PathItem::new(
-                    utoipa::openapi::path::PathItemType::Get,
+                    utoipa::openapi::path::HttpMethod::Get,
                     utoipa::openapi::path::OperationBuilder::new().operation_id(Some("get_user")),
                 ),
             )
             .path(
                 "/search",
                 utoipa::openapi::PathItem::new(
-                    utoipa::openapi::path::PathItemType::Get,
+                    utoipa::openapi::path::HttpMethod::Get,
                     utoipa::openapi::path::OperationBuilder::new()
                         .operation_id(Some("search_user")),
                 ),
@@ -305,7 +295,7 @@ mod tests {
             .path(
                 "/api/customer/",
                 utoipa::openapi::PathItem::new(
-                    utoipa::openapi::path::PathItemType::Get,
+                    utoipa::openapi::path::HttpMethod::Get,
                     utoipa::openapi::path::OperationBuilder::new()
                         .operation_id(Some("get_customer")),
                 ),
@@ -313,7 +303,7 @@ mod tests {
             .path(
                 "/search",
                 utoipa::openapi::PathItem::new(
-                    utoipa::openapi::path::PathItemType::Get,
+                    utoipa::openapi::path::HttpMethod::Get,
                     utoipa::openapi::path::OperationBuilder::new()
                         .operation_id(Some("search_user")),
                 ),

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -7,7 +7,7 @@ use syn::{Attribute, GenericArgument, Path, PathArguments, PathSegment, Type, Ty
 
 use crate::doc_comment::CommentAttributes;
 use crate::schema_type::{SchemaFormat, SchemaTypeInner};
-use crate::{as_tokens_or_diagnostics, Diagnostics, OptionExt, ToTokensDiagnostics};
+use crate::{as_tokens_or_diagnostics, AttributesExt, Diagnostics, OptionExt, ToTokensDiagnostics};
 use crate::{schema_type::SchemaType, Deprecated};
 
 use self::features::{
@@ -32,18 +32,11 @@ fn is_default(container_rules: &SerdeContainer, field_rule: &SerdeValue) -> bool
 /// Find `#[deprecated]` attribute from given attributes. Typically derive type attributes
 /// or field attributes of struct.
 fn get_deprecated(attributes: &[Attribute]) -> Option<Deprecated> {
-    attributes.iter().find_map(|attribute| {
-        if attribute
-            .path()
-            .get_ident()
-            .map(|ident| *ident == "deprecated")
-            .unwrap_or(false)
-        {
-            Some(Deprecated::True)
-        } else {
-            None
-        }
-    })
+    if attributes.has_deprecated() {
+        Some(Deprecated::True)
+    } else {
+        None
+    }
 }
 
 /// Check whether field is required based on following rules.

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -10,7 +10,7 @@ use syn::spanned::Spanned;
 use syn::{punctuated::Punctuated, token::Comma, ItemFn};
 
 use crate::component::{ComponentSchema, ComponentSchemaProps, TypeTree};
-use crate::path::{PathOperation, PathTypeTree};
+use crate::path::{OperationMethod, PathTypeTree};
 use crate::{as_tokens_or_diagnostics, Diagnostics, ToTokensDiagnostics};
 
 #[cfg(feature = "auto_into_responses")]
@@ -261,7 +261,7 @@ pub struct ArgValue {
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct ResolvedOperation {
-    pub path_operation: PathOperation,
+    pub operation_method: Vec<OperationMethod>,
     pub path: String,
     #[allow(unused)] // this is needed only if axum, actix or rocket
     pub body: String,
@@ -324,7 +324,6 @@ impl PathOperationResolver for PathOperations {}
 pub mod fn_arg {
 
     use proc_macro2::Ident;
-    // use proc_macro_error::abort;
     #[cfg(any(feature = "actix_extras", feature = "axum_extras"))]
     use quote::quote;
     use syn::spanned::Spanned;

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -1,8 +1,5 @@
 use std::borrow::Cow;
 
-#[cfg(feature = "rocket_extras")]
-use std::cmp::Ordering;
-
 use proc_macro2::TokenStream;
 use quote::{quote, quote_spanned};
 use syn::parse_quote;
@@ -239,7 +236,7 @@ pub enum MacroArg {
 impl MacroArg {
     /// Get ordering by name
     #[cfg(feature = "rocket_extras")]
-    fn by_name(a: &MacroArg, b: &MacroArg) -> Ordering {
+    fn by_name(a: &MacroArg, b: &MacroArg) -> std::cmp::Ordering {
         a.get_value().name.cmp(&b.get_value().name)
     }
 
@@ -261,7 +258,7 @@ pub struct ArgValue {
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct ResolvedOperation {
-    pub operation_method: Vec<HttpMethod>,
+    pub methods: Vec<HttpMethod>,
     pub path: String,
     #[allow(unused)] // this is needed only if axum, actix or rocket
     pub body: String,
@@ -349,10 +346,10 @@ pub mod fn_arg {
         Destructed(Vec<&'t Ident>),
     }
 
+    #[cfg(feature = "rocket_extras")]
     impl FnArgType<'_> {
         /// Get best effort name `Ident` for the type. For `FnArgType::Tuple` types it will take the first one
         /// from `Vec`.
-        #[cfg(feature = "rocket_extras")]
         pub(super) fn get_name(&self) -> &Ident {
             match self {
                 Self::Single(ident) => ident,

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -10,7 +10,7 @@ use syn::spanned::Spanned;
 use syn::{punctuated::Punctuated, token::Comma, ItemFn};
 
 use crate::component::{ComponentSchema, ComponentSchemaProps, TypeTree};
-use crate::path::{OperationMethod, PathTypeTree};
+use crate::path::{HttpMethod, PathTypeTree};
 use crate::{as_tokens_or_diagnostics, Diagnostics, ToTokensDiagnostics};
 
 #[cfg(feature = "auto_into_responses")]
@@ -261,7 +261,7 @@ pub struct ArgValue {
 
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct ResolvedOperation {
-    pub operation_method: Vec<OperationMethod>,
+    pub operation_method: Vec<HttpMethod>,
     pub path: String,
     #[allow(unused)] // this is needed only if axum, actix or rocket
     pub body: String,

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -7,7 +7,7 @@ use syn::{parse::Parse, punctuated::Punctuated, token::Comma, ItemFn, LitStr};
 use crate::{
     component::{TypeTree, ValueType},
     ext::ArgValue,
-    path::PathOperation,
+    path::OperationMethod,
     Diagnostics,
 };
 
@@ -117,7 +117,7 @@ impl PathOperationResolver for PathOperations {
                 if is_valid_request_type(attribute.path().get_ident()) {
                     match attribute.parse_args::<Path>() {
                         Ok(path) => {
-                            let path_operation = match PathOperation::from_ident(
+                            let operation_method = match OperationMethod::from_ident(
                                 attribute.path().get_ident().unwrap(),
                             ) {
                                 Ok(path_operation) => path_operation,
@@ -126,16 +126,11 @@ impl PathOperationResolver for PathOperations {
 
                             Some(Ok(ResolvedOperation {
                                 path: path.0,
-                                path_operation,
+                                operation_method: vec![operation_method],
                                 body: String::new(),
                             }))
                         }
                         Err(error) => Some(Err(Into::<Diagnostics>::into(error))),
-                        // Err(error) => abort!(
-                        //     error.span(),
-                        //     "parse path of path operation attribute: {}",
-                        //     error
-                        // ),
                     }
                 } else {
                     None

--- a/utoipa-gen/src/ext/actix.rs
+++ b/utoipa-gen/src/ext/actix.rs
@@ -7,7 +7,7 @@ use syn::{parse::Parse, punctuated::Punctuated, token::Comma, ItemFn, LitStr};
 use crate::{
     component::{TypeTree, ValueType},
     ext::ArgValue,
-    path::OperationMethod,
+    path::HttpMethod,
     Diagnostics,
 };
 
@@ -117,12 +117,12 @@ impl PathOperationResolver for PathOperations {
                 if is_valid_request_type(attribute.path().get_ident()) {
                     match attribute.parse_args::<Path>() {
                         Ok(path) => {
-                            let operation_method = match OperationMethod::from_ident(
-                                attribute.path().get_ident().unwrap(),
-                            ) {
-                                Ok(path_operation) => path_operation,
-                                Err(diagnostics) => return Some(Err(diagnostics)),
-                            };
+                            let operation_method =
+                                match HttpMethod::from_ident(attribute.path().get_ident().unwrap())
+                                {
+                                    Ok(path_operation) => path_operation,
+                                    Err(diagnostics) => return Some(Err(diagnostics)),
+                                };
 
                             Some(Ok(ResolvedOperation {
                                 path: path.0,

--- a/utoipa-gen/src/ext/rocket.rs
+++ b/utoipa-gen/src/ext/rocket.rs
@@ -8,7 +8,7 @@ use syn::{parse::Parse, LitStr, Token};
 use crate::{
     component::ValueType,
     ext::{ArgValue, ArgumentIn, MacroArg, ValueArgument},
-    path::PathOperation,
+    path::OperationMethod,
     Diagnostics, OptionExt,
 };
 
@@ -170,15 +170,15 @@ impl PathOperationResolver for PathOperations {
                 )| {
                     if !operation.is_empty() {
                         Ok(ResolvedOperation {
-                            path_operation: PathOperation::from_str(&operation).unwrap(),
+                            operation_method: vec![OperationMethod::from_str(&operation).unwrap()],
                             path,
                             body,
                         })
                     } else {
                         Ok(ResolvedOperation {
-                            path_operation: PathOperation::from_ident(
+                            operation_method: vec![OperationMethod::from_ident(
                                 attribute.path().get_ident().unwrap(),
-                            )?,
+                            )?],
                             path,
                             body,
                         })

--- a/utoipa-gen/src/ext/rocket.rs
+++ b/utoipa-gen/src/ext/rocket.rs
@@ -170,13 +170,13 @@ impl PathOperationResolver for PathOperations {
                 )| {
                     if !operation.is_empty() {
                         Ok(ResolvedOperation {
-                            operation_method: vec![HttpMethod::from_str(&operation).unwrap()],
+                            methods: vec![HttpMethod::from_str(&operation).unwrap()],
                             path,
                             body,
                         })
                     } else {
                         Ok(ResolvedOperation {
-                            operation_method: vec![HttpMethod::from_ident(
+                            methods: vec![HttpMethod::from_ident(
                                 attribute.path().get_ident().unwrap(),
                             )?],
                             path,

--- a/utoipa-gen/src/ext/rocket.rs
+++ b/utoipa-gen/src/ext/rocket.rs
@@ -8,7 +8,7 @@ use syn::{parse::Parse, LitStr, Token};
 use crate::{
     component::ValueType,
     ext::{ArgValue, ArgumentIn, MacroArg, ValueArgument},
-    path::OperationMethod,
+    path::HttpMethod,
     Diagnostics, OptionExt,
 };
 
@@ -170,13 +170,13 @@ impl PathOperationResolver for PathOperations {
                 )| {
                     if !operation.is_empty() {
                         Ok(ResolvedOperation {
-                            operation_method: vec![OperationMethod::from_str(&operation).unwrap()],
+                            operation_method: vec![HttpMethod::from_str(&operation).unwrap()],
                             path,
                             body,
                         })
                     } else {
                         Ok(ResolvedOperation {
-                            operation_method: vec![OperationMethod::from_ident(
+                            operation_method: vec![HttpMethod::from_ident(
                                 attribute.path().get_ident().unwrap(),
                             )?],
                             path,

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -10,6 +10,15 @@
 #[cfg(all(feature = "decimal", feature = "decimal_float"))]
 compile_error!("`decimal` and `decimal_float` are mutually exclusive feature flags");
 
+#[cfg(all(
+    feature = "actix_extras",
+    feature = "axum_extras",
+    feature = "rocket_extras"
+))]
+compile_error!(
+    "`actix_extras`, `axum_extras` and `rocket_extras` are mutually exclusive feature flags"
+);
+
 use std::{
     borrow::{Borrow, Cow},
     error::Error,
@@ -1386,12 +1395,12 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
         };
     }
 
-    let mut resolved_operation = match PathOperations::resolve_operation(&ast_fn) {
+    let mut resolved_methods = match PathOperations::resolve_operation(&ast_fn) {
         Ok(operation) => operation,
         Err(diagnostics) => return diagnostics.into_token_stream().into(),
     };
     let resolved_path = PathOperations::resolve_path(
-        &resolved_operation
+        &resolved_methods
             .as_mut()
             .map(|operation| mem::take(&mut operation.path).to_string())
             .or_else(|| path_attribute.path.as_ref().map(|path| path.to_string())), // cannot use mem take because we need this later
@@ -1413,7 +1422,7 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
         use ext::ArgumentResolver;
         use path::parameter::Parameter;
         let path_args = resolved_path.as_mut().map(|path| mem::take(&mut path.args));
-        let body = resolved_operation
+        let body = resolved_methods
             .as_mut()
             .map(|path| mem::take(&mut path.body))
             .unwrap_or_default();
@@ -1435,18 +1444,10 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
     }
 
     let path = Path::new(path_attribute, &ast_fn.sig.ident)
-        .path_operation(resolved_operation.map(|operation| operation.path_operation))
+        .ext_method_operations(resolved_methods.map(|operation| operation.operation_method))
         .path(|| resolved_path.map(|path| path.path))
         .doc_comments(CommentAttributes::from_attributes(&ast_fn.attrs).0)
-        .deprecated(ast_fn.attrs.iter().find_map(|attr| {
-
-            if !matches!(attr.path().get_ident(), Some(ident) if &*ident.to_string() == "deprecated")
-            {
-                None
-            } else {
-                Some(true)
-            }
-        }));
+        .deprecated(ast_fn.attrs.has_deprecated());
 
     let handler = path::handler::Handler {
         path,
@@ -2919,6 +2920,148 @@ macro_rules! as_tokens_or_diagnostics {
 
 use as_tokens_or_diagnostics;
 
+#[derive(Debug)]
+struct Diagnostics {
+    diagnostics: Vec<DiangosticsInner>,
+}
+
+#[derive(Debug)]
+struct DiangosticsInner {
+    span: Span,
+    message: Cow<'static, str>,
+    suggestions: Vec<Suggestion>,
+}
+
+#[derive(Debug)]
+enum Suggestion {
+    Help(Cow<'static, str>),
+    Note(Cow<'static, str>),
+}
+
+impl Display for Diagnostics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message())
+    }
+}
+
+impl Display for Suggestion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Help(help) => {
+                let s: &str = help.borrow();
+                write!(f, "help = {}", s)
+            }
+            Self::Note(note) => {
+                let s: &str = note.borrow();
+                write!(f, "note = {}", s)
+            }
+        }
+    }
+}
+
+impl Diagnostics {
+    fn message(&self) -> Cow<'static, str> {
+        self.diagnostics
+            .first()
+            .as_ref()
+            .map(|diagnostics| diagnostics.message.clone())
+            .unwrap_or_else(|| Cow::Borrowed(""))
+    }
+
+    pub fn new<S: Into<Cow<'static, str>>>(message: S) -> Self {
+        Self::with_span(Span::call_site(), message)
+    }
+
+    pub fn with_span<S: Into<Cow<'static, str>>>(span: Span, message: S) -> Self {
+        Self {
+            diagnostics: vec![DiangosticsInner {
+                span,
+                message: message.into(),
+                suggestions: Vec::new(),
+            }],
+        }
+    }
+
+    pub fn help<S: Into<Cow<'static, str>>>(mut self, help: S) -> Self {
+        if let Some(diagnostics) = self.diagnostics.first_mut() {
+            diagnostics.suggestions.push(Suggestion::Help(help.into()));
+        }
+
+        self
+    }
+
+    pub fn note<S: Into<Cow<'static, str>>>(mut self, note: S) -> Self {
+        if let Some(diagnostics) = self.diagnostics.first_mut() {
+            diagnostics.suggestions.push(Suggestion::Note(note.into()));
+        }
+
+        self
+    }
+}
+
+impl From<syn::Error> for Diagnostics {
+    fn from(value: syn::Error) -> Self {
+        Self::with_span(value.span(), value.to_string())
+    }
+}
+
+impl ToTokens for Diagnostics {
+    fn to_tokens(&self, tokens: &mut TokenStream2) {
+        for diagnostics in &self.diagnostics {
+            let span = diagnostics.span;
+            let message: &str = diagnostics.message.borrow();
+
+            let suggestions = diagnostics
+                .suggestions
+                .iter()
+                .map(Suggestion::to_string)
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let diagnostics = if !suggestions.is_empty() {
+                Cow::Owned(format!("{message}\n\n{suggestions}"))
+            } else {
+                Cow::Borrowed(message)
+            };
+
+            tokens.extend(quote_spanned! {span=>
+                ::core::compile_error!(#diagnostics);
+            })
+        }
+    }
+}
+
+impl Error for Diagnostics {}
+
+impl FromIterator<Diagnostics> for Option<Diagnostics> {
+    fn from_iter<T: IntoIterator<Item = Diagnostics>>(iter: T) -> Self {
+        iter.into_iter().reduce(|mut acc, diagnostics| {
+            acc.diagnostics.extend(diagnostics.diagnostics);
+            acc
+        })
+    }
+}
+
+trait AttributesExt {
+    fn has_deprecated(&self) -> bool;
+}
+
+impl AttributesExt for Vec<syn::Attribute> {
+    fn has_deprecated(&self) -> bool {
+        self.iter().any(|attr| {
+            matches!(attr.path().get_ident(), Some(ident) if &*ident.to_string() == "deprecated")
+        })
+    }
+}
+
+impl<'a> AttributesExt for &'a [syn::Attribute] {
+    fn has_deprecated(&self) -> bool {
+        self.iter().any(|attr| {
+            matches!(attr.path().get_ident(), Some(ident) if &*ident.to_string() == "deprecated")
+        })
+    }
+}
+
 /// Parsing utils
 mod parse_utils {
     use std::fmt::Display;
@@ -3104,127 +3247,5 @@ mod parse_utils {
                 }
             }
         }
-    }
-}
-
-#[derive(Debug)]
-struct Diagnostics {
-    diagnostics: Vec<DiangosticsInner>,
-}
-
-#[derive(Debug)]
-struct DiangosticsInner {
-    span: Span,
-    message: Cow<'static, str>,
-    suggestions: Vec<Suggestion>,
-}
-
-#[derive(Debug)]
-enum Suggestion {
-    Help(Cow<'static, str>),
-    Note(Cow<'static, str>),
-}
-
-impl Display for Diagnostics {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message())
-    }
-}
-
-impl Display for Suggestion {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Help(help) => {
-                let s: &str = help.borrow();
-                write!(f, "help = {}", s)
-            }
-            Self::Note(note) => {
-                let s: &str = note.borrow();
-                write!(f, "note = {}", s)
-            }
-        }
-    }
-}
-
-impl Diagnostics {
-    fn message(&self) -> Cow<'static, str> {
-        self.diagnostics
-            .first()
-            .as_ref()
-            .map(|diagnostics| diagnostics.message.clone())
-            .unwrap_or_else(|| Cow::Borrowed(""))
-    }
-
-    pub fn new<S: Into<Cow<'static, str>>>(message: S) -> Self {
-        Self::with_span(Span::call_site(), message)
-    }
-
-    pub fn with_span<S: Into<Cow<'static, str>>>(span: Span, message: S) -> Self {
-        Self {
-            diagnostics: vec![DiangosticsInner {
-                span,
-                message: message.into(),
-                suggestions: Vec::new(),
-            }],
-        }
-    }
-
-    pub fn help<S: Into<Cow<'static, str>>>(mut self, help: S) -> Self {
-        if let Some(diagnostics) = self.diagnostics.first_mut() {
-            diagnostics.suggestions.push(Suggestion::Help(help.into()));
-        }
-
-        self
-    }
-
-    pub fn note<S: Into<Cow<'static, str>>>(mut self, note: S) -> Self {
-        if let Some(diagnostics) = self.diagnostics.first_mut() {
-            diagnostics.suggestions.push(Suggestion::Note(note.into()));
-        }
-
-        self
-    }
-}
-
-impl From<syn::Error> for Diagnostics {
-    fn from(value: syn::Error) -> Self {
-        Self::with_span(value.span(), value.to_string())
-    }
-}
-
-impl ToTokens for Diagnostics {
-    fn to_tokens(&self, tokens: &mut TokenStream2) {
-        for diagnostics in &self.diagnostics {
-            let span = diagnostics.span;
-            let message: &str = diagnostics.message.borrow();
-
-            let suggestions = diagnostics
-                .suggestions
-                .iter()
-                .map(Suggestion::to_string)
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            let diagnostics = if !suggestions.is_empty() {
-                Cow::Owned(format!("{message}\n\n{suggestions}"))
-            } else {
-                Cow::Borrowed(message)
-            };
-
-            tokens.extend(quote_spanned! {span=>
-                ::core::compile_error!(#diagnostics);
-            })
-        }
-    }
-}
-
-impl Error for Diagnostics {}
-
-impl FromIterator<Diagnostics> for Option<Diagnostics> {
-    fn from_iter<T: IntoIterator<Item = Diagnostics>>(iter: T) -> Self {
-        iter.into_iter().reduce(|mut acc, diagnostics| {
-            acc.diagnostics.extend(diagnostics.diagnostics);
-            acc
-        })
     }
 }

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -633,15 +633,20 @@ fn impl_paths(handler_paths: &Punctuated<ExprPath, Comma>) -> TokenStream {
                 struct #handler_ident_nested;
                 #[allow(non_camel_case_types)]
                 impl utoipa::__dev::PathConfig for #handler_ident_nested {
-                    fn config() -> (String, Vec<&'static str>, utoipa::openapi::path::PathItem) {
-                        let item = #usage::path_item();
-                        let path = #usage::path();
+                    fn path() -> String {
+                        #usage::path()
+                    }
+                    fn methods() -> Vec<utoipa::openapi::path::PathItemType> {
+                        #usage::methods()
+                    }
+                    fn tags_and_operation() -> (Vec<&'static str>, utoipa::openapi::path::Operation) {
+                        let item = #usage::operation();
                         let mut tags = <#usage as utoipa::__dev::Tags>::tags();
                         if !#tag.is_empty() && tags.is_empty() {
                             tags.push(#tag);
                         }
 
-                        (path, tags, item)
+                        (tags, item)
                     }
                 }
             }

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -636,7 +636,7 @@ fn impl_paths(handler_paths: &Punctuated<ExprPath, Comma>) -> TokenStream {
                     fn path() -> String {
                         #usage::path()
                     }
-                    fn methods() -> Vec<utoipa::openapi::path::PathItemType> {
+                    fn methods() -> Vec<utoipa::openapi::path::HttpMethod> {
                         #usage::methods()
                     }
                     fn tags_and_operation() -> (Vec<&'static str>, utoipa::openapi::path::Operation) {

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -2339,7 +2339,7 @@ fn path_nest_without_any_tags() {
 fn derive_path_with_multiple_methods() {
     #[allow(dead_code)]
     #[utoipa::path(
-        method = [head, get],
+        method(head, get),
         path = "/test-multiple",
         responses(
             (status = 200, description = "success response")

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -98,7 +98,6 @@ test_path_operation! {
     derive_path_head: head
     derive_path_patch: patch
     derive_path_trace: trace
-    derive_path_connect: connect
 }
 
 macro_rules! api_fn_doc_with_params {

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -1926,8 +1926,8 @@ fn derive_path_with_const_expression_context_path() {
     const FOOBAR: &str = "/api/v1/prefix";
 
     #[utoipa::path(
-        context_path = FOOBAR,
         get,
+        context_path = FOOBAR,
         path = "/items",
         responses(
             (status = 200, description = "success response")
@@ -1952,8 +1952,8 @@ fn derive_path_with_const_expression_reference_context_path() {
     const FOOBAR: &str = "/api/v1/prefix";
 
     #[utoipa::path(
-        context_path = &FOOBAR,
         get,
+        context_path = &FOOBAR,
         path = "/items",
         responses(
             (status = 200, description = "success response")
@@ -2331,6 +2331,55 @@ fn path_nest_without_any_tags() {
                     "responses": {},
                     "tags": []
                 },
+            }
+        })
+    );
+}
+
+#[test]
+fn derive_path_with_multiple_methods() {
+    #[allow(dead_code)]
+    #[utoipa::path(
+        method = [head, get],
+        path = "/test-multiple",
+        responses(
+            (status = 200, description = "success response")
+        ),
+    )]
+    #[allow(unused)]
+    async fn test_multiple() -> &'static str {
+        ""
+    }
+    use utoipa::OpenApi;
+    #[derive(OpenApi, Default)]
+    #[openapi(paths(test_multiple))]
+    struct ApiDoc;
+
+    let doc = &serde_json::to_value(ApiDoc::openapi()).unwrap();
+    let paths = doc.pointer("/paths").expect("OpenApi must have paths");
+
+    assert_json_eq!(
+        &paths,
+        json!({
+            "/test-multiple": {
+                "get": {
+                    "operationId": "test_multiple",
+                    "responses": {
+                        "200": {
+                            "description": "success response",
+                        },
+                    },
+                    "tags": []
+                },
+                "head": {
+                    "operationId": "test_multiple",
+                    "responses": {
+                        "200": {
+                            "description": "success response",
+                        },
+                    },
+                    "tags": []
+                }
             }
         })
     );

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -1097,7 +1097,6 @@ test_derive_path_operations! {
     derive_path_operation_delete, mod_test_delete: delete
     derive_path_operation_put, mod_test_put: put
     derive_path_operation_head, mod_test_head: head
-    derive_path_operation_connect, mod_test_connect: connect
     derive_path_operation_options, mod_test_options: options
     derive_path_operation_trace, mod_test_trace: trace
     derive_path_operation_patch, mod_test_patch: patch

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -1,15 +1,14 @@
 #![cfg(feature = "actix_extras")]
 
-use std::{fmt::Display, future::Ready};
-
 use actix_web::{
-    get, post,
+    get, post, route,
     web::{Json, Path, Query},
-    FromRequest, ResponseError,
+    FromRequest, Responder, ResponseError,
 };
 use assert_json_diff::assert_json_eq;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::{fmt::Display, future::Ready, todo};
 use utoipa::{
     openapi::{
         path::{Parameter, ParameterBuilder, ParameterIn},
@@ -1100,4 +1099,27 @@ test_derive_path_operations! {
     derive_path_operation_options, mod_test_options: options
     derive_path_operation_trace, mod_test_trace: trace
     derive_path_operation_patch, mod_test_patch: patch
+}
+
+#[test]
+fn derive_path_with_mulitple_methods_skip_connect() {
+    #[utoipa::path(
+        responses(
+            (status = 200, description = "success response")
+        )
+    )]
+    #[route("/route foo", method = "GET", method = "HEAD", method = "CONNECT")]
+    #[allow(unused)]
+    async fn mulitple_methods() -> impl Responder {
+        String::new()
+    }
+
+    use utoipa::Path;
+    assert_eq!(
+        vec![
+            utoipa::openapi::path::HttpMethod::Get,
+            utoipa::openapi::path::HttpMethod::Head
+        ],
+        __path_mulitple_methods::methods()
+    )
 }

--- a/utoipa-gen/tests/path_parameter_derive_test.rs
+++ b/utoipa-gen/tests/path_parameter_derive_test.rs
@@ -357,9 +357,9 @@ macro_rules! into_params {
             #[allow(unused)]
             fn handler() {}
 
-            let value = serde_json::to_value(&__path_handler::path_item())
+            let value = serde_json::to_value(__path_handler::operation())
                 .expect("path item should serialize to json");
-            value.pointer("/get/parameters").expect("should have get/handler").clone()
+            value.pointer("/parameters").expect("operation should have parameters").clone()
         }
     };
 }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -675,7 +675,7 @@ impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for Option<HashMap
 /// utoipa::openapi::PathsBuilder::new().path(
 ///         "/pets/{id}",
 ///         utoipa::openapi::PathItem::new(
-///             utoipa::openapi::PathItemType::Get,
+///             utoipa::openapi::HttpMethod::Get,
 ///             utoipa::openapi::path::OperationBuilder::new()
 ///                 .responses(
 ///                     utoipa::openapi::ResponsesBuilder::new()
@@ -715,7 +715,7 @@ impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for Option<HashMap
 ///
 /// [derive]: attr.path.html
 pub trait Path {
-    fn methods() -> Vec<openapi::path::PathItemType>;
+    fn methods() -> Vec<openapi::path::HttpMethod>;
 
     fn path() -> String;
 
@@ -946,7 +946,7 @@ pub mod __dev {
     pub trait PathConfig {
         fn path() -> String;
 
-        fn methods() -> Vec<crate::openapi::path::PathItemType>;
+        fn methods() -> Vec<crate::openapi::path::HttpMethod>;
 
         fn tags_and_operation() -> (Vec<&'static str>, utoipa::openapi::path::Operation);
     }
@@ -960,7 +960,7 @@ pub mod __dev {
             <Self as PathConfig>::path()
         }
 
-        fn methods() -> Vec<crate::openapi::path::PathItemType> {
+        fn methods() -> Vec<crate::openapi::path::HttpMethod> {
             <Self as PathConfig>::methods()
         }
 

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -715,9 +715,11 @@ impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for Option<HashMap
 ///
 /// [derive]: attr.path.html
 pub trait Path {
+    fn methods() -> Vec<openapi::path::PathItemType>;
+
     fn path() -> String;
 
-    fn path_item() -> openapi::path::PathItem;
+    fn operation() -> openapi::path::Operation;
 }
 
 /// Trait that allows OpenApi modification at runtime.
@@ -939,12 +941,14 @@ pub trait ToResponse<'__r> {
 /// Internal dev module used internally by utoipa-gen
 #[doc(hidden)]
 pub mod __dev {
-
-    use crate::openapi::PathItemType;
     use crate::{utoipa, OpenApi};
 
     pub trait PathConfig {
-        fn config() -> (String, Vec<&'static str>, utoipa::openapi::path::PathItem);
+        fn path() -> String;
+
+        fn methods() -> Vec<crate::openapi::path::PathItemType>;
+
+        fn tags_and_operation() -> (Vec<&'static str>, utoipa::openapi::path::Operation);
     }
 
     pub trait Tags<'t> {
@@ -953,18 +957,20 @@ pub mod __dev {
 
     impl<T: PathConfig> utoipa::Path for T {
         fn path() -> String {
-            <Self as PathConfig>::config().0.to_string()
+            <Self as PathConfig>::path()
         }
 
-        fn path_item() -> crate::openapi::path::PathItem {
-            let (_, tags, mut item) = <Self as PathConfig>::config();
+        fn methods() -> Vec<crate::openapi::path::PathItemType> {
+            <Self as PathConfig>::methods()
+        }
 
-            for (_, operation) in item.operations.iter_mut() {
-                let operation_tags = operation.tags.get_or_insert(Vec::new());
-                operation_tags.extend(tags.iter().map(ToString::to_string));
-            }
+        fn operation() -> crate::openapi::path::Operation {
+            let (tags, mut operation) = <Self as PathConfig>::tags_and_operation();
 
-            item
+            let operation_tags = operation.tags.get_or_insert(Vec::new());
+            operation_tags.extend(tags.iter().map(ToString::to_string));
+
+            operation
         }
     }
 
@@ -990,10 +996,6 @@ pub mod __dev {
 
             api
         }
-    }
-
-    pub trait PathItemTypes {
-        fn path_item_types() -> Vec<PathItemType>;
     }
 }
 

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -12,7 +12,7 @@ pub use self::{
     external_docs::ExternalDocs,
     header::{Header, HeaderBuilder},
     info::{Contact, ContactBuilder, Info, InfoBuilder, License, LicenseBuilder},
-    path::{PathItem, PathItemType, Paths, PathsBuilder},
+    path::{HttpMethod, PathItem, Paths, PathsBuilder},
     response::{Response, ResponseBuilder, Responses, ResponsesBuilder},
     schema::{
         AllOf, AllOfBuilder, Array, ArrayBuilder, Components, ComponentsBuilder, Discriminator,
@@ -255,13 +255,13 @@ impl OpenApi {
     /// ```rust
     ///  # use utoipa::openapi::{OpenApi, OpenApiBuilder};
     ///  # use utoipa::openapi::path::{PathsBuilder, PathItemBuilder, PathItem,
-    ///  # PathItemType, OperationBuilder};
+    ///  # HttpMethod, OperationBuilder};
     ///  let api = OpenApiBuilder::new()
     ///      .paths(
     ///          PathsBuilder::new().path(
     ///              "/api/v1/status",
     ///              PathItem::new(
-    ///                  PathItemType::Get,
+    ///                  HttpMethod::Get,
     ///                  OperationBuilder::new()
     ///                      .description(Some("Get status"))
     ///                      .build(),
@@ -273,7 +273,7 @@ impl OpenApi {
     ///     .paths(
     ///         PathsBuilder::new().path(
     ///             "/",
-    ///             PathItem::new(PathItemType::Post, OperationBuilder::new().build()),
+    ///             PathItem::new(HttpMethod::Post, OperationBuilder::new().build()),
     ///         )
     ///     )
     ///     .build();
@@ -672,21 +672,21 @@ mod tests {
                 .path(
                     "/api/v1/users",
                     PathItem::new(
-                        PathItemType::Get,
+                        HttpMethod::Get,
                         OperationBuilder::new().response("200", Response::new("Get users list")),
                     ),
                 )
                 .path(
                     "/api/v1/users",
                     PathItem::new(
-                        PathItemType::Post,
+                        HttpMethod::Post,
                         OperationBuilder::new().response("200", Response::new("Post new user")),
                     ),
                 )
                 .path(
                     "/api/v1/users/{id}",
                     PathItem::new(
-                        PathItemType::Get,
+                        HttpMethod::Get,
                         OperationBuilder::new().response("200", Response::new("Get user by id")),
                     ),
                 ),
@@ -710,7 +710,7 @@ mod tests {
                 .path(
                     "/api/v1/user",
                     PathItem::new(
-                        PathItemType::Get,
+                        HttpMethod::Get,
                         OperationBuilder::new().response("200", Response::new("Get user success")),
                     ),
                 )
@@ -724,7 +724,7 @@ mod tests {
                     .path(
                         "/api/v1/user",
                         PathItem::new(
-                            PathItemType::Get,
+                            HttpMethod::Get,
                             OperationBuilder::new()
                                 .response("200", Response::new("This will not get added")),
                         ),
@@ -732,7 +732,7 @@ mod tests {
                     .path(
                         "/ap/v2/user",
                         PathItem::new(
-                            PathItemType::Get,
+                            HttpMethod::Get,
                             OperationBuilder::new()
                                 .response("200", Response::new("Get user success 2")),
                         ),
@@ -740,7 +740,7 @@ mod tests {
                     .path(
                         "/api/v2/user",
                         PathItem::new(
-                            PathItemType::Post,
+                            HttpMethod::Post,
                             OperationBuilder::new()
                                 .response("200", Response::new("Get user success")),
                         ),
@@ -826,7 +826,7 @@ mod tests {
                 .path(
                     "/api/v1/user",
                     PathItem::new(
-                        PathItemType::Get,
+                        HttpMethod::Get,
                         OperationBuilder::new()
                             .response("200", Response::new("Get user success 1")),
                     ),
@@ -841,7 +841,7 @@ mod tests {
                     .path(
                         "/api/v1/user",
                         PathItem::new(
-                            PathItemType::Get,
+                            HttpMethod::Get,
                             OperationBuilder::new()
                                 .response("200", Response::new("This will not get added")),
                         ),
@@ -849,7 +849,7 @@ mod tests {
                     .path(
                         "/api/v1/user",
                         PathItem::new(
-                            PathItemType::Post,
+                            HttpMethod::Post,
                             OperationBuilder::new()
                                 .response("200", Response::new("Post user success 1")),
                         ),
@@ -857,7 +857,7 @@ mod tests {
                     .path(
                         "/api/v2/user",
                         PathItem::new(
-                            PathItemType::Get,
+                            HttpMethod::Get,
                             OperationBuilder::new()
                                 .response("200", Response::new("Get user success 2")),
                         ),
@@ -865,7 +865,7 @@ mod tests {
                     .path(
                         "/api/v2/user",
                         PathItem::new(
-                            PathItemType::Post,
+                            HttpMethod::Post,
                             OperationBuilder::new()
                                 .response("200", Response::new("Post user success 2")),
                         ),
@@ -955,7 +955,7 @@ mod tests {
                 PathsBuilder::new().path(
                     "/api/v1/status",
                     PathItem::new(
-                        PathItemType::Get,
+                        HttpMethod::Get,
                         OperationBuilder::new()
                             .description(Some("Get status"))
                             .build(),
@@ -970,7 +970,7 @@ mod tests {
                     .path(
                         "/",
                         PathItem::new(
-                            PathItemType::Get,
+                            HttpMethod::Get,
                             OperationBuilder::new()
                                 .description(Some("Get user details"))
                                 .build(),
@@ -978,7 +978,7 @@ mod tests {
                     )
                     .path(
                         "/foo",
-                        PathItem::new(PathItemType::Post, OperationBuilder::new().build()),
+                        PathItem::new(HttpMethod::Post, OperationBuilder::new().build()),
                     ),
             )
             .build();


### PR DESCRIPTION
Add support for defining multiple operation methods to 
`#[utoipa::path(...)]` attribte macro as follows.
```rust
 #[utoipa::path(method(head, get), ...)]
 async fn path() {}
```

Remove `CONNECT` http method from supported path operation types since
it actually is not supported by the OpenAPI specification. Also this
commit renames the `PathItemType` `HttpMethod` to more precisely
describe the use case.

Add `#[route(...)]` macro support for `actix-web` library.

Enhance `utoipa-axum` bindings to support multiple operation methods.

### Breaking

This commit renames `PathItemType` to `HttpMethod` to better describe the 
usage. Also this commit removes `Connect` from the `HttpMethod` since it is 
not supported by OpenAPI specification. https://spec.openapis.org/oas/latest.html#path-item-object

Fixes #827