### PR TITLE
Fix parameter inline for tuple path params

### DIFF
--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -60,7 +60,10 @@ impl<'p> Parameter<'p> {
         match (self, other) {
             (Self::Value(value), Parameter::Value(other)) => {
                 let (schema_features, _) = &value.features;
-                value.parameter_schema = other.parameter_schema;
+                // if value parameter schema has not been defined use the external one
+                if value.parameter_schema.is_none() {
+                    value.parameter_schema = other.parameter_schema;
+                }
 
                 if let Some(parameter_schema) = &mut value.parameter_schema {
                     parameter_schema.features.clone_from(schema_features);
@@ -274,7 +277,9 @@ impl Parse for ValueParameter<'_> {
 
         if input.fork().parse::<ParameterIn>().is_ok() {
             parameter.parameter_in = input.parse()?;
-            input.parse::<Token![,]>()?;
+            if !input.is_empty() {
+                input.parse::<Token![,]>()?;
+            }
         }
 
         let (schema_features, parameter_features) = input

--- a/utoipa-gen/tests/path_derive_axum_test.rs
+++ b/utoipa-gen/tests/path_derive_axum_test.rs
@@ -752,3 +752,58 @@ fn derive_path_with_validation_attributes_axum() {
         config
     );
 }
+
+#[test]
+fn path_derive_inline_with_tuple() {
+    #[derive(utoipa::ToSchema)]
+    #[allow(unused)]
+    pub enum ResourceType {
+        Type1,
+        Type2,
+    }
+
+    #[utoipa::path(
+        get,
+        path = "/test_2params_separated/{resource_type}/{id}",
+        params(
+            ("resource_type" = inline(ResourceType), Path),
+            ("id" = String, Path)
+        )
+    )]
+    #[allow(unused)]
+    pub async fn inline_tuple(
+        Path((resource_type, id)): axum::extract::Path<(ResourceType, String)>,
+    ) {
+    }
+
+    use utoipa::Path;
+    let value = __path_inline_tuple::operation();
+    let value = serde_json::to_value(value).expect("operation should serialize to json");
+
+    assert_json_eq!(
+        value,
+        json!({
+            "operationId": "inline_tuple",
+            "parameters": [
+                {
+                    "in": "path",
+                    "name": "resource_type",
+                    "required": true,
+                    "schema": {
+                        "enum": ["Type1", "Type2"],
+                        "type": "string"
+                    },
+                },
+                {
+                    "in": "path",
+                    "name": "id",
+                    "required": true,
+                    "schema": {
+                        "type": "string"
+                    },
+                }
+            ],
+            "responses": {}
+        })
+    )
+}


### PR DESCRIPTION
This commit fixes bug where already defined parameter schema were overridden by external parameter schema in all cases. This caused an issue where sometimes inline information was lost which caused parameter render as reference schema instead.

Fixes #995