### PR TITLE
Wip make `as` attribute authoritative name

### DIFF
--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -23,7 +23,7 @@ ulid = { version = "1", optional = true, default-features = false }
 url = { version = "2", optional = true }
 
 [dev-dependencies]
-utoipa = { path = "../utoipa", features = ["debug", "uuid"], default-features = false }
+utoipa = { path = "../utoipa", features = ["debug", "uuid", "macros"], default-features = false }
 serde_json = "1"
 serde = "1"
 actix-web = { version = "4", features = ["macros"], default-features = false }

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use syn::{
     parse::Parse, punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, Data, Field,
-    Generics, Ident,
+    Generics,
 };
 
 use crate::{
@@ -25,7 +25,7 @@ use crate::{
         FieldRename,
     },
     doc_comment::CommentAttributes,
-    Array, Diagnostics, GenericsExt, OptionExt, Required, ToTokensDiagnostics,
+    Array, Diagnostics, OptionExt, Required, ToTokensDiagnostics,
 };
 
 use super::{
@@ -147,7 +147,6 @@ impl ToTokensDiagnostics for IntoParams {
                         name,
                     },
                     serde_container: &serde_container,
-                    generics: &self.generics
                 };
 
                 let mut param_tokens = TokenStream::new();
@@ -301,8 +300,6 @@ struct Param<'a> {
     container_attributes: FieldParamContainerAttributes<'a>,
     /// Either serde rename all rule or into_params rename all rule if provided.
     serde_container: &'a SerdeContainer,
-    /// Container gnerics
-    generics: &'a Generics,
 }
 
 impl Param<'_> {
@@ -455,13 +452,14 @@ impl ToTokensDiagnostics for Param<'_> {
             });
             tokens.extend(param_features.to_token_stream()?);
 
+            // TODO get the field type and generics??????
+            let type_and_generics = (&Ident::new("empty_param", Span::call_site()), &Generics::default());
             let schema = ComponentSchema::new(component::ComponentSchemaProps {
                 type_tree: &component,
                 features: Some(schema_features),
                 description: None,
                 deprecated: None,
-                object_name: "",
-                is_generics_type_arg: self.generics.any_match_type_tree(&component),
+                type_and_generics,
             })?;
             let schema_tokens = crate::as_tokens_or_diagnostics!(&schema);
 

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned};
-use syn::parse_quote;
 use syn::spanned::Spanned;
+use syn::{parse_quote, Generics};
 use syn::{punctuated::Punctuated, token::Comma, ItemFn};
 
 use crate::component::{ComponentSchema, ComponentSchemaProps, TypeTree};
