### PR TITLE
Use fs::read to overwrite swagger UI contents

### DIFF
--- a/utoipa-swagger-ui/build.rs
+++ b/utoipa-swagger-ui/build.rs
@@ -327,7 +327,7 @@ fn overwrite_target_file(target_dir: &str, swagger_ui_dist_zip: &str, path_in: P
     let filename = path_in.file_name().unwrap().to_str().unwrap();
     println!("overwrite file: {:?}", path_in.file_name().unwrap());
 
-    let content = fs::read_to_string(path_in.clone());
+    let content = fs::read(path_in.clone());
 
     match content {
         Ok(content) => {


### PR DESCRIPTION
When using SWAGGER_UI_OVERWRITE_FOLDER, text files get properly overwritten, but other files like icons fail with:
`cannot read content from file: icon.png`

Using `fs::read` instead of `fs::read_file` solves the issue. It overwrites the files using bytes instead of strings.