### PR TITLE
Add support for `links` in `#[utoipa::path]`

### DIFF
--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -276,7 +276,7 @@ impl ToTokens for Tag {
 // (url = "http:://url", description = "description", variables(...))
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
-struct Server {
+pub struct Server {
     url: String,
     description: Option<String>,
     variables: Punctuated<ServerVariable, Comma>,

--- a/utoipa-gen/src/path/response/link.rs
+++ b/utoipa-gen/src/path/response/link.rs
@@ -1,0 +1,149 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::parse::Parse;
+use syn::punctuated::Punctuated;
+use syn::token::Comma;
+use syn::{Ident, Token};
+
+use crate::openapi::Server;
+use crate::{parse_utils, AnyValue};
+
+/// ("name" = (link))
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct LinkTuple(pub parse_utils::LitStrOrExpr, pub Link);
+
+impl Parse for LinkTuple {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let inner;
+        syn::parenthesized!(inner in input);
+
+        let name = inner.parse::<parse_utils::LitStrOrExpr>()?;
+        inner.parse::<Token![=]>()?;
+        let value = inner.parse::<Link>()?;
+
+        Ok(LinkTuple(name, value))
+    }
+}
+
+/// (operation_ref = "", operation_id = "",
+///     parameters(
+///          ("name" = value),
+///          ("name" = value)
+///     ),
+///     request_body = value,
+///     description = "",
+///     server(...)
+/// )
+#[derive(Default)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct Link {
+    operation_ref: Option<parse_utils::LitStrOrExpr>,
+    operation_id: Option<parse_utils::LitStrOrExpr>,
+    parameters: Punctuated<LinkParameter, Comma>,
+    request_body: Option<AnyValue>,
+    description: Option<parse_utils::LitStrOrExpr>,
+    server: Option<Server>,
+}
+
+impl Parse for Link {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let inner;
+        syn::parenthesized!(inner in input);
+        let mut link = Link::default();
+
+        while !inner.is_empty() {
+            let ident = inner.parse::<Ident>()?;
+            let attribute = &*ident.to_string();
+
+            match attribute {
+                "operation_ref" => link.operation_ref = Some(parse_utils::parse_next_literal_str_or_expr(&inner)?),
+                "operation_id" => link.operation_id = Some(parse_utils::parse_next_literal_str_or_expr(&inner)?),
+                "parameters" => {
+                    link.parameters = parse_utils::parse_punctuated_within_parenthesis(&inner)?;
+                },
+                "request_body" => link.request_body = Some(parse_utils::parse_next(&inner, || { AnyValue::parse_any(&inner)})?),
+                "description" => link.description = Some(parse_utils::parse_next_literal_str_or_expr(&inner)?),
+                "server" => link.server = Some(inner.call(Server::parse)?),
+                _ => return Err(syn::Error::new(ident.span(), &format!("unexpected attribute: {attribute}, expected any of: operation_ref, operation_id, parameters, request_body, description, server")))
+            }
+
+            if !inner.is_empty() {
+                inner.parse::<Token![,]>()?;
+            }
+        }
+
+        Ok(link)
+    }
+}
+
+impl ToTokens for Link {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        let operation_ref = self
+            .operation_ref
+            .as_ref()
+            .map(|operation_ref| quote! { .operation_ref(#operation_ref)});
+
+        let operation_id = self
+            .operation_id
+            .as_ref()
+            .map(|operation_id| quote! { .operation_id(#operation_id)});
+
+        let parameters =
+            self.parameters
+                .iter()
+                .fold(TokenStream::new(), |mut params, parameter| {
+                    let name = &parameter.name;
+                    let value = &parameter.value;
+                    params.extend(quote! { .parameter(#name, #value) });
+
+                    params
+                });
+
+        let request_body = self
+            .request_body
+            .as_ref()
+            .map(|request_body| quote! { .request_body(Some(#request_body)) });
+
+        let description = self
+            .description
+            .as_ref()
+            .map(|description| quote! { .description(#description) });
+
+        let server = self
+            .server
+            .as_ref()
+            .map(|server| quote! { .server(Some(#server)) });
+
+        tokens.extend(quote! {
+            utoipa::openapi::link::Link::builder()
+                #operation_ref
+                #operation_id
+                #parameters
+                #request_body
+                #description
+                #server
+                .build()
+        })
+    }
+}
+
+/// ("foobar" = json!(...))
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct LinkParameter {
+    name: parse_utils::LitStrOrExpr,
+    value: parse_utils::LitStrOrExpr,
+}
+
+impl Parse for LinkParameter {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let inner;
+        syn::parenthesized!(inner in input);
+        let name = inner.parse::<parse_utils::LitStrOrExpr>()?;
+
+        inner.parse::<Token![=]>()?;
+
+        let value = inner.parse::<parse_utils::LitStrOrExpr>()?;
+
+        Ok(LinkParameter { name, value })
+    }
+}

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -30,6 +30,7 @@ pub mod example;
 pub mod external_docs;
 pub mod header;
 pub mod info;
+pub mod link;
 pub mod path;
 pub mod request_body;
 pub mod response;
@@ -586,17 +587,25 @@ pub(crate) use from;
 
 macro_rules! builder {
     ( $( #[$builder_meta:meta] )* $builder_name:ident; $(#[$meta:meta])* $vis:vis $key:ident $name:ident $( $tt:tt )* ) => {
-        builder!( @type_impl $( #[$meta] )* $vis $key $name $( $tt )* );
+        builder!( @type_impl $builder_name $( #[$meta] )* $vis $key $name $( $tt )* );
         builder!( @builder_impl $( #[$builder_meta] )* $builder_name $( #[$meta] )* $vis $key $name $( $tt )* );
     };
 
-    ( @type_impl $( #[$meta:meta] )* $vis:vis $key:ident $name:ident
+    ( @type_impl $builder_name:ident $( #[$meta:meta] )* $vis:vis $key:ident $name:ident
         { $( $( #[$field_meta:meta] )* $field_vis:vis $field:ident: $field_ty:ty, )* }
     ) => {
-
         $( #[$meta] )*
         $vis $key $name {
             $( $( #[$field_meta] )* $field_vis $field: $field_ty, )*
+        }
+
+        impl $name {
+            #[doc = concat!("Construct a new ", stringify!($builder_name), ".")]
+            #[doc = ""]
+            #[doc = concat!("This is effectively same as calling [`", stringify!($builder_name), "::new`]")]
+            $vis fn builder() -> $builder_name {
+                $builder_name::new()
+            }
         }
     };
 

--- a/utoipa/src/openapi/link.rs
+++ b/utoipa/src/openapi/link.rs
@@ -1,0 +1,131 @@
+//! Implements [Open API Link Object][link_object] for responses.
+//!
+//! [link_object]: https://spec.openapis.org/oas/latest.html#link-object
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::{builder, Server};
+
+builder! {
+    LinkBuilder;
+
+    /// Implements [Open API Link Object][link_object] for responses.
+    ///
+    /// The `Link` represents possible design time link for a response. It does not guarantee
+    /// callers ability to invoke it but rather provides known relationship between responses and
+    /// other operations.
+    ///
+    /// For computing links, and providing instructions to execute them,
+    /// a runtime [expression][expression] is used for accessing values in an operation
+    /// and using them as parameters while invoking the linked operation.
+    ///
+    /// [expression]: https://spec.openapis.org/oas/latest.html#runtime-expressions
+    /// [link_object]: https://spec.openapis.org/oas/latest.html#link-object
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Default)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    #[non_exhaustive]
+    pub struct Link {
+        /// A relative or absolute URI reference to an OAS operation. This field is
+        /// mutually exclusive of the _`operation_id`_ field, and **must** point to an [Operation
+        /// Object][operation].
+        /// Relative _`operation_ref`_ values may be used to locate an existing [Operation
+        /// Object][operation] in the OpenAPI definition. See the rules for resolving [Relative
+        /// References][relative_references].
+        ///
+        /// [relative_references]: https://spec.openapis.org/oas/latest.html#relative-references-in-uris
+        /// [operation]: ../path/struct.Operation.html
+        #[serde(skip_serializing_if = "String::is_empty", default)]
+        pub operation_ref: String,
+
+        /// The name of an existing, resolvable OAS operation, as defined with a unique
+        /// _`operation_id`_.
+        /// This field is mutually exclusive of the _`operation_ref`_ field.
+        #[serde(skip_serializing_if = "String::is_empty", default)]
+        pub operation_id: String,
+
+        /// A map representing parameters to pass to an operation as specified with _`operation_id`_
+        /// or identified by _`operation_ref`_. The key is parameter name to be used and value can
+        /// be any value supported by JSON or an [expression][expression] e.g. `$path.id`
+        ///
+        /// [expression]: https://spec.openapis.org/oas/latest.html#runtime-expressions
+        #[serde(skip_serializing_if = "BTreeMap::is_empty")]
+        pub parameters: BTreeMap<String, serde_json::Value>,
+
+        /// A literal value or an [expression][expression] to be used as request body when operation is called.
+        ///
+        /// [expression]: https://spec.openapis.org/oas/latest.html#runtime-expressions
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub request_body: Option<serde_json::Value>,
+
+        /// Description of the link. Value supports Markdown syntax.
+        #[serde(skip_serializing_if = "String::is_empty", default)]
+        pub description: String,
+
+        /// A [`Server`][server] object to be used by the target operation.
+        ///
+        /// [server]: ../server/struct.Server.html
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub server: Option<Server>,
+    }
+}
+
+impl LinkBuilder {
+    /// Set a relative or absolute URI reference to an OAS operation. This field is
+    /// mutually exclusive of the _`operation_id`_ field, and **must** point to an [Operation
+    /// Object][operation].
+    ///
+    /// [operation]: ../path/struct.Operation.html
+    pub fn operation_ref<S: Into<String>>(mut self, operation_ref: S) -> Self {
+        self.operation_ref = operation_ref.into();
+
+        self
+    }
+
+    /// Set the name of an existing, resolvable OAS operation, as defined with a unique
+    /// _`operation_id`_.
+    /// This field is mutually exclusive of the _`operation_ref`_ field.
+    pub fn operation_id<S: Into<String>>(mut self, operation_id: S) -> Self {
+        self.operation_id = operation_id.into();
+
+        self
+    }
+
+    /// Add parameter to be passed to [Operation][operation] upon execution.
+    ///
+    /// [operation]: ../path/struct.Operation.html
+    pub fn parameter<N: Into<String>, V: Into<serde_json::Value>>(
+        mut self,
+        name: N,
+        value: V,
+    ) -> Self {
+        self.parameters.insert(name.into(), value.into());
+
+        self
+    }
+
+    /// Set a literal value or an [expression][expression] to be used as request body when operation is called.
+    ///
+    /// [expression]: https://spec.openapis.org/oas/latest.html#runtime-expressions
+    pub fn request_body<B: Into<serde_json::Value>>(mut self, request_body: Option<B>) -> Self {
+        self.request_body = request_body.map(|request_body| request_body.into());
+
+        self
+    }
+
+    /// Set description of the link. Value supports Markdown syntax.
+    pub fn description<S: Into<String>>(mut self, description: S) -> Self {
+        self.description = description.into();
+
+        self
+    }
+
+    /// Set a [`Server`][server] object to be used by the target operation.
+    ///
+    /// [server]: ../server/struct.Server.html
+    pub fn server<S: Into<Server>>(mut self, server: Option<S>) -> Self {
+        self.server = server.map(|server| server.into());
+
+        self
+    }
+}

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::openapi::{Ref, RefOr};
 use crate::IntoResponses;
 
+use super::link::Link;
 use super::{builder, header::Header, set_value, Content};
 
 builder! {
@@ -123,6 +124,11 @@ builder! {
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
         pub extensions: Option<HashMap<String, serde_json::Value>>,
+
+        /// A map of operations links that can be followed from the response. The key of the
+        /// map is a short name for the link.
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+        pub links: BTreeMap<String, RefOr<Link>>,
     }
 }
 
@@ -161,6 +167,13 @@ impl ResponseBuilder {
     /// Add openapi extensions (x-something) to the [`Header`].
     pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Add link that can be followed from the response.
+    pub fn link<S: Into<String>, L: Into<RefOr<Link>>>(mut self, name: S, link: L) -> Self {
+        self.links.insert(name.into(), link.into());
+
+        self
     }
 }
 


### PR DESCRIPTION
This commit adds support for OpenAPI links https://spec.openapis.org/oas/latest.html#link-object in `#[utoipa::path(...)]` response object.

Also improve documentation as mentioned in issue #919

This commit also adds `builder()` method to each type which has builder instance . The method is synonymous for `*Builder::new()`.

Closes #551 Closes #919