### PR TITLE
Make referenced schemas required

### DIFF
--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -25,7 +25,7 @@ use crate::{
         FieldRename,
     },
     doc_comment::CommentAttributes,
-    Array, Diagnostics, OptionExt, Required, ToTokensDiagnostics,
+    Array, Diagnostics, GenericsExt, OptionExt, Required, ToTokensDiagnostics,
 };
 
 use super::{
@@ -147,6 +147,7 @@ impl ToTokensDiagnostics for IntoParams {
                         name,
                     },
                     serde_container: &serde_container,
+                    generics: &self.generics
                 };
 
                 let mut param_tokens = TokenStream::new();
@@ -300,6 +301,8 @@ struct Param<'a> {
     container_attributes: FieldParamContainerAttributes<'a>,
     /// Either serde rename all rule or into_params rename all rule if provided.
     serde_container: &'a SerdeContainer,
+    /// Container gnerics
+    generics: &'a Generics,
 }
 
 impl Param<'_> {
@@ -458,6 +461,7 @@ impl ToTokensDiagnostics for Param<'_> {
                 description: None,
                 deprecated: None,
                 object_name: "",
+                is_generics_type_arg: self.generics.any_match_type_tree(&component),
             })?;
             let schema_tokens = crate::as_tokens_or_diagnostics!(&schema);
 

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -137,6 +137,8 @@ impl ToTokensDiagnostics for RequestBody<'_> {
                 description: None,
                 deprecated: None,
                 object_name: "",
+                // Currently Request body cannot know about possible generic types
+                is_generics_type_arg: false, // TODO check whether this is correct
             })?);
 
             tokens.extend(quote_spanned! {actual_body.span.unwrap()=>

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -185,6 +185,8 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                             description: None,
                             deprecated: None,
                             object_name: "",
+                            // TODO check whether this is correct
+                            is_generics_type_arg: false
                         }
                     )?),
                     required,
@@ -206,6 +208,8 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                             description: None,
                             deprecated: None,
                             object_name: "",
+                            // TODO check whether this is correct
+                            is_generics_type_arg: false
                         }
                     )?),
                     required,

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -169,6 +169,7 @@ impl ToTokensDiagnostics for RequestBodyAttr<'_> {
                         description: None,
                         deprecated: None,
                         object_name: "",
+                        is_generics_type_arg: false,
                     })?
                     .to_token_stream()
                 }

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -294,6 +294,7 @@ impl ToTokensDiagnostics for ResponseTuple<'_> {
                                 description: None,
                                 deprecated: None,
                                 object_name: "",
+                                is_generics_type_arg: false,
                             })?
                             .to_token_stream()
                         }
@@ -866,6 +867,7 @@ impl ToTokensDiagnostics for Header {
                 description: None,
                 deprecated: None,
                 object_name: "",
+                is_generics_type_arg: false,
             })?
             .to_token_stream();
 

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -352,6 +352,7 @@ impl NamedStructResponse<'_> {
             rename_all: None,
             struct_name: Cow::Owned(ident.to_string()),
             schema_as: None,
+            generics: &Generics::default(),
         };
 
         let ty = Self::to_type(ident);
@@ -438,6 +439,7 @@ impl<'p> ToResponseNamedStructResponse<'p> {
             struct_name: Cow::Owned(ident.to_string()),
             rename_all: None,
             schema_as: None,
+            generics: &Generics::default(),
         };
         let response_type = PathType::InlineSchema(inline_schema.to_token_stream(), ty);
 
