### PR TITLE
Chore change the operations implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also an awesome type of beer 
   When disabled, the properties are listed in alphabetical order.
 - **`preserve_path_order`**: Preserve order of OpenAPI Paths according to order they have been
   introduced to the `#[openapi(paths(...))]` macro attribute. If disabled the paths will be
-  ordered in alphabetical order.
+  ordered in alphabetical order. **However** the operations order under the path **will** be always constant according to [specification](https://spec.openapis.org/oas/latest.html#fixed-fields-6)
 - **`indexmap`**: Add support for [indexmap](https://crates.io/crates/indexmap). When enabled `IndexMap` will be rendered as a map similar to
   `BTreeMap` and `HashMap`.
 - **`non_strict_integers`**: Add support for non-standard integer formats `int8`, `int16`, `uint8`, `uint16`, `uint32`, and `uint64`.

--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -141,9 +141,7 @@ macro_rules! routes {
             let mut method_router = types.iter().by_ref().fold(axum::routing::MethodRouter::new(), |router, path_type| {
                 router.on(path_type.to_method_filter(), $handler)
             });
-            for method_type in types {
-                paths.add_path(&path, utoipa::openapi::path::PathItem::new(method_type, item.clone()));
-            }
+            paths.add_path_operation(&path, types, item);
             $( method_router = routes!( method_router: paths: $tail ); )*
             (paths, method_router)
         }
@@ -154,9 +152,7 @@ macro_rules! routes {
             let router = types.iter().by_ref().fold($router, |router, path_type| {
                 router.on(path_type.to_method_filter(), $handler)
             });
-            for method_type in types {
-                $paths.add_path(&path, utoipa::openapi::path::PathItem::new(method_type, item.clone()));
-            }
+            $paths.add_path_operation(&path, types, item);
             router
         }
     };

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -4,7 +4,7 @@ use serde::{
     de::{Error, Expected, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{collections::HashMap, fmt::Formatter};
+use std::{collections::HashMap, fmt::Formatter, mem};
 
 use self::path::PathsMap;
 pub use self::{
@@ -201,8 +201,8 @@ impl OpenApi {
 
         if !other.paths.paths.is_empty() {
             for (path, that) in &mut other.paths.paths {
-                if let Some(this) = self.paths.get_path_item(path) {
-                    that.operations.extend(this.operations.clone());
+                if let Some(this) = self.paths.paths.get_mut(path) {
+                    that.merge_operations(mem::take(this));
                 }
             }
             self.paths.paths.extend(other.paths.paths);


### PR DESCRIPTION
As stated here #972 the `operations` and `extensions` were both map. This caused deserializing issues where operations where mistakenly deserialized to extensions as well.

This commit removes the `operations` map and changes them to static fields as they would be in the specification.
https://spec.openapis.org/oas/latest.html#fixed-fields-6

This is a breaking change and `preserver_path_order` feature changes so that all operations under same path will always be serialized in constant order according to fields order in the specification (link above).

Fixes #972