### PR TITLE
Always use system `curl` by default when building `utoipa-swagger-ui`

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -45,20 +45,12 @@ zip = { version = "2", default-features = false, features = ["deflate"] }
 regex = "1.7"
 
 # enabled optionally to allow rust only build with expense of bigger dependency tree and platform
-# independant build. By default `curl` system package is tried for downloading the Swagger UI.
+# independent build. By default `curl` system package is tried for downloading the Swagger UI.
 reqwest = { version = "0.12", features = [
     "blocking",
     "rustls-tls",
 ], default-features = false, optional = true }
 url = { version = "2", optional = true }
-utoipa-swagger-ui-vendored = { version = "0.1", path = "../utoipa-swagger-ui-vendored", optional = true }
-
-# Windows is forced to use reqwest to download the Swagger UI.
-[target.'cfg(windows)'.build-dependencies]
-reqwest = { version = "0.12", features = [
-    "blocking",
-    "rustls-tls",
-], default-features = false }
 utoipa-swagger-ui-vendored = { version = "0.1", path = "../utoipa-swagger-ui-vendored", optional = true }
 
 [lints.rust]

--- a/utoipa-swagger-ui/README.md
+++ b/utoipa-swagger-ui/README.md
@@ -57,10 +57,9 @@ utoipa-swagger-ui = { version = "7", features = ["actix-web"] }
 
 > [!IMPORTANT]
 > _`utoipa-swagger-ui` crate will by default try to use system `curl` package for downloading the Swagger UI. It
-> can optionally be downloaded with `reqwest` by enabling `reqwest` feature. On Windows the `reqwest` feature
-> is enabled by default. Reqwest can be useful for platform independent builds however bringing quite a few 
-> unnecessary dependencies just to download a file. If the `SWAGGER_UI_DOWNLOAD_URL` is a file path then no 
-> downloading will happen._
+> can optionally be downloaded with `reqwest` by enabling `reqwest` feature. Reqwest can be useful for platform
+> independent builds however bringing quite a few unnecessary dependencies just to download a file.
+> If the `SWAGGER_UI_DOWNLOAD_URL` is a file path then no downloading will happen._
 
 > [!TIP]
 > Use **`vendored`** feature flag to use vendored Swagger UI. This is especially useful for no network 


### PR DESCRIPTION
Also fixes #1044