@@ -564,8 +566,13 @@ impl<'r> EnumResponse<'r> {
             description,
         });
         response_value.response_type = if content.is_empty() {
-            let inline_schema =
-                EnumSchema::new(Cow::Owned(ident.to_string()), variants, attributes)?;
+            let generics = Generics::default();
+            let inline_schema = EnumSchema::new(
+                Cow::Owned(ident.to_string()),
+                variants,
+                attributes,
+                &generics,
+            )?;
 
             Some(PathType::InlineSchema(
                 inline_schema.into_token_stream(),

--- a/utoipa-gen/tests/path_derive_axum_test.rs
+++ b/utoipa-gen/tests/path_derive_axum_test.rs
@@ -145,6 +145,7 @@ fn get_todo_with_path_tuple() {
 
 #[test]
 fn get_todo_with_extension() {
+    #[derive(utoipa::ToSchema)]
     struct Todo {
         #[allow(unused)]
         id: i32,

--- a/utoipa-gen/tests/request_body_derive_test.rs
+++ b/utoipa-gen/tests/request_body_derive_test.rs
@@ -39,7 +39,7 @@ fn derive_path_request_body_simple_success() {
     #[openapi(paths(derive_request_body_simple::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
         "paths.~1foo.post.requestBody.content.application~1json.schema.$ref" = r###""#/components/schemas/Foo""###, "Request body content object type"
@@ -60,7 +60,7 @@ fn derive_path_request_body_simple_array_success() {
     #[openapi(paths(derive_request_body_simple_array::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
         "paths.~1foo.post.requestBody.content.application~1json.schema.$ref" = r###"null"###, "Request body content object type"
@@ -83,7 +83,7 @@ fn derive_request_body_option_array_success() {
     #[openapi(paths(derive_request_body_option_array::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
     let body = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
 
     assert_json_eq!(
@@ -115,7 +115,7 @@ fn derive_request_body_primitive_simple_success() {
     #[openapi(paths(derive_request_body_primitive_simple::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     assert_value! {doc=>
         "paths.~1foo.post.requestBody.content.application~1json.schema.$ref" = r###"null"###, "Request body content object type not application/json"
@@ -138,7 +138,7 @@ fn derive_request_body_primitive_array_success() {
     #[openapi(paths(derive_request_body_primitive_simple_array::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
     let content = doc
         .pointer("/paths/~1foo/post/requestBody/content")
         .unwrap();
@@ -172,7 +172,7 @@ fn derive_request_body_complex_success() {
     #[openapi(paths(derive_request_body_complex::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
 
@@ -203,7 +203,7 @@ fn derive_request_body_complex_multi_content_type_success() {
     #[openapi(paths(derive_request_body_complex_multi_content_type::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
 
@@ -239,7 +239,7 @@ fn derive_request_body_complex_success_inline() {
     #[openapi(paths(derive_request_body_complex_inline::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
 
@@ -280,7 +280,7 @@ fn derive_request_body_complex_success_array() {
     #[openapi(paths(derive_request_body_complex_array::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
 
@@ -314,7 +314,7 @@ fn derive_request_body_complex_success_inline_array() {
     #[openapi(paths(derive_request_body_complex_inline_array::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
 
@@ -358,7 +358,7 @@ fn derive_request_body_simple_inline_success() {
     #[openapi(paths(derive_request_body_simple_inline::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
     let request_body: &Value = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
 
     assert_json_eq!(
@@ -397,7 +397,7 @@ fn derive_request_body_complex_required_explicit_false_success() {
     #[openapi(paths(derive_request_body_complex_required_explicit::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
     let body = doc.pointer("/paths/~1foo/post/requestBody").unwrap();
 
     assert_json_eq!(
@@ -434,7 +434,7 @@ fn derive_request_body_complex_primitive_array_success() {
     #[openapi(paths(derive_request_body_complex_primitive_array::post_foo))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
     let content = doc
         .pointer("/paths/~1foo/post/requestBody/content")
         .unwrap();
@@ -456,9 +456,31 @@ fn derive_request_body_complex_primitive_array_success() {
     );
 }
 
-test_fn! {
-    module: derive_request_body_ref_path,
-    body: = path::to::Foo
+#[allow(unused)]
+mod derive_request_body_ref_path {
+    #[derive(utoipa::ToSchema)]
+    #[doc = r" Some struct"]
+    pub struct Foo {
+        #[doc = r" Some name"]
+        name: String,
+    }
+
+    mod path {
+        pub mod to {
+            #[derive(utoipa::ToSchema)]
+            pub struct Foo;
+        }
+    }
+
+    #[utoipa::path(
+            post,
+            path = "/foo",
+            request_body = path::to::Foo,
+            responses(
+                (status = 200, description = "success response")
+            )
+        )]
+    fn post_foo() {}
 }
 
 #[test]
@@ -479,7 +501,7 @@ fn derive_request_body_ref_path_success() {
     )]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
     let schemas = doc.pointer("/components/schemas").unwrap();
     assert!(schemas.get("path.to.Foo").is_some());
 
@@ -505,7 +527,7 @@ fn unit_type_request_body() {
     #[openapi(paths(unit_type_test))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
     let request_body = doc
         .pointer("/paths/~1unit_type_test/post/requestBody")
         .unwrap();
@@ -541,7 +563,7 @@ fn request_body_with_example() {
     #[openapi(components(schemas(Foo)), paths(get_item))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     let content = doc
         .pointer("/paths/~1item/get/requestBody/content")
@@ -586,7 +608,7 @@ fn request_body_with_examples() {
     #[openapi(components(schemas(Foo)), paths(get_item))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     let content = doc
         .pointer("/paths/~1item/get/requestBody/content")
@@ -625,7 +647,7 @@ fn request_body_with_binary() {
     #[openapi(paths(get_item))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     let content = doc
         .pointer("/paths/~1item/get/requestBody/content")
@@ -658,7 +680,7 @@ fn request_body_with_external_ref() {
     #[openapi(paths(get_item))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
     let content = doc
         .pointer("/paths/~1item/get/requestBody/content")

--- a/utoipa-gen/tests/response_derive_test.rs
+++ b/utoipa-gen/tests/response_derive_test.rs
@@ -298,11 +298,13 @@ fn derive_response_multiple_examples() {
 
 #[test]
 fn derive_response_with_enum_contents() {
+    #[derive(utoipa::ToSchema)]
     #[allow(unused)]
     struct Admin {
         name: String,
     }
     #[allow(unused)]
+    #[derive(utoipa::ToSchema)]
     struct Moderator {
         name: String,
     }

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -21,10 +21,10 @@ macro_rules! api_doc {
         }
     };
     ( @schema $ident:ident < $($life:lifetime , )? $generic:ident > $($tt:tt)* ) => {
-         <$ident<$generic> as utoipa::ToSchema>::schema().1
+         <$ident<$generic> as utoipa::PartialSchema>::schema()
     };
     ( @schema $ident:ident $($tt:tt)* ) => {
-         <$ident as utoipa::ToSchema>::schema().1
+         <$ident as utoipa::PartialSchema>::schema()
     };
 }
 
@@ -307,6 +307,7 @@ fn derive_struct_with_default_attr() {
 
 #[test]
 fn derive_struct_with_default_attr_field() {
+    #[derive(ToSchema)]
     struct Book;
     let owner = api_doc! {
         struct Owner {
@@ -416,6 +417,7 @@ fn derive_struct_with_serde_default_attr() {
 
 #[test]
 fn derive_struct_with_optional_properties() {
+    #[derive(ToSchema)]
     struct Book;
     let owner = api_doc! {
         struct Owner {
@@ -473,6 +475,7 @@ fn derive_struct_with_optional_properties() {
 
 #[test]
 fn derive_struct_with_comments() {
+    #[derive(ToSchema)]
     struct Foobar;
     let account = api_doc! {
         /// This is user account dto object
@@ -905,6 +908,7 @@ fn derive_struct_with_cow() {
 #[test]
 fn derive_with_box_and_refcell() {
     #[allow(unused)]
+    #[derive(ToSchema)]
     struct Foo {
         name: &'static str,
     }
@@ -1153,7 +1157,7 @@ fn derive_struct_unnamed_field_reference_with_comment() {
 /// Derive a complex enum with named and unnamed fields.
 #[test]
 fn derive_complex_unnamed_field_reference_with_comment() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct CommentedReference(String);
 
     let value: Value = api_doc! {
@@ -1285,7 +1289,7 @@ fn derive_complex_enum_with_schema_properties() {
 // TODO fixme https://github.com/juhaku/utoipa/issues/285#issuecomment-1249625860
 #[test]
 fn derive_enum_with_unnamed_single_field_with_tag() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct ReferenceValue(String);
 
     let value: Value = api_doc! {
@@ -1328,7 +1332,7 @@ fn derive_enum_with_unnamed_single_field_with_tag() {
 
 #[test]
 fn derive_enum_with_named_fields_with_reference_with_tag() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct ReferenceValue(String);
 
     let value: Value = api_doc! {
@@ -1413,7 +1417,7 @@ fn derive_enum_with_named_fields_with_reference_with_tag() {
 /// Derive a complex enum with named and unnamed fields.
 #[test]
 fn derive_complex_enum() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Foo(String);
 
     let value: Value = api_doc! {
@@ -1477,7 +1481,7 @@ fn derive_complex_enum() {
 
 #[test]
 fn derive_complex_enum_title() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Foo(String);
 
     let value: Value = api_doc! {
@@ -1540,7 +1544,7 @@ fn derive_complex_enum_title() {
 
 #[test]
 fn derive_complex_enum_example() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Foo(String);
 
     let value: Value = api_doc! {
@@ -1605,7 +1609,7 @@ fn derive_complex_enum_example() {
 
 #[test]
 fn derive_complex_enum_serde_rename_all() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Foo(String);
 
     let value: Value = api_doc! {
@@ -1670,7 +1674,7 @@ fn derive_complex_enum_serde_rename_all() {
 
 #[test]
 fn derive_complex_enum_serde_rename_variant() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Foo(String);
 
     let value: Value = api_doc! {
@@ -2082,13 +2086,13 @@ fn derive_complex_enum_serde_tag() {
 
 #[test]
 fn derive_serde_flatten() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Metadata {
         category: String,
         total: u64,
     }
 
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Record {
         amount: i64,
         description: String,
@@ -2096,7 +2100,7 @@ fn derive_serde_flatten() {
         metadata: Metadata,
     }
 
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Pagination {
         page: i64,
         next_page: i64,
@@ -2210,7 +2214,7 @@ fn derive_complex_enum_serde_untagged() {
 
 #[test]
 fn derive_complex_enum_with_ref_serde_untagged() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Foo {
         name: String,
         age: u32,
@@ -2403,7 +2407,7 @@ fn derive_complex_enum_serde_adjacently_tagged() {
 
 #[test]
 fn derive_complex_enum_with_ref_serde_adjacently_tagged() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Foo {
         name: String,
         age: u32,
@@ -3067,6 +3071,12 @@ fn derive_struct_component_field_type_override() {
 
 #[test]
 fn derive_struct_component_field_type_path_override() {
+    mod path {
+        pub mod to {
+            #[derive(utoipa::ToSchema)]
+            pub struct Foo;
+        }
+    }
     let post = api_doc! {
         struct Post {
             id: i32,
@@ -3186,13 +3196,14 @@ fn derive_struct_override_type_with_object_type() {
 #[test]
 fn derive_struct_override_type_with_a_reference() {
     mod custom {
+        #[derive(utoipa::ToSchema)]
         #[allow(dead_code)]
-        struct NewBar;
+        pub struct NewBar;
     }
 
     let value = api_doc! {
         struct Value {
-            #[schema(value_type = NewBar)]
+            #[schema(value_type = custom::NewBar)]
             field: String,
         }
     };
@@ -3203,7 +3214,7 @@ fn derive_struct_override_type_with_a_reference() {
             "type": "object",
             "properties": {
                 "field": {
-                    "$ref": "#/components/schemas/NewBar"
+                    "$ref": "#/components/schemas/custom.NewBar"
                 }
             },
             "required": ["field"]
@@ -3402,7 +3413,7 @@ fn derive_parse_serde_simple_enum_attributes() {
 
 #[test]
 fn derive_parse_serde_complex_enum() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct Foo;
     let complex_enum = api_doc! {
         #[derive(Serialize)]
@@ -3460,6 +3471,7 @@ fn derive_component_with_generic_types_having_path_expression() {
 
 #[test]
 fn derive_component_with_aliases() {
+    #[derive(ToSchema)]
     struct A;
 
     #[derive(Debug, OpenApi)]
@@ -3484,6 +3496,7 @@ fn derive_component_with_aliases() {
 
 #[test]
 fn derive_complex_enum_as() {
+    #[derive(ToSchema)]
     struct Foobar;
 
     #[derive(ToSchema)]
@@ -3497,7 +3510,7 @@ fn derive_complex_enum_as() {
     #[openapi(components(schemas(BarBar)))]
     struct ApiDoc;
 
-    let doc = serde_json::to_value(&ApiDoc::openapi()).unwrap();
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
     let value = doc
         .pointer("/components/schemas/named.BarBar")
         .expect("Should have BarBar named to named.BarBar");
@@ -4063,6 +4076,7 @@ fn derive_struct_with_vec_field_with_example() {
 
 #[test]
 fn derive_struct_field_with_example() {
+    #[derive(ToSchema)]
     struct MyStruct;
     let doc = api_doc! {
         struct MyValue {
@@ -4734,6 +4748,7 @@ fn derive_struct_with_unit_alias() {
 
 #[test]
 fn derive_struct_with_deprecated_fields() {
+    #[derive(ToSchema)]
     struct Foobar;
     let account = api_doc! {
         struct Account {
@@ -4794,6 +4809,7 @@ fn derive_struct_with_deprecated_fields() {
 
 #[test]
 fn derive_struct_with_schema_deprecated_fields() {
+    #[derive(ToSchema)]
     struct Foobar;
     let account = api_doc! {
         struct AccountA {
@@ -5002,7 +5018,7 @@ fn derive_nullable_tuple() {
 
 #[test]
 fn derive_unit_type_untagged_enum() {
-    #[derive(Serialize)]
+    #[derive(Serialize, ToSchema)]
     struct AggregationRequest;
 
     let value = api_doc! {
@@ -5462,6 +5478,7 @@ fn derive_simple_enum_description_override() {
 #[test]
 fn derive_complex_enum_description_override() {
     #[allow(unused)]
+    #[derive(ToSchema)]
     struct User {
         name: &'static str,
     }

--- a/utoipa-gen/tests/utoipa_gen_test.rs
+++ b/utoipa-gen/tests/utoipa_gen_test.rs
@@ -145,10 +145,10 @@ impl Modify for Foo {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct Foo;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, ToSchema)]
 struct FooResources;
 
 #[test]

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -142,7 +142,9 @@ impl ComponentsBuilder {
         // are created when the main schema is a generic type which should be included in OpenAPI
         // spec in its generic form.
         if aliases.is_empty() {
-            let (name, schema) = I::schema();
+            let name = I::name();
+            let schema = I::schema();
+            // let (name, schema) = I::schema();
             self.schemas.insert(name.to_string(), schema);
         }
 


### PR DESCRIPTION
This will affect in all places where schema is being rendered. These are `value_type = ..` `request_body`, `response_body = ...` to name few. This is still very much work in progress but aims to enforce `PartialSchema` implementation for every type that is being used in OpenAPI spec generated by utoipa.

The `Schema` trait will be split to `PartialSchema` and `Schema` and `Schema` will extend the `PartialSchema` trait. `PartialSchema` will provide the actual schema and `Schema` will provide name and other data related to the schema itself. This is useful since we already provide `PartialSchema` implementation for many standard Rust types and not all types need the full schema but only the schema definition. This makes schema definition implementation easier by juts allowing users to manually implement `PartialSchema` type for their type if needed. Still as usual the implementation can be automatically derived with `ToSchema` derive trait.

Fixes #500 Fixes #801