### PR TITLE
Enhance `utoipa-axum` bindings

### DIFF
--- a/utoipa-axum/Cargo.toml
+++ b/utoipa-axum/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utoipa-axum"
 description = "Utoipa's axum bindings for seamless integration for the two"
-version = "0.1.0-beta.0"
+version = "0.1.0-beta.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
@@ -16,7 +16,7 @@ debug = []
 
 [dependencies]
 axum = { version = "0.7", default-features = false }
-utoipa = { version = "5.0.0-alpha", path = "../utoipa", default-features = false }
+utoipa = { version = "5.0.0-beta", path = "../utoipa", default-features = false }
 tower-service = "0.3"
 tower-layer = "0.3.2"
 paste = "1.0"

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -42,7 +42,7 @@
 //!
 //! # Crate Features
 //!
-//! - **`macros`** Enable `utoipa-gen` macros. **This is enabled by default.**
+//! * **`macros`** Enable `utoipa-gen` macros. **This is enabled by default.**
 //! * **`yaml`** Enables **serde_yaml** serialization of OpenAPI objects.
 //! * **`actix_extras`** Enhances [actix-web](https://github.com/actix/actix-web/) integration with being able to
 //!   parse `path`, `path` and `query` parameters from actix web path attribute macros. See [actix extras support][actix_path] or


### PR DESCRIPTION
Add support for colonized params in `nest` method of `UtoipaMethodRouter`. This makes the `nest` method to accept both colonized and path template syntax params.
```rust
.nest("/api/{version}/customer", customer_router)
.nest("/api/:version/customer", customer_router)
```

Add `UtoipaMethodRouterExt` trait which adds convenience methods for `UtoipaMethodRouter` to add layers and state as well as other custom mappings via `map` method.

Fixes #1016