### PR TITLE
Add `utoipa-axum` binding example and update docs

### DIFF
--- a/examples/axum-utoipa-bindings/Cargo.toml
+++ b/examples/axum-utoipa-bindings/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "axum-utoipa-bindings"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+axum = "0.7"
+tokio = { version = "1", features = ["full"] }
+tower = "0.5"
+utoipa = { path = "../../utoipa", features = ["axum_extras", "debug"] }
+utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["axum"] }
+utoipa-axum = { path = "../../utoipa-axum" ,features = ["debug"] }
+serde = "1"
+serde_json = "1"
+
+[workspace]

--- a/examples/axum-utoipa-bindings/README.md
+++ b/examples/axum-utoipa-bindings/README.md
@@ -1,0 +1,14 @@
+# utoipa with axum bindings
+
+This demo `axum` application demonstrates `utoipa` and `axum` seamless integration with `utoipa-axum` crate.
+API doc is served via Swagger UI.
+
+Run the app
+```bash
+cargo run
+```
+
+Browse the API docs.
+```
+http://localhost:8080/swagger-ui
+```

--- a/examples/axum-utoipa-bindings/src/main.rs
+++ b/examples/axum-utoipa-bindings/src/main.rs
@@ -1,0 +1,128 @@
+use std::io;
+use std::net::Ipv4Addr;
+
+use tokio::net::TcpListener;
+use utoipa::OpenApi;
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use utoipa_swagger_ui::SwaggerUi;
+
+const CUSTOMER_TAG: &str = "customer";
+const ORDER_TAG: &str = "order";
+
+#[derive(OpenApi)]
+#[openapi(
+    tags(
+        (name = CUSTOMER_TAG, description = "Customer API endpoints"),
+        (name = ORDER_TAG, description = "Order API endpoints")
+    )
+)]
+struct ApiDoc;
+
+/// Get health of the API.
+#[utoipa::path(
+    method(get, head),
+    path = "/api/health",
+    responses(
+        (status = OK, description = "Success", body = str, content_type = "text/plain")
+    )
+)]
+async fn health() -> &'static str {
+    "ok"
+}
+
+#[tokio::main]
+async fn main() -> Result<(), io::Error> {
+    let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
+        .routes(routes!(health))
+        .nest("/api/customer", customer::router())
+        .nest("/api/order", order::router())
+        .split_for_parts();
+
+    let router = router.merge(SwaggerUi::new("/swagger-ui").url("/apidoc/openapi.json", api));
+
+    let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 8080)).await?;
+    axum::serve(listener, router).await
+}
+
+mod customer {
+    use axum::Json;
+    use serde::Serialize;
+    use utoipa::{OpenApi, ToSchema};
+    use utoipa_axum::router::OpenApiRouter;
+    use utoipa_axum::routes;
+
+    #[derive(OpenApi)]
+    #[openapi(components(schemas(Customer)))]
+    struct CustomerApi;
+
+    /// This is the customer
+    #[derive(ToSchema, Serialize)]
+    struct Customer {
+        name: String,
+    }
+
+    /// expose the Customer OpenAPI to parent module
+    pub fn router() -> OpenApiRouter {
+        OpenApiRouter::with_openapi(CustomerApi::openapi()).routes(routes!(get_customer))
+    }
+
+    /// Get customer
+    ///
+    /// Just return a static Customer object
+    #[utoipa::path(get, path = "", responses((status = OK, body = Customer)), tag = super::CUSTOMER_TAG)]
+    async fn get_customer() -> Json<Customer> {
+        Json(Customer {
+            name: String::from("Bill Book"),
+        })
+    }
+}
+
+mod order {
+    use axum::Json;
+    use serde::{Deserialize, Serialize};
+    use utoipa::{OpenApi, ToSchema};
+    use utoipa_axum::router::OpenApiRouter;
+    use utoipa_axum::routes;
+
+    #[derive(OpenApi)]
+    #[openapi(components(schemas(Order, OrderRequest)))]
+    struct OrderApi;
+
+    /// This is the order
+    #[derive(ToSchema, Serialize)]
+    struct Order {
+        id: i32,
+        name: String,
+    }
+
+    #[derive(ToSchema, Deserialize, Serialize)]
+    struct OrderRequest {
+        name: String,
+    }
+
+    /// expose the Order OpenAPI to parent module
+    pub fn router() -> OpenApiRouter {
+        OpenApiRouter::with_openapi(OrderApi::openapi()).routes(routes!(get_order, create_order))
+    }
+
+    /// Get static order object
+    #[utoipa::path(get, path = "", responses((status = OK, body = Order)), tag = super::ORDER_TAG)]
+    async fn get_order() -> Json<Order> {
+        Json(Order {
+            id: 100,
+            name: String::from("Bill Book"),
+        })
+    }
+
+    /// Create an order.
+    ///
+    /// Create an order by basically passing through the name of the request with static id.
+    #[utoipa::path(post, path = "", responses((status = OK, body = OrderRequest)), tag = super::ORDER_TAG)]
+    async fn create_order(Json(order): Json<OrderRequest>) -> Json<Order> {
+        Json(Order {
+            id: 120,
+            name: order.name,
+        })
+    }
+}

