### PR TITLE
Add support for `termsOfService` to OpenApi derive

### DIFF
--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -587,7 +587,7 @@ impl From<SchemaWith> for Feature {
 impl_feature! {
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[derive(Clone)]
-    pub struct Description(parse_utils::Value);
+    pub struct Description(parse_utils::LitStrOrExpr);
 }
 
 impl Parse for Description {

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -80,8 +80,8 @@ impl ToTokensDiagnostics for RequestBody<'_> {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct RequestBodyAttr<'r> {
     content: Option<PathType<'r>>,
-    content_type: Vec<parse_utils::Value>,
-    description: Option<parse_utils::Value>,
+    content_type: Vec<parse_utils::LitStrOrExpr>,
+    description: Option<parse_utils::LitStrOrExpr>,
     example: Option<AnyValue>,
     examples: Option<Punctuated<Example, Comma>>,
 }

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -168,7 +168,7 @@ impl<'r> From<(ResponseStatus, ResponseValue<'r>)> for ResponseTuple<'r> {
 
 pub struct DeriveResponsesAttributes<T> {
     derive_value: T,
-    description: parse_utils::Value,
+    description: parse_utils::LitStrOrExpr,
 }
 
 impl<'r> From<DeriveResponsesAttributes<DeriveIntoResponsesValue>> for ResponseValue<'r> {
@@ -198,9 +198,9 @@ impl<'r> From<DeriveResponsesAttributes<Option<DeriveToResponseValue>>> for Resp
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct ResponseValue<'r> {
-    description: parse_utils::Value,
+    description: parse_utils::LitStrOrExpr,
     response_type: Option<PathType<'r>>,
-    content_type: Option<Vec<parse_utils::Value>>,
+    content_type: Option<Vec<parse_utils::LitStrOrExpr>>,
     headers: Vec<Header>,
     example: Option<AnyValue>,
     examples: Option<Punctuated<Example, Comma>>,
@@ -210,7 +210,7 @@ pub struct ResponseValue<'r> {
 impl<'r> ResponseValue<'r> {
     fn from_derive_to_response_value(
         derive_value: DeriveToResponseValue,
-        description: parse_utils::Value,
+        description: parse_utils::LitStrOrExpr,
     ) -> Self {
         Self {
             description: if derive_value.description.is_empty_litstr()
@@ -230,7 +230,7 @@ impl<'r> ResponseValue<'r> {
 
     fn from_derive_into_responses_value(
         response_value: DeriveIntoResponsesValue,
-        description: parse_utils::Value,
+        description: parse_utils::LitStrOrExpr,
     ) -> Self {
         ResponseValue {
             description: if response_value.description.is_empty_litstr()
@@ -409,9 +409,9 @@ trait DeriveResponseValue: Parse {
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 struct DeriveToResponseValue {
-    content_type: Option<Vec<parse_utils::Value>>,
+    content_type: Option<Vec<parse_utils::LitStrOrExpr>>,
     headers: Vec<Header>,
-    description: parse_utils::Value,
+    description: parse_utils::LitStrOrExpr,
     example: Option<(AnyValue, Ident)>,
     examples: Option<(Punctuated<Example, Comma>, Ident)>,
 }
@@ -482,9 +482,9 @@ impl Parse for DeriveToResponseValue {
 #[derive(Default)]
 struct DeriveIntoResponsesValue {
     status: ResponseStatus,
-    content_type: Option<Vec<parse_utils::Value>>,
+    content_type: Option<Vec<parse_utils::LitStrOrExpr>>,
     headers: Vec<Header>,
-    description: parse_utils::Value,
+    description: parse_utils::LitStrOrExpr,
     example: Option<(AnyValue, Ident)>,
     examples: Option<(Punctuated<Example, Comma>, Ident)>,
 }

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -273,7 +273,7 @@ impl<'u> UnnamedStructResponse<'u> {
             .expect("`IntoResponses` must have `#[response(...)]` attribute");
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
-            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+            parse_utils::LitStrOrExpr::LitStr(LitStr::new(&s, Span::call_site()))
         };
         let status_code = mem::take(&mut derive_value.status);
 
@@ -340,7 +340,7 @@ impl NamedStructResponse<'_> {
             .expect("`IntoResponses` must have `#[response(...)]` attribute");
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
-            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+            parse_utils::LitStrOrExpr::LitStr(LitStr::new(&s, Span::call_site()))
         };
         let status_code = mem::take(&mut derive_value.status);
         let inline_schema = NamedStructSchema {
@@ -390,7 +390,7 @@ impl UnitStructResponse<'_> {
         let status_code = mem::take(&mut derive_value.status);
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
-            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+            parse_utils::LitStrOrExpr::LitStr(LitStr::new(&s, Span::call_site()))
         };
 
         Ok(Self(
@@ -427,7 +427,7 @@ impl<'p> ToResponseNamedStructResponse<'p> {
         let derive_value = DeriveToResponseValue::from_attributes(attributes)?;
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
-            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+            parse_utils::LitStrOrExpr::LitStr(LitStr::new(&s, Span::call_site()))
         };
         let ty = Self::to_type(ident);
 
@@ -483,7 +483,7 @@ impl<'u> ToResponseUnnamedStructResponse<'u> {
         let derive_value = DeriveToResponseValue::from_attributes(attributes)?;
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
-            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+            parse_utils::LitStrOrExpr::LitStr(LitStr::new(&s, Span::call_site()))
         };
 
         let is_inline = inner_attributes
@@ -533,7 +533,7 @@ impl<'r> EnumResponse<'r> {
         let ty = Self::to_type(ident);
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
-            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+            parse_utils::LitStrOrExpr::LitStr(LitStr::new(&s, Span::call_site()))
         };
 
         let variants_content = variants
@@ -680,7 +680,7 @@ impl ToResponseUnitStructResponse<'_> {
         let derive_value = DeriveToResponseValue::from_attributes(attributes)?;
         let description = {
             let s = CommentAttributes::from_attributes(attributes).as_formatted_string();
-            parse_utils::Value::LitStr(LitStr::new(&s, Span::call_site()))
+            parse_utils::LitStrOrExpr::LitStr(LitStr::new(&s, Span::call_site()))
         };
         let response_value: ResponseValue = ResponseValue::from(DeriveResponsesAttributes {
             derive_value,

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -255,6 +255,7 @@ fn derive_openapi_with_servers() {
 fn derive_openapi_with_custom_info() {
     #[derive(OpenApi)]
     #[openapi(info(
+        terms_of_service = "http://localhost/terms",
         title = "title override",
         description = "description override",
         version = "1.0.0",
@@ -271,6 +272,7 @@ fn derive_openapi_with_custom_info() {
             json!(
                 {
                     "title": "title override",
+                    "termsOfService": "http://localhost/terms",
                     "description": "description override",
                     "license": {
                         "name": "MIT OR Apache-2.0",


### PR DESCRIPTION
Add support for `termsOfService` field in `OpenApi` derive macro. https://spec.openapis.org/oas/latest.html#info-object

Closes #1035