### PR TITLE
Fix negative value parsing on schema attributes

### DIFF
--- a/utoipa-gen/src/component/features/validators.rs
+++ b/utoipa-gen/src/component/features/validators.rs
@@ -1,6 +1,8 @@
 use crate::component::{GenericType, TypeTree};
 use crate::schema_type::SchemaType;
 
+use super::validation::NumberValue;
+
 pub trait Validator {
     fn is_valid(&self) -> Result<(), &'static str>;
 }
@@ -53,11 +55,16 @@ impl Validator for IsVec<'_> {
     }
 }
 
-pub struct AboveZeroUsize(pub(super) usize);
+pub struct AboveZeroUsize<'a>(pub(super) &'a NumberValue);
 
-impl Validator for AboveZeroUsize {
+impl Validator for AboveZeroUsize<'_> {
     fn is_valid(&self) -> Result<(), &'static str> {
-        if self.0 != 0 {
+        let usize: usize = self
+            .0
+            .try_from_str()
+            .map_err(|_| "invalid type, expected `usize`")?;
+
+        if usize != 0 {
             Ok(())
         } else {
             Err("can only be above zero value")
@@ -65,11 +72,15 @@ impl Validator for AboveZeroUsize {
     }
 }
 
-pub struct AboveZeroF64(pub(super) f64);
+pub struct AboveZeroF64<'a>(pub(super) &'a NumberValue);
 
-impl Validator for AboveZeroF64 {
+impl Validator for AboveZeroF64<'_> {
     fn is_valid(&self) -> Result<(), &'static str> {
-        if self.0 > 0.0 {
+        let float: f64 = self
+            .0
+            .try_from_str()
+            .map_err(|_| "invalid type, expected `f64`")?;
+        if float > 0.0 {
             Ok(())
         } else {
             Err("can only be above zero value")

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -2794,9 +2794,10 @@ impl AnyValue {
 
     fn parse_any(input: ParseStream) -> syn::Result<Self> {
         if input.peek(Lit) {
-            let lit = input.parse::<Lit>().unwrap().to_token_stream();
+            let punct = input.parse::<Option<Token![-]>>()?;
+            let lit = input.parse::<Lit>().unwrap();
 
-            Ok(AnyValue::Json(lit))
+            Ok(AnyValue::Json(quote! { #punct #lit}))
         } else {
             let fork = input.fork();
             let is_json = if fork.peek(syn::Ident) && fork.peek2(Token![!]) {

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5638,3 +5638,39 @@ fn derive_schema_required_custom_type_required() {
         })
     );
 }
+
+#[test]
+fn derive_negative_numbers() {
+    let value = api_doc! {
+        #[schema(default)]
+        #[derive(Default)]
+        struct Negative {
+            #[schema(default = -1, minimum = -2.1)]
+            number: f64,
+            #[schema(default = -2, maximum = -3)]
+            solid_number: i64,
+        }
+    };
+
+    assert_json_eq! {
+        value,
+        json!({
+            "properties": {
+                "number": {
+                    "type": "number",
+                    "format": "double",
+                    "default": -1,
+                    "minimum": -2.1
+                },
+                "solid_number": {
+                    "format": "int64",
+                    "type": "integer",
+                    "default": -2,
+                    "maximum": -3,
+                }
+            },
+            "required": [ "number", "solid_number" ],
+            "type": "object"
+        })
+    }
+}


### PR DESCRIPTION
This commit fixes issue where negative numbers caused parsing error by `rust_analyzer` however the code compiled correctly and created valid code.

The issue is fixed for validation attributes and `AnyValue` which is used in various places. The original issue only reported the issue in validation attributes.

Fixes #994