### PR TITLE
Add global config for `utiopa`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,7 @@ jobs:
           - utoipa-rapidoc
           - utoipa-scalar
           - utoipa-axum
+          - utoipa-config
       fail-fast: true
     runs-on: ubuntu-latest
 
@@ -68,6 +69,8 @@ jobs:
             elif [[ "$change" == "utoipa-scalar" && "${{ matrix.crate }}" == "utoipa-scalar" && $changes == false ]]; then
               changes=true
             elif [[ "$change" == "utoipa-axum" && "${{ matrix.crate }}" == "utoipa-axum" && $changes == false ]]; then
+              changes=true
+            elif [[ "$change" == "utoipa-config" && "${{ matrix.crate }}" == "utoipa-config" && $changes == false ]]; then
               changes=true
             fi
           done < <(git diff --name-only ${{ github.sha }}~ ${{ github.sha }} | grep .rs | awk -F \/ '{print $1}')

--- a/.github/workflows/draft.yaml
+++ b/.github/workflows/draft.yaml
@@ -21,6 +21,7 @@ jobs:
           - utoipa-rapidoc
           - utoipa-scalar
           - utoipa-axum
+          - utoipa-config
     runs-on: ubuntu-latest
 
     steps:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,12 @@ members = [
     "utoipa-rapidoc",
     "utoipa-scalar",
     "utoipa-axum",
+    "utoipa-config",
 ]
 
 [workspace.metadata.publish]
 order = [
+    "utoipa-config",
     "utoipa-gen",
     "utoipa",
     "utoipa-swagger-ui-vendored",

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also an awesome type of beer 
 - **`non_strict_integers`**: Add support for non-standard integer formats `int8`, `int16`, `uint8`, `uint16`, `uint32`, and `uint64`.
 - **`rc_schema`**: Add `ToSchema` support for `Arc<T>` and `Rc<T>` types. **Note!** serde `rc` feature flag must be enabled separately to allow
   serialization and deserialization of `Arc<T>` and `Rc<T>` types. See more about [serde feature flags](https://serde.rs/feature-flags.html).
+- **`config`** Enables [`utoipa-config`](./utoipa-config/README.md) for the project which allows defining global configuration options `utoipa`.
 
 Utoipa implicitly has partial support for `serde` attributes. See [docs](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html#partial-serde-attributes-support) for more details.
 
@@ -332,10 +333,10 @@ Find `utoipa-swagger-ui` [feature flags here](https://github.com/juhaku/utoipa/t
 
 There are few ways around this that are elaborated [here in detail](https://github.com/juhaku/utoipa/issues/790#issuecomment-1787754185).
 
-### How to use Rust's type aliases?
+### How to define Rust type aliases?
 
-At the moment that is not possible due to there is no way to evaluate the actual type behind the type token that is visible to the proc macro code generation.
-This might be possible in future if a global alias registry can be implemented. Here is an issue related to the topic [#766](https://github.com/juhaku/utoipa/issues/766).
+1. Enable `config` feature flag.
+2. See instructions [here](./utoipa-config/README.md).
 
 ### Auto discover for OpenAPI schemas and paths?
 

--- a/examples/config-test-crate
+++ b/examples/config-test-crate
@@ -1,0 +1,1 @@
+../utoipa-config/config-test-crate

--- a/scripts/doc.sh
+++ b/scripts/doc.sh
@@ -3,5 +3,5 @@
 # Generate utoipa workspace docs
 
 cargo +nightly doc -Z unstable-options --workspace --no-deps \
-    --features actix_extras,openapi_extensions,yaml,uuid,ulid,url,non_strict_integers,actix-web,axum,rocket,macros \
+    --features actix_extras,openapi_extensions,yaml,uuid,ulid,url,non_strict_integers,actix-web,axum,rocket,macros,config \
     --config 'build.rustdocflags = ["--cfg", "doc_cfg"]'

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -40,5 +40,9 @@ for crate in $crates; do
         $CARGO ${CARGO_COMMAND} -p utoipa-scalar --features actix-web,rocket,axum,utoipa/macros
     elif [[ "$crate" == "utoipa-axum" ]]; then
         $CARGO ${CARGO_COMMAND} -p utoipa-axum --features debug,utoipa/debug,utoipa/macros
+    elif [[ "$crate" == "utoipa-config" ]]; then
+        pushd utoipa-config/config-test-crate/
+        $CARGO ${CARGO_COMMAND}
+        popd
     fi
 done

--- a/utoipa-config/Cargo.toml
+++ b/utoipa-config/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "utoipa-config"
+description = "Config for controlling utoipa's various aspects"
+version = "0.1.0"
+edition = "2021"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+keywords = ["utoipa", "config", "utoipa-gen", "openapi", "auto-generate"]
+repository = "https://github.com/juhaku/utoipa"
+categories = ["web-programming"]
+authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
+rust-version.workspace = true
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0" }
+
+[package.metadata.docs.rs]
+features = []
+rustdoc-args = ["--cfg", "doc_cfg"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/utoipa-config/README.md
+++ b/utoipa-config/README.md
@@ -1,0 +1,44 @@
+# utoipa-config
+
+[![Utoipa build](https://github.com/juhaku/utoipa/actions/workflows/build.yaml/badge.svg)](https://github.com/juhaku/utoipa/actions/workflows/build.yaml)
+[![crates.io](https://img.shields.io/crates/v/utoipa-config.svg?label=crates.io&color=orange&logo=rust)](https://crates.io/crates/utoipa-config)
+[![docs.rs](https://img.shields.io/static/v1?label=docs.rs&message=utoipa-config&color=blue&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K)](https://docs.rs/utoipa-config/latest/)
+![rustc](https://img.shields.io/static/v1?label=rustc&message=1.75&color=orange&logo=rust)
+
+This crate provides global configuration capabilities for `utoipa`. Currently only supports providing Rust type aliases.
+
+## Install
+
+Add dependency declaration to `Cargo.toml`.
+
+```toml
+[build-dependencies]
+utoipa_config = "0.1"
+```
+
+> [NOTE!]
+> Not released yet.
+
+## Examples
+
+Create `build.rs` file with following content, then in your code you can just use `MyType` as 
+alternative for `i32`.
+
+```rust
+use utoipa_config::Config;
+
+fn main() {
+    Config::new()
+        .alias_for("MyType", "i32")
+        .write_to_file();
+}
+```
+
+See full [example for utoipa-config](../examples/config-test-crate/).
+
+## License
+
+Licensed under either of [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT) license at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this crate
+by you, shall be dual licensed, without any additional terms or conditions.

--- a/utoipa-config/config-test-crate/Cargo.toml
+++ b/utoipa-config/config-test-crate/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "utoipa-config-test"
+version = "0.1.0"
+edition = "2021"
+rust-version = "1.75"
+
+[dependencies]
+utoipa = { version = "5.0.0-beta.0", path = "../../utoipa", features = [
+    "debug",
+    "config",
+] }
+serde = "1"
+serde_json = "1"
+
+[build-dependencies]
+utoipa-config = { version = "0.1", path = "../../utoipa-config" }
+
+[dev-dependencies]
+utoipa-config = { version = "0.1", path = "../../utoipa-config" }
+
+[workspace]

--- a/utoipa-config/config-test-crate/README.md
+++ b/utoipa-config/config-test-crate/README.md
@@ -1,0 +1,4 @@
+# utoipa-config-test
+
+This example demonstrates global Rust type aliases in utoipa project. 
+Check out `main.rs` and `build.rs` and then run `cargo run`.

--- a/utoipa-config/config-test-crate/build.rs
+++ b/utoipa-config/config-test-crate/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    utoipa_config::Config::new()
+        .alias_for("MyType", "bool")
+        .alias_for("MyInt", "Option<i32>")
+        .alias_for("MyValue", "str")
+        .alias_for("MyDateTime", "String")
+        .write_to_file()
+}

--- a/utoipa-config/config-test-crate/src/main.rs
+++ b/utoipa-config/config-test-crate/src/main.rs
@@ -1,0 +1,35 @@
+use utoipa::ToSchema;
+
+#[allow(unused)]
+#[derive(ToSchema)]
+struct AliasValues {
+    name: String,
+
+    #[schema(value_type = MyType)]
+    my_type: String,
+
+    #[schema(value_type = MyInt)]
+    my_int: String,
+
+    #[schema(value_type = MyValue)]
+    my_value: bool,
+
+    date: MyDateTime,
+}
+
+#[allow(unused)]
+struct MyDateTime {
+    millis: usize,
+}
+
+fn main() {
+    let schema = utoipa::schema!(
+        #[inline]
+        AliasValues
+    );
+
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&schema).expect("schema must be JSON serializable")
+    );
+}

--- a/utoipa-config/config-test-crate/tests/config.rs
+++ b/utoipa-config/config-test-crate/tests/config.rs
@@ -1,0 +1,86 @@
+use std::borrow::Cow;
+
+use utoipa::ToSchema;
+use utoipa_config::Config;
+
+#[test]
+fn test_create_config_with_aliases() {
+    Config::new()
+        .alias_for("i32", "Option<String>")
+        .write_to_file();
+
+    let config = Config::read_from_file();
+
+    assert!(!config.aliases.is_empty());
+    assert!(config.aliases.contains_key("i32"));
+    assert_eq!(
+        config.aliases.get("i32"),
+        Some(&Cow::Borrowed("Option<String>"))
+    );
+}
+
+#[test]
+fn test_to_schema_with_aliases() {
+    #[allow(unused)]
+    #[derive(ToSchema)]
+    struct AliasValues {
+        name: String,
+
+        #[schema(value_type = MyType)]
+        my_type: String,
+
+        #[schema(value_type = MyInt)]
+        my_int: String,
+
+        #[schema(value_type = MyValue)]
+        my_value: bool,
+
+        date: MyDateTime,
+    }
+
+    #[allow(unused)]
+    struct MyDateTime {
+        millis: usize,
+    }
+
+    let schema = utoipa::schema!(
+        #[inline]
+        AliasValues
+    );
+
+    let actual = serde_json::to_string_pretty(&schema).expect("schema must be JSON serializable");
+
+    let expected = r#"{
+  "type": "object",
+  "required": [
+    "name",
+    "my_type",
+    "my_value",
+    "date"
+  ],
+  "properties": {
+    "date": {
+      "type": "string"
+    },
+    "my_int": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "int32"
+    },
+    "my_type": {
+      "type": "boolean"
+    },
+    "my_value": {
+      "type": "string"
+    },
+    "name": {
+      "type": "string"
+    }
+  }
+}"#;
+
+    println!("{actual}");
+    assert_eq!(expected.trim(), actual.trim())
+}

--- a/utoipa-config/src/lib.rs
+++ b/utoipa-config/src/lib.rs
@@ -1,0 +1,143 @@
+#![warn(missing_docs)]
+#![warn(rustdoc::broken_intra_doc_links)]
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
+//! This crate provides global configuration capabilities for [`utoipa`](https://docs.rs/utoipa/latest/utoipa/). Currently only
+//! supports providing Rust type aliases.
+//!
+//! ## Install
+//!
+//! Add dependency declaration to `Cargo.toml`.
+//!
+//! ```toml
+//! [build-dependencies]
+//! utoipa_config = "0.1"
+//! ```
+//!
+//! ## Examples
+//!
+//! _**Create `build.rs` file with following content, then in your code you can just use `MyType` as
+//! alternative for `i32`.**_
+//!
+//! ```rust
+//! # #![allow(clippy::needless_doctest_main)]
+//! use utoipa_config::Config;
+//!
+//! fn main() {
+//!     Config::new()
+//!         .alias_for("MyType", "i32")
+//!         .write_to_file();
+//! }
+//! ```
+//!
+//! See full [example for utoipa-config](https://github.com/juhaku/utoipa/tree/master/examples/config-test-crate/).
+
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fs;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+/// Global configuration initialized in `build.rs` of user project.
+///
+/// This works similar fashion to what `hyperium/tonic` grpc library does with the project configuration. See
+/// the quick usage from [module documentation][module]
+///
+/// [module]: ./index.html
+#[derive(Default, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Config<'c> {
+    /// A map of global aliases `utoipa` will recognize as types.
+    #[doc(hidden)]
+    pub aliases: HashMap<Cow<'c, str>, Cow<'c, str>>,
+}
+
+impl<'c> Config<'c> {
+    const NAME: &'static str = "utoipa-config.json";
+
+    /// Construct a new [`Config`].
+    pub fn new() -> Self {
+        Self {
+            ..Default::default()
+        }
+    }
+
+    /// Add new global alias.
+    ///
+    /// This method accepts two arguments. First being identifier of the user's type alias.
+    /// Second is the type path definition to be used as alias value. The _`value`_ can be anything
+    /// that `utoipa` can parse as `TypeTree` and can be used as type for a value.
+    ///
+    /// Because of `TypeTree` the aliased value can also be a fairly complex type and not limited
+    /// to primitive types. This also allows users create custom types which can be treated as
+    /// primitive types. E.g. One could create custom date time type that is treated as chrono's
+    /// DateTime or a String.
+    ///
+    /// # Examples
+    ///
+    /// _**Create `MyType` alias for `i32`.**_
+    /// ```rust
+    /// use utoipa_config::Config;
+    ///
+    /// let _ = Config::new()
+    ///     .alias_for("MyType", "i32");
+    /// ```
+    ///
+    /// _**Create `Json` alias for `serde_json::Value`.**_
+    /// ```rust
+    /// use utoipa_config::Config;
+    ///
+    /// let _ = Config::new()
+    ///     .alias_for("Json", "Value");
+    /// ```
+    /// _**Create `NullableString` alias for `Option<String>`.**_
+    /// ```rust
+    /// use utoipa_config::Config;
+    ///
+    /// let _ = Config::new()
+    ///     .alias_for("NullableString", "Option<String>");
+    /// ```
+    pub fn alias_for(mut self, alias: &'c str, value: &'c str) -> Config<'c> {
+        self.aliases
+            .insert(Cow::Borrowed(alias), Cow::Borrowed(value));
+
+        self
+    }
+
+    fn get_out_dir() -> Option<String> {
+        match std::env::var("OUT_DIR") {
+            Ok(out_dir) => Some(out_dir),
+            Err(_) => None,
+        }
+    }
+
+    /// Write the current [`Config`] to a file. This persists the [`Config`] for `utoipa` to read
+    /// and use later.
+    pub fn write_to_file(&self) {
+        let json = serde_json::to_string(self).expect("Config must be JSON serializable");
+
+        let Some(out_dir) = Config::get_out_dir() else {
+            return;
+        };
+
+        match fs::write([&*out_dir, Config::NAME].iter().collect::<PathBuf>(), json) {
+            Ok(_) => (),
+            Err(error) => panic!("Failed to write config {}, error: {error}", Config::NAME),
+        };
+    }
+
+    /// Read a [`Config`] from a file. Used internally by `utiopa`.
+    #[doc(hidden)]
+    pub fn read_from_file() -> Config<'c> {
+        let Some(out_dir) = Config::get_out_dir() else {
+            return Config::default();
+        };
+
+        let str = match fs::read_to_string([&*out_dir, Config::NAME].iter().collect::<PathBuf>()) {
+            Ok(str) => str,
+            Err(error) => panic!("Failed to read config: {}, error: {error}", Config::NAME),
+        };
+
+        serde_json::from_str(&str).expect("Config muts be JSON deserializable")
+    }
+}

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -14,6 +14,8 @@ rust-version.workspace = true
 proc-macro = true
 
 [dependencies]
+utoipa-config = { version = "0.1", path = "../utoipa-config", optional = true }
+once_cell = { version = "1.19.0", optional = true }
 proc-macro2 = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
@@ -23,11 +25,18 @@ ulid = { version = "1", optional = true, default-features = false }
 url = { version = "2", optional = true }
 
 [dev-dependencies]
-utoipa = { path = "../utoipa", features = ["debug", "uuid", "macros"], default-features = false }
+utoipa = { path = "../utoipa", features = [
+    "debug",
+    "uuid",
+    "macros",
+], default-features = false }
 serde_json = "1"
 serde = "1"
 actix-web = { version = "4", features = ["macros"], default-features = false }
-axum = { version = "0.7", default-features = false, features = ["json", "query"] }
+axum = { version = "0.7", default-features = false, features = [
+    "json",
+    "query",
+] }
 paste = "1"
 rocket = { version = "0.5", features = ["json"] }
 smallvec = { version = "1.10", features = ["serde"] }
@@ -56,6 +65,7 @@ smallvec = []
 repr = []
 indexmap = []
 rc_schema = []
+config = ["dep:utoipa-config", "dep:once_cell"]
 
 # EXPERIEMENTAL! use with cauntion
 auto_into_responses = []

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -410,6 +410,24 @@ impl<'t> TypeTree<'t> {
 
         Ok(generics)
     }
+
+    /// Get possible global alias defined in `utoipa_config::Config` for current `TypeTree`.
+    pub fn get_alias_type(&self) -> Result<Option<syn::Type>, Diagnostics> {
+        #[cfg(feature = "config")]
+        {
+            self.path
+                .as_ref()
+                .and_then(|path| path.segments.iter().last())
+                .and_then(|last_segment| {
+                    crate::CONFIG.aliases.get(&*last_segment.ident.to_string())
+                })
+                .map_try(|alias| syn::parse_str::<syn::Type>(alias.as_ref()))
+                .map_err(|error| Diagnostics::new(error.to_string()))
+        }
+
+        #[cfg(not(feature = "config"))]
+        Ok(None)
+    }
 }
 
 impl PartialEq for TypeTree<'_> {

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -287,6 +287,11 @@ impl NamedStructSchema<'_> {
         let schema_with = pop_feature!(field_features => Feature::SchemaWith(_));
         let required = pop_feature!(field_features => Feature::Required(_) as Option<crate::component::features::attributes::Required>);
         let type_tree = override_type_tree.as_ref().unwrap_or(type_tree);
+
+        let alias_type = type_tree.get_alias_type()?;
+        let alias_type_tree = alias_type.as_ref().map_try(TypeTree::from_type)?;
+        let type_tree = alias_type_tree.as_ref().unwrap_or(type_tree);
+
         let is_option = type_tree.is_option();
 
         Ok(NamedStructFieldOptions {
@@ -556,6 +561,11 @@ impl ToTokensDiagnostics for UnnamedStructSchema<'_> {
                 .map(ComponentDescription::Description)
                 .or(Some(ComponentDescription::CommentAttributes(&comments)));
             let type_tree = override_type_tree.as_ref().unwrap_or(first_part);
+
+            let alias_type = type_tree.get_alias_type()?;
+            let alias_type_tree = alias_type.as_ref().map_try(TypeTree::from_type)?;
+            let type_tree = alias_type_tree.as_ref().unwrap_or(type_tree);
+
             tokens.extend(
                 ComponentSchema::new(super::ComponentSchemaProps {
                     type_tree,

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -65,6 +65,10 @@ use self::{
     path::response::derive::{IntoResponses, ToResponse},
 };
 
+#[cfg(feature = "config")]
+static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
+    once_cell::sync::Lazy::new(utoipa_config::Config::read_from_file);
+
 #[proc_macro_derive(ToSchema, attributes(schema))]
 /// Generate reusable OpenAPI schema to be used
 /// together with [`OpenApi`][openapi_derive].

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -43,6 +43,7 @@ preserve_order = []
 preserve_path_order = []
 rc_schema = ["utoipa-gen?/rc_schema"]
 macros = ["dep:utoipa-gen"]
+config = ["utoipa-gen?/config"]
 
 # EXPERIEMENTAL! use with cauntion
 auto_into_responses = ["utoipa-gen?/auto_into_responses"]
@@ -59,7 +60,16 @@ assert-json-diff = "2"
 utoipa = { path = ".", features = ["debug"] }
 
 [package.metadata.docs.rs]
-features = ["actix_extras", "non_strict_integers", "openapi_extensions", "uuid", "ulid", "url", "yaml", "macros"]
+features = [
+    "actix_extras",
+    "non_strict_integers",
+    "openapi_extensions",
+    "uuid",
+    "ulid",
+    "url",
+    "yaml",
+    "macros",
+]
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [lints.rust]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -96,6 +96,8 @@
 //! * **`non_strict_integers`** Add support for non-standard integer formats `int8`, `int16`, `uint8`, `uint16`, `uint32`, and `uint64`.
 //! * **`rc_schema`** Add `ToSchema` support for `Arc<T>` and `Rc<T>` types. **Note!** serde `rc` feature flag must be enabled separately to allow
 //!   serialization and deserialization of `Arc<T>` and `Rc<T>` types. See more about [serde feature flags](https://serde.rs/feature-flags.html).
+//! * **`config`** Enables [`utoipa-config`](https://docs.rs/utoipa-config/) for the project which allows
+//!   defining global configuration options `utoipa`.
 //!
 //! Utoipa implicitly has partial support for `serde` attributes. See [`ToSchema` derive][serde] for more details.
 //!


### PR DESCRIPTION
This PR adds global config for `utiopa` which allows defining global Rust type aliases that can be recognized by `utoipa`.

```rust
 let _ = Config::new()
     .alias_for("MyType", "i32");
     .alias_for("Json", "Value");
     .alias_for("NullableString", "Option<String>");
```

Closes #984 Closes #787 Closes #766 Closes #429 Closes #547