### PR TITLE
Add parsing support for non strict integers

### DIFF
--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -4398,6 +4398,59 @@ fn derive_struct_with_validation_fields() {
 }
 
 #[test]
+#[cfg(feature = "non_strict_integers")]
+fn uint_non_strict_integers_format() {
+    let value = api_doc! {
+        struct Numbers {
+            #[schema(format = UInt8)]
+            ui8: String,
+            #[schema(format = UInt16)]
+            ui16: String,
+            #[schema(format = UInt32)]
+            ui32: String,
+            #[schema(format = UInt64)]
+            ui64: String,
+            #[schema(format = UInt16)]
+            i16: String,
+            #[schema(format = Int8)]
+            i8: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "ui8": {
+                    "type": "integer",
+                    "format": "uint8"
+                },
+                "ui16": {
+                    "type": "integer",
+                    "format": "uint16"
+                },
+                "ui32": {
+                    "type": "integer",
+                    "format": "uint32"
+                },
+                "ui64": {
+                    "type": "integer",
+                    "format": "uint64"
+                },
+                "i16": {
+                    "type": "integer",
+                    "format": "int16"
+                },
+                "i8": {
+                    "type": "integer",
+                    "format": "int8"
+                }
+            }
+        })
+    )
+}
+
+#[test]
 fn derive_schema_with_slice_and_array() {
     let value = api_doc! {
         struct Item<'a> {


### PR DESCRIPTION
Prior to this PR the schema `format = ...` attribute was missing support for `non_strict_integers` feature flag enabled formats. This commit adds support for those formats.

E.g. now the following will work if `non_strict_integers` feature flag is enabled.
```rust
struct Numbers {
    #[schema(format = UInt8)]
    ui8: String,
}
```

Fixes #996