--- a/utoipa-axum/README.md
+++ b/utoipa-axum/README.md
@@ -4,6 +4,10 @@ Utoipa axum brings `utoipa` and `axum` closer together by the way of providing a
 the `axum` API. It gives a natural way to register handlers known to `axum` and also simultaneously generates OpenAPI
 specification from the handlers.
 
+## Crate features
+
+- **`debug`**: Implement debug traits for types.
+
 ## Install
 
 Add dependency declaration to `Cargo.toml`.
@@ -28,12 +32,8 @@ struct Todo {
 struct Api;
 
 let mut router: OpenApiRouter = OpenApiRouter::with_openapi(Api::openapi())
-    .routes(get_path(search_user))
-    .routes(
-        get_path(get_user)
-            .post_path(post_user)
-            .delete_path(delete_user),
-    );
+    .routes(routes!(search_user))
+    .routes(routes!(get_user, post_user, delete_user));
 
 let api = router.to_openapi();
 let axum_router: axum::Router = router.into();

--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -6,6 +6,10 @@
 //! the `axum` API. It gives a natural way to register handlers known to `axum` and also simultaneously generates OpenAPI
 //! specification from the handlers.
 //!
+//! ## Crate features
+//!
+//! - **`debug`**: Implement debug traits for types.
+//!
 //! ## Install
 //!
 //! Add dependency declaration to `Cargo.toml`.

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -184,7 +184,7 @@ impl Parse for Modifier {
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 struct Tag {
-    name: String,
+    name: parse_utils::Value,
     description: Option<Str>,
     external_docs: Option<ExternalDocs>,
 }
@@ -203,7 +203,7 @@ impl Parse for Tag {
             let attribute_name = &*ident.to_string();
 
             match attribute_name {
-                "name" => tag.name = parse_utils::parse_next_literal_str(input)?,
+                "name" => tag.name = parse_utils::parse_next_literal_str_or_expr(input)?,
                 "description" => {
                     tag.description =
                         Some(parse_utils::parse_next_literal_str_or_include_str(input)?)

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -75,6 +75,23 @@ fn derive_openapi_tags_include_str() {
 }
 
 #[test]
+fn derive_openapi_tags_with_const_name() {
+    const TAG: &str = "random::api";
+    #[derive(OpenApi)]
+    #[openapi(tags(
+        (name = TAG),
+    ))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
+
+    assert_value! {doc=>
+        "tags.[0].name" = r###""random::api""###, "Tags random_api name"
+        "tags.[0].description" = r###"null"###, "Tags random_api description"
+    }
+}
+
+#[test]
 fn derive_openapi_with_external_docs() {
     #[derive(OpenApi)]
     #[openapi(external_docs(

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -125,7 +125,7 @@ impl PathsBuilder {
     }
 
     /// Appends a [`Path`] to map of paths. Method must be called with one generic argument that
-    /// implements [`utoipa::Path`] trait.
+    /// implements [`trait@Path`] trait.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This PR adds new `axum` app example to demonstrate new seamless integration between axum and utoipa.

Along the above this commit streamlines the user facing API in `utoipa-axum`, fixes some minor bugs, update docs and adds one extra feature which allows using expressions e.g. `const` references in `tags((name = ...))` attribute. This allows sharing a single `const` reference between OpenApi and the handlers annotated with `#[utoipa::path(...)]`

Fixes #780