### PR TITLE
Wip add support for real generics

### DIFF
--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::quote;
 use syn::{
     parse::Parse, punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, Data, Field,
@@ -34,7 +34,7 @@ use super::{
         Merge, ToTokensExt,
     },
     serde::{self, SerdeContainer, SerdeValue},
-    ComponentSchema, TypeTree,
+    ComponentSchema, Container, TypeTree,
 };
 
 impl_merge!(IntoParamsFeatures, FieldFeatures);
@@ -460,8 +460,10 @@ impl ToTokensDiagnostics for Param<'_> {
                 features: Some(schema_features),
                 description: None,
                 deprecated: None,
-                object_name: "",
-                is_generics_type_arg: self.generics.any_match_type_tree(&component),
+                container: &Container {
+                    ident: &Ident::new("empty_param", Span::call_site()),
+                    generics: &self.generics,
+                },
             })?;
             let schema_tokens = crate::as_tokens_or_diagnostics!(&schema);
 

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -1,12 +1,12 @@
 use std::borrow::Cow;
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned};
-use syn::parse_quote;
 use syn::spanned::Spanned;
+use syn::{parse_quote, Generics};
 use syn::{punctuated::Punctuated, token::Comma, ItemFn};
 
-use crate::component::{ComponentSchema, ComponentSchemaProps, TypeTree};
+use crate::component::{ComponentSchema, ComponentSchemaProps, Container, TypeTree};
 use crate::path::{HttpMethod, PathTypeTree};
 use crate::{as_tokens_or_diagnostics, Diagnostics, ToTokensDiagnostics};
 
@@ -136,9 +136,10 @@ impl ToTokensDiagnostics for RequestBody<'_> {
                 features: None,
                 description: None,
                 deprecated: None,
-                object_name: "",
-                // Currently Request body cannot know about possible generic types
-                is_generics_type_arg: false, // TODO check whether this is correct
+                container: &Container {
+                    ident: &Ident::new("empty_request_body", Span::call_site()),
+                    generics: &Generics::default(),
+                }
             })?);
 
             tokens.extend(quote_spanned! {actual_body.span.unwrap()=>

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -1,11 +1,11 @@
 use std::{borrow::Cow, fmt::Display};
 
-use proc_macro2::{Ident, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::{
     parenthesized,
     parse::{Parse, ParseBuffer, ParseStream},
-    Error, LitStr, Token, TypePath,
+    Error, Generics, LitStr, Token, TypePath,
 };
 
 use crate::{
@@ -24,7 +24,7 @@ use crate::{
             },
             Feature, ToTokensExt,
         },
-        ComponentSchema,
+        ComponentSchema, Container,
     },
     parse_utils, Diagnostics, Required, ToTokensDiagnostics,
 };
@@ -184,9 +184,10 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                             features: Some(self.features.clone()),
                             description: None,
                             deprecated: None,
-                            object_name: "",
-                            // TODO check whether this is correct
-                            is_generics_type_arg: false
+                            container: &Container {
+                                ident: &Ident::new("empty_parameter_external", Span::call_site()),
+                                generics: &Generics::default(),
+                            }
                         }
                     )?),
                     required,
@@ -207,9 +208,10 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                             features: Some(schema_features),
                             description: None,
                             deprecated: None,
-                            object_name: "",
-                            // TODO check whether this is correct
-                            is_generics_type_arg: false
+                            container: &Container {
+                                ident: &Ident::new("empty_parameter_parsed", Span::call_site()),
+                                generics: &Generics::default(),
+                            }
                         }
                     )?),
                     required,

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -1,11 +1,12 @@
-use proc_macro2::{Ident, TokenStream as TokenStream2};
+use proc_macro2::{Ident, Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::punctuated::Punctuated;
 use syn::token::Comma;
+use syn::Generics;
 use syn::{parenthesized, parse::Parse, token::Paren, Error, Token};
 
 use crate::component::features::attributes::Inline;
-use crate::component::ComponentSchema;
+use crate::component::{ComponentSchema, Container};
 use crate::{parse_utils, AnyValue, Array, Diagnostics, Required, ToTokensDiagnostics};
 
 use super::example::Example;
@@ -168,8 +169,10 @@ impl ToTokensDiagnostics for RequestBodyAttr<'_> {
                         features: Some(vec![Inline::from(body_type.is_inline).into()]),
                         description: None,
                         deprecated: None,
-                        object_name: "",
-                        is_generics_type_arg: false,
+                        container: &Container {
+                            ident: &Ident::new("empty_request_body", Span::call_site()),
+                            generics: &Generics::default(),
+                        },
                     })?
                     .to_token_stream()
                 }

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -7,11 +7,11 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     token::Comma,
-    Attribute, Error, ExprPath, LitInt, LitStr, Token, TypePath,
+    Attribute, Error, ExprPath, Generics, LitInt, LitStr, Token, TypePath,
 };
 
 use crate::{
-    component::{features::attributes::Inline, ComponentSchema, TypeTree},
+    component::{features::attributes::Inline, ComponentSchema, Container, TypeTree},
     parse_utils, AnyValue, Array, Diagnostics, ToTokensDiagnostics,
 };
 