@@ -131,14 +131,15 @@ impl ToTokensDiagnostics for RequestBody<'_> {
         let mut create_body_tokens = |content_type: &str,
                                       actual_body: &TypeTree|
          -> Result<(), Diagnostics> {
+            let (ident, generics) = actual_body.get_path_type_and_generics()?;
+            let type_and_generics = (ident, &generics);
+            // let type_and_generics = (&Ident::new("empty_request_body", Span::call_site()), &Generics::default());
             let schema = as_tokens_or_diagnostics!(&ComponentSchema::new(ComponentSchemaProps {
                 type_tree: actual_body,
                 features: None,
                 description: None,
                 deprecated: None,
-                object_name: "",
-                // Currently Request body cannot know about possible generic types
-                is_generics_type_arg: false, // TODO check whether this is correct
+                type_and_generics
             })?);
 
             tokens.extend(quote_spanned! {actual_body.span.unwrap()=>

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -43,7 +43,7 @@ use syn::{
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
     token::Bracket,
-    DeriveInput, ExprPath, ItemFn, Lit, LitStr, Member, Token,
+    DeriveInput, ExprPath, Generics, ItemFn, Lit, LitStr, Member, Token,
 };
 
 mod component;
@@ -2584,13 +2584,35 @@ pub fn schema(input: TokenStream) -> TokenStream {
         Err(diagnostics) => return diagnostics.into_token_stream().into(),
     };
 
+    // let segment = type_tree
+    //     .path
+    //     .as_ref()
+    //     .expect("schema must have Path, do not provide tuple here as an argument")
+    //     .segments
+    //     .last()
+    //     .expect("Path must have segments");
+
+    dbg!(&schema.ty);
+    dbg!(&type_tree);
+    // let mut generics = Generics::default();
+
+    let (ident, generics) = match type_tree.get_path_type_and_generics() {
+        Ok(type_and_generics) => type_and_generics,
+        Err(error) => return error.to_compile_error().into(),
+    };
+    // generics.lt_token = Some(syn::token::Lt { spans: gcckj })
+    // let g = Generics::from(segment.arguments);
+    // TODO get the correct type and generics???
+    let type_and_generics = (ident, &generics);
+
+    dbg!("does not get here");
+    dbg!(ident, &generics);
     let schema = ComponentSchema::new(ComponentSchemaProps {
         features: Some(vec![Feature::Inline(schema.inline.into())]),
         type_tree: &type_tree,
         deprecated: None,
         description: None,
-        object_name: "",
-        is_generics_type_arg: false, // it cannot be generic struct here
+        type_and_generics,
     });
 
     match schema {

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -1,11 +1,11 @@
 use std::{borrow::Cow, fmt::Display};
 
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     parenthesized,
     parse::{Parse, ParseBuffer, ParseStream},
-    Error, LitStr, Token, TypePath,
+    Error, Generics, LitStr, Token, TypePath,
 };
 
 use crate::{
@@ -168,6 +168,8 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
             tokens.extend(quote! { .schema(Some(#param_schema)).required(#required) });
         };
 
+        // TODO where to get parameter type and generics????
+        let type_and_generics = (&Ident::new("empty_parameter_schema", Span::call_site()), &Generics::default());
         match &self.parameter_type {
             #[cfg(any(
                 feature = "actix_extras",
@@ -184,9 +186,7 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                             features: Some(self.features.clone()),
                             description: None,
                             deprecated: None,
-                            object_name: "",
-                            // TODO check whether this is correct
-                            is_generics_type_arg: false
+                            type_and_generics
                         }
                     )?),
                     required,
@@ -207,9 +207,7 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                             features: Some(schema_features),
                             description: None,
                             deprecated: None,
-                            object_name: "",
-                            // TODO check whether this is correct
-                            is_generics_type_arg: false
+                            type_and_generics
                         }
                     )?),
                     required,

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -1,7 +1,8 @@
-use proc_macro2::{Ident, TokenStream as TokenStream2};
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
+use syn::Generics;
 use syn::{parenthesized, parse::Parse, token::Paren, Error, Token};
 
 use crate::component::features::attributes::Inline;
@@ -163,13 +164,15 @@ impl ToTokensDiagnostics for RequestBodyAttr<'_> {
                 },
                 PathType::MediaType(body_type) => {
                     let type_tree = body_type.as_type_tree()?;
+                    // TODO get the body type and generics from body_type
+                    let type_and_generics =
+                        (&Ident::new("empty_request_body", Span::call_site()), &Generics::default());
                     ComponentSchema::new(crate::component::ComponentSchemaProps {
                         type_tree: &type_tree,
                         features: Some(vec![Inline::from(body_type.is_inline).into()]),
                         description: None,
                         deprecated: None,
-                        object_name: "",
-                        is_generics_type_arg: false,
+                        type_and_generics,
                     })?
                     .to_token_stream()
                 }

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -7,7 +7,7 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     token::Comma,
-    Attribute, Error, ExprPath, LitInt, LitStr, Token, TypePath,
+    Attribute, Error, ExprPath, Generics, LitInt, LitStr, Token, TypePath,
 };
 
 use crate::{
@@ -288,13 +288,15 @@ impl ToTokensDiagnostics for ResponseTuple<'_> {
                         PathType::MediaType(ref path_type) => {
                             let type_tree = path_type.as_type_tree()?;
 
+                            let (ident, generics) = type_tree.get_path_type_and_generics()?;
+                            dbg!(&type_tree, ident, &generics);
+                            let type_and_generics = (ident, &generics);
                             ComponentSchema::new(crate::component::ComponentSchemaProps {
                                 type_tree: &type_tree,
                                 features: Some(vec![Inline::from(path_type.is_inline).into()]),
                                 description: None,
                                 deprecated: None,
-                                object_name: "",
-                                is_generics_type_arg: false,
+                                type_and_generics,
                             })?
                             .to_token_stream()
                         }
@@ -861,13 +863,14 @@ impl ToTokensDiagnostics for Header {
             // header property with custom type
             let type_tree = header_type.as_type_tree()?;
 
+            // TODO get header type and generics
+            let type_and_generics = (&Ident::new("empty_header", Span::call_site()), &Generics::default());
             let media_type_schema = ComponentSchema::new(crate::component::ComponentSchemaProps {
                 type_tree: &type_tree,
                 features: Some(vec![Inline::from(header_type.is_inline).into()]),
                 description: None,
                 deprecated: None,
-                object_name: "",
-                is_generics_type_arg: false,
+                type_and_generics,
             })?
             .to_token_stream();
 

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -343,6 +343,7 @@ impl NamedStructResponse<'_> {
             parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
         };
         let status_code = mem::take(&mut derive_value.status);
+        let type_and_generics = (ident, &Generics::default());
         let inline_schema = NamedStructSchema {
             attributes,
             fields,
@@ -350,9 +351,8 @@ impl NamedStructResponse<'_> {
             description: None,
             features: None,
             rename_all: None,
-            struct_name: Cow::Owned(ident.to_string()),
             schema_as: None,
-            generics: &Generics::default(),
+            type_and_generics,
         };
 
         let ty = Self::to_type(ident);
@@ -430,16 +430,16 @@ impl<'p> ToResponseNamedStructResponse<'p> {
         };
         let ty = Self::to_type(ident);
 
+        let type_and_generics = (ident, &Generics::default());
         let inline_schema = NamedStructSchema {
             aliases: None,
             description: None,
             fields,
             features: None,
             attributes,
-            struct_name: Cow::Owned(ident.to_string()),
             rename_all: None,
             schema_as: None,
-            generics: &Generics::default(),
+            type_and_generics,
         };
         let response_type = PathType::InlineSchema(inline_schema.to_token_stream(), ty);
 
@@ -565,14 +565,9 @@ impl<'r> EnumResponse<'r> {
             derive_value,
             description,
         });
+        let type_and_generics = (ident, &Generics::default());
         response_value.response_type = if content.is_empty() {
-            let generics = Generics::default();
-            let inline_schema = EnumSchema::new(
-                Cow::Owned(ident.to_string()),
-                variants,
-                attributes,
-                &generics,
-            )?;
+            let inline_schema = EnumSchema::new(type_and_generics, variants, attributes)?;
 
             Some(PathType::InlineSchema(
                 inline_schema.into_token_stream(),

--- a/utoipa-gen/tests/path_derive_axum_test.rs
+++ b/utoipa-gen/tests/path_derive_axum_test.rs
@@ -157,8 +157,9 @@ fn get_todo_with_extension() {
     ///
     /// List all Todo items from in-memory storage.
     #[utoipa::path(
-        get,
+        post,
         path = "/todo",
+        request_body = [Todo],
         responses(
             (status = 200, description = "List all todos successfully", body = [Todo])
         )

--- a/utoipa-gen/tests/request_body_derive_test.rs
+++ b/utoipa-gen/tests/request_body_derive_test.rs
@@ -456,33 +456,6 @@ fn derive_request_body_complex_primitive_array_success() {
     );
 }
 
-#[allow(unused)]
-mod derive_request_body_ref_path {
-    #[derive(utoipa::ToSchema)]
-    #[doc = r" Some struct"]
-    pub struct Foo {
-        #[doc = r" Some name"]
-        name: String,
-    }
-
-    mod path {
-        pub mod to {
-            #[derive(utoipa::ToSchema)]
-            pub struct Foo;
-        }
-    }
-
-    #[utoipa::path(
-            post,
-            path = "/foo",
-            request_body = path::to::Foo,
-            responses(
-                (status = 200, description = "success response")
-            )
-        )]
-    fn post_foo() {}
-}
-
 #[test]
 fn derive_request_body_ref_path_success() {
     /// Some struct
@@ -494,9 +467,20 @@ fn derive_request_body_ref_path_success() {
         name: String,
     }
 
+    #[utoipa::path(
+            post,
+            path = "/foo",
+            request_body = Foo,
+            responses(
+                (status = 200, description = "success response")
+            )
+        )]
+    #[allow(unused)]
+    fn post_foo() {}
+
     #[derive(OpenApi, Default)]
     #[openapi(
-        paths(derive_request_body_ref_path::post_foo),
+        paths(post_foo),
         components(schemas(Foo))
     )]
     struct ApiDoc;


### PR DESCRIPTION
This PR aims to change the logic how the prefix is defined for the request bodies and response bodies throughout the library. Prior to this the name is resolved from the value provided to the `request_body` or response `body` attribute. However this current logic becomes cumbersome when user needs to always provide the correct path to the attribute value that correspond the name in the OpenAPI specification.

This changes it so that the name itself will be resolved from the name of the schema itself thus eliminating the need for manual path prefixing. If schema itself is provided with `as` attribute then the name will be resolved from the same `as` attribute value.

Fixes #993