@@ -293,8 +293,10 @@ impl ToTokensDiagnostics for ResponseTuple<'_> {
                                 features: Some(vec![Inline::from(path_type.is_inline).into()]),
                                 description: None,
                                 deprecated: None,
-                                object_name: "",
-                                is_generics_type_arg: false,
+                                container: &Container {
+                                    ident: &Ident::new("empty_repopnse_tuple", Span::call_site()),
+                                    generics: &Generics::default(),
+                                },
                             })?
                             .to_token_stream()
                         }
@@ -866,8 +868,10 @@ impl ToTokensDiagnostics for Header {
                 features: Some(vec![Inline::from(header_type.is_inline).into()]),
                 description: None,
                 deprecated: None,
-                object_name: "",
-                is_generics_type_arg: false,
+                container: &Container {
+                    ident: &Ident::new("empty header", Span::call_site()),
+                    generics: &Generics::default(),
+                },
             })?
             .to_token_stream();
 

--- a/utoipa-gen/tests/schema_generics.rs
+++ b/utoipa-gen/tests/schema_generics.rs
@@ -1,0 +1,57 @@
+use std::borrow::Cow;
+
+use utoipa::openapi::{RefOr, Schema};
+use utoipa::{schema, OpenApi, ToSchema};
+
+#[test]
+fn test_generics() {
+    #![allow(unused)]
+
+    #[derive(ToSchema)]
+    struct Type<T> {
+        t: T,
+    }
+
+    #[derive(ToSchema)]
+    struct Person<'p, T: Sized, P> {
+        id: usize,
+        name: Cow<'p, str>,
+        field: T,
+        t: P,
+    }
+
+    #[derive(ToSchema)]
+    struct Page<T> {
+        total: usize,
+        page: usize,
+        pages: usize,
+        items: Vec<T>,
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(
+        components(
+            schemas(
+                Person::<'_, String, Type<i32>>,
+                Page::<Person<'_, String, Type<i32>>>,
+            )
+        )
+    )]
+    struct ApiDoc;
+
+    let schema: RefOr<Schema> = schema!(Page<Person<'_, String, Type<i32>>>);
+    // let schema: RefOr<Schema> = schema!(Person<'_, String>);
+    // let schema: RefOr<Schema> = schema!(Vec<Person<'_, String>>);
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&schema).expect("schema is JSON serializable")
+    );
+    dbg!("output schema", &schema);
+
+    println!(
+        "{}",
+        ApiDoc::openapi()
+            .to_pretty_json()
+            .expect("ApiDoc is JSON serializable")
+    );
+}

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -393,7 +393,7 @@ pub trait OpenApi {
 ///     }
 /// }
 /// ```
-pub trait ToSchema<'__s>: PartialSchema {
+pub trait ToSchema<'__s>: PartialSchema + __dev::ComposeSchema {
     /// Return a tuple of name and schema or reference to a schema that can be referenced by the
     /// name or inlined directly to responses, request bodies or parameters.
     fn name() -> Cow<'__s, str>;
@@ -421,15 +421,23 @@ impl<'__s, T: ToSchema<'__s>> From<T> for openapi::RefOr<openapi::schema::Schema
 /// [`openapi::schema::Schema`] for the type.
 pub type TupleUnit = ();
 
-impl PartialSchema for TupleUnit {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        openapi::schema::empty().into()
-    }
-}
+// impl PartialSchema for TupleUnit {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         openapi::schema::empty().into()
+//     }
+// }
 
 impl<'__s> ToSchema<'__s> for TupleUnit {
     fn name() -> Cow<'__s, str> {
         Cow::Borrowed("TupleUnit")
+    }
+}
+
+impl __dev::ComposeSchema for TupleUnit {
+    fn compose(
+        _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+    ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        Self::schema()
     }
 }
 
@@ -546,165 +554,165 @@ impl_partial_schema_primitive!(
 
 impl_partial_schema!(&str);
 
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, T: ToSchema<'__s>> PartialSchema for Vec<T> {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(#[inline] Vec<T>).into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, T: ToSchema<'__s>> PartialSchema for Option<Vec<T>> {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(#[inline] Option<Vec<T>>).into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, T: ToSchema<'__s>> PartialSchema for [T] {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            [T]
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, T: ToSchema<'__s>> PartialSchema for &[T] {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            &[T]
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, T: ToSchema<'__s>> PartialSchema for &mut [T] {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            &mut [T]
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, T: ToSchema<'__s>> PartialSchema for Option<&[T]> {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            Option<&[T]>
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, T: ToSchema<'__s>> PartialSchema for Option<&mut [T]> {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            Option<&mut [T]>
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, T: ToSchema<'__s>> PartialSchema for Option<T> {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(#[inline] Option<T>).into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for BTreeMap<K, V> {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            BTreeMap<K, V>
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for Option<BTreeMap<K, V>> {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            Option<BTreeMap<K, V>>
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for BTreeMap<K, Option<V>> {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            BTreeMap<K, Option<V>>
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for std::collections::HashMap<K, V> {
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            std::collections::HashMap<K, V>
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema
-    for Option<std::collections::HashMap<K, V>>
-{
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            Option<std::collections::HashMap<K, V>>
-        )
-        .into()
-    }
-}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema
-    for std::collections::HashMap<K, Option<V>>
-{
-    fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-        schema!(
-            #[inline]
-            std::collections::HashMap<K, Option<V>>
-        )
-        .into()
-    }
-}
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, T: ToSchema<'__s>> PartialSchema for Vec<T> {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(#[inline] Vec<T>).into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, T: ToSchema<'__s>> PartialSchema for Option<Vec<T>> {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(#[inline] Option<Vec<T>>).into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, T: ToSchema<'__s>> PartialSchema for [T] {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             [T]
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, T: ToSchema<'__s>> PartialSchema for &[T] {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             &[T]
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, T: ToSchema<'__s>> PartialSchema for &mut [T] {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             &mut [T]
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, T: ToSchema<'__s>> PartialSchema for Option<&[T]> {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             Option<&[T]>
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, T: ToSchema<'__s>> PartialSchema for Option<&mut [T]> {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             Option<&mut [T]>
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, T: ToSchema<'__s>> PartialSchema for Option<T> {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(#[inline] Option<T>).into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for BTreeMap<K, V> {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             BTreeMap<K, V>
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for Option<BTreeMap<K, V>> {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             Option<BTreeMap<K, V>>
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for BTreeMap<K, Option<V>> {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             BTreeMap<K, Option<V>>
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema for std::collections::HashMap<K, V> {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             std::collections::HashMap<K, V>
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema
+//     for Option<std::collections::HashMap<K, V>>
+// {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             Option<std::collections::HashMap<K, V>>
+//         )
+//         .into()
+//     }
+// }
+//
+// #[cfg(feature = "macros")]
+// #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+// impl<'__s, K: PartialSchema, V: ToSchema<'__s>> PartialSchema
+//     for std::collections::HashMap<K, Option<V>>
+// {
+//     fn schema() -> openapi::RefOr<openapi::schema::Schema> {
+//         schema!(
+//             #[inline]
+//             std::collections::HashMap<K, Option<V>>
+//         )
+//         .into()
+//     }
+// }
 
 /// Trait for implementing OpenAPI PathItem object with path.
 ///
@@ -1078,6 +1086,8 @@ impl_from_for_number!(
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
 pub mod __dev {
+    use std::borrow::Cow;
+
     use crate::{utoipa, OpenApi};
 
     pub trait PathConfig {
@@ -1143,6 +1153,103 @@ pub mod __dev {
             api
         }
     }
+
+    pub struct SchemaGeneric<'s> {
+        name: Cow<'s, str>,
+        field_ref: Cow<'s, str>,
+    }
+
+    pub trait SchemaComposer {
+        // generate from original type generic args will include the T and other generic args
+        fn get_generics() -> Vec<SchemaGeneric<'static>>;
+    }
+
+    pub trait ComposeSchema {
+        fn compose(
+            new_generics: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+        ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>;
+    }
+
+    // Default implementation
+    impl<T: utoipa::__dev::ComposeSchema> utoipa::PartialSchema for T {
+        fn schema() -> crate::openapi::RefOr<crate::openapi::schema::Schema> {
+            T::compose(Vec::new())
+        }
+    }
+
+    //
+    // let generics = <Person as SchemaComposer>::get_generics(); => [T]
+    //
+    // ty: TypeTree = Person<'_, String>;
+    //
+    // let use_point_generics = ty.generics(); => [String]
+    //
+    //
+    // fn compose(....) {
+    //    let original_generics = <Person as SchemaComposer>::get_generics(); => [T]
+    //    let original = <Person as PartialSchema>::schema();
+    //
+    //    let use_point_generics = ?????
+    //
+    //    use_point_generics.zip(original_generics).for_each(|(new, old) | {
+    //      *original.get_field(original) = new;
+    //    });
+    //
+    //    let composed = ...;
+    //
+    //    Call generics type's PartialSchema::schema() for the field argument.
+    //
+    //
+    //
+    //
+    //    composed
+    // }
+    //
+    //
+    //
+    // impl<'p, '__s, T: Sized> utoipa::__dev::ComposeSchema for Person<'p, T> {
+    //     fn compose(new_generics: [String]) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+    //         utoipa::openapi::ObjectBuilder::new()
+    //             .property(
+    //                 "id",
+    //                 utoipa::openapi::ObjectBuilder::new()
+    //                     .schema_type(utoipa::openapi::schema::SchemaType::new(
+    //                         utoipa::openapi::schema::Type::Integer,
+    //                     ))
+    //                     .minimum(Some(0f64)),
+    //             )
+    //             .required("id")
+    //             .property(
+    //                 "name",
+    //                 utoipa::openapi::ObjectBuilder::new().schema_type(
+    //                     utoipa::openapi::schema::SchemaType::new(utoipa::openapi::schema::Type::String),
+    //                 ),
+    //             )
+    //             .required("name")
+    //             .property("field", {
+    //                 let generic_index = 0;
+    //                 new_generics.get(generic_index).or_else(|| {
+    //                     utoipa::openapi::schema::RefBuilder::new().ref_location_from_schema_name("T")
+    //                 })
+    //             })
+    //             .required("field")
+    //             .into()
+    //     }
+    // }
+    //
+    // impl<'p, '__s, T: Sized> utoipa::PartialSchema<'__s> for Person<'p, T> {
+    //     fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+    //          <Self as utoipa::__dev::ComposeSchema::compose([])
+    //     }
+    // }
+    //
+    // impl<'p, '__s, T: Sized> utoipa::ToSchema<'__s> for Person<'p, T> {
+    //     fn name() -> std::borrow::Cow<'__s, str> {
+    //         std::borrow::Cow::Borrowed("Person")
+    //     }
+    // }
+    //
+    //
 }
 
 #[cfg(test)]

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -137,6 +137,9 @@ impl ComponentsBuilder {
     pub fn schema_from<'s, I: ToSchema<'s>>(mut self) -> Self {
         let aliases = I::aliases();
 
+        // TODO this need to call similar to schema! macro call with inline always to get the full
+        // schema which then need to be composed with generic args of the schema!!!
+
         // TODO a temporal hack to add the main schema only if there are no aliases pre-defined.
         // Eventually aliases functionality should be extracted out from the `ToSchema`. Aliases
         // are created when the main schema is a generic type which should be included in OpenAPI


### PR DESCRIPTION
This PR adds support for real generics which allows users to use deeply nested generic types as schemas without the alias hassle known to users. This commit will remove the old aliases support and implement completely new generics handling. (Something that many has been longing for long)

This PR will also change the `schema!(...)` macro functionality to correctly generate schemas for arbitrary types even generic ones. Prior to this commit the generics where not resolved correctly.

Example of new syntax.
```rust
 #[derive(ToSchema)]
 struct Type<T> {
     t: T,
 }

 #[derive(ToSchema)]
 struct Person<'p, T: Sized, P> {
     id: usize,
     name: Cow<'p, str>,
     field: T,
     t: P,
 }

 #[derive(ToSchema)]
 struct Page<T> {
     total: usize,
     page: usize,
     pages: usize,
     items: Vec<T>,
 }

 #[derive(OpenApi)]
 #[openapi(
     components(
         schemas(
             Person::<'_, String, Type<i32>>,
             Page::<Person<'_, String, Type<i32>>>,
         )
     )
 )]
 struct ApiDoc;
```

Fixes #703 Fixes #818 Fixes #574  Fixes #566