### PR TITLE
Add explicit `Extensions` type

### DIFF
--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -4,7 +4,7 @@ use serde::{
     de::{Error, Expected, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::{collections::HashMap, fmt::Formatter, mem};
+use std::{fmt::Formatter, mem};
 
 use self::path::PathsMap;
 pub use self::{
@@ -27,6 +27,7 @@ pub use self::{
 pub mod content;
 pub mod encoding;
 pub mod example;
+pub mod extensions;
 pub mod external_docs;
 pub mod header;
 pub mod info;
@@ -128,7 +129,7 @@ builder! {
 
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -637,6 +638,7 @@ macro_rules! builder {
         crate::openapi::from!($name $builder_name $( $field ),* );
     };
 }
+use crate::openapi::extensions::Extensions;
 pub(crate) use builder;
 
 #[cfg(test)]
@@ -1035,7 +1037,7 @@ mod tests {
     #[test]
     fn openapi_custom_extension() {
         let mut api = OpenApiBuilder::new().build();
-        let extensions = api.extensions.get_or_insert(HashMap::new());
+        let extensions = api.extensions.get_or_insert(Default::default());
         extensions.insert(
             String::from("x-tagGroup"),
             String::from("anything that serializes to Json").into(),

--- a/utoipa/src/openapi/extensions.rs
+++ b/utoipa/src/openapi/extensions.rs
@@ -1,0 +1,97 @@
+//! Implements [OpenAPI Extensions][external_docs].
+//!
+/// [extensions]: https://spec.openapis.org/oas/latest.html#specification-extensions
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
+
+use serde::Serialize;
+
+use super::builder;
+
+const EXTENSION_PREFIX: &str = "x-";
+
+builder! {
+    ExtensionsBuilder;
+
+    /// Additional [data for extending][extensions] the OpenAPI specification.
+    ///
+    /// [extensions]: https://spec.openapis.org/oas/latest.html#specification-extensions
+    #[derive(Default, Serialize, Clone, PartialEq, Eq)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct Extensions{
+        #[serde(flatten)]
+        extensions: HashMap<String, serde_json::Value>,
+    }
+}
+
+impl Deref for Extensions {
+    type Target = HashMap<String, serde_json::Value>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.extensions
+    }
+}
+
+impl DerefMut for Extensions {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.extensions
+    }
+}
+
+impl From<Extensions> for HashMap<String, serde_json::Value> {
+    fn from(value: Extensions) -> Self {
+        value.extensions
+    }
+}
+
+impl<'de> serde::de::Deserialize<'de> for Extensions {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let extensions: HashMap<String, _> = HashMap::deserialize(deserializer)?;
+        let extensions = extensions
+            .into_iter()
+            .filter(|(k, _)| k.starts_with(EXTENSION_PREFIX))
+            .collect();
+        Ok(Self { extensions })
+    }
+}
+
+impl ExtensionsBuilder {
+    /// Adds a key-value pair to the extensions. Extensions keys are prefixed with `"x-"` if
+    /// not done already.
+    pub fn add<K, V>(mut self, key: K, value: V) -> Self
+    where
+        K: Into<String>,
+        V: Into<serde_json::Value>,
+    {
+        let mut key: String = key.into();
+        if !key.starts_with(EXTENSION_PREFIX) {
+            key = format!("{EXTENSION_PREFIX}{key}");
+        }
+        self.extensions.insert(key, value.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extensions_builder() {
+        let expected = json!("value");
+        let extensions = ExtensionsBuilder::new()
+            .add("x-some-extension", expected.clone())
+            .add("another-extension", expected.clone())
+            .build();
+
+        let value = serde_json::to_value(&extensions).unwrap();
+        assert_eq!(value.get("x-some-extension"), Some(&expected));
+        assert_eq!(value.get("x-another-extension"), Some(&expected));
+    }
+}

--- a/utoipa/src/openapi/extensions.rs
+++ b/utoipa/src/openapi/extensions.rs
@@ -40,6 +40,18 @@ impl DerefMut for Extensions {
     }
 }
 
+impl<K, V> FromIterator<(K, V)> for Extensions
+where
+    K: Into<String>,
+    V: Into<serde_json::Value>,
+{
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let iter = iter.into_iter().map(|(k, v)| (k.into(), v.into()));
+        let extensions = HashMap::from_iter(iter);
+        Self { extensions }
+    }
+}
+
 impl From<Extensions> for HashMap<String, serde_json::Value> {
     fn from(value: Extensions) -> Self {
         value.extensions
@@ -93,5 +105,19 @@ mod tests {
         let value = serde_json::to_value(&extensions).unwrap();
         assert_eq!(value.get("x-some-extension"), Some(&expected));
         assert_eq!(value.get("x-another-extension"), Some(&expected));
+    }
+
+    #[test]
+    fn extensions_from_iter() {
+        let expected = json!("value");
+        let extensions: Extensions = [
+            ("x-some-extension", expected.clone()),
+            ("another-extension", expected.clone()),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(extensions.get("x-some-extension"), Some(&expected));
+        assert_eq!(extensions.get("another-extension"), Some(&expected));
     }
 }

--- a/utoipa/src/openapi/info.rs
+++ b/utoipa/src/openapi/info.rs
@@ -6,11 +6,10 @@
 //! [info]: <https://spec.openapis.org/oas/latest.html#info-object>
 //! [openapi_trait]: ../../trait.OpenApi.html
 //! [derive]: ../../derive.OpenApi.html
-use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use super::{builder, set_value};
+use super::{builder, extensions::Extensions, set_value};
 
 builder! {
     /// # Examples
@@ -71,7 +70,7 @@ builder! {
 
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -128,7 +127,7 @@ impl InfoBuilder {
     }
 
     /// Add openapi extensions (x-something) of the API.
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 }

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -1,14 +1,13 @@
 //! Implements [OpenAPI Path Object][paths] types.
 //!
 //! [paths]: https://spec.openapis.org/oas/latest.html#paths-object
-use std::collections::HashMap;
-
 use crate::Path;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use super::{
     builder,
+    extensions::Extensions,
     request_body::RequestBody,
     response::{Response, Responses},
     security::SecurityRequirement,
@@ -39,7 +38,7 @@ builder! {
 
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -148,7 +147,7 @@ impl PathsBuilder {
     }
 
     /// Add extensions to the paths section.
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 
@@ -262,7 +261,7 @@ builder! {
 
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -377,7 +376,7 @@ impl PathItemBuilder {
     }
 
     /// Add openapi extensions (x-something) to this [`PathItem`].
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 }
@@ -495,7 +494,7 @@ builder! {
 
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -639,7 +638,7 @@ impl OperationBuilder {
     }
 
     /// Add openapi extensions (x-something) of the [`Operation`].
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 }
@@ -715,7 +714,7 @@ builder! {
 
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -789,7 +788,7 @@ impl ParameterBuilder {
     }
 
     /// Add openapi extensions (x-something) to the [`Parameter`].
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 }

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -1,7 +1,7 @@
 //! Implements [OpenApi Responses][responses].
 //!
 //! [responses]: https://spec.openapis.org/oas/latest.html#responses-object
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 use crate::openapi::{Ref, RefOr};
 use crate::IntoResponses;
 
+use super::extensions::Extensions;
 use super::link::Link;
 use super::{builder, header::Header, set_value, Content};
 
@@ -123,7 +124,7 @@ builder! {
 
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
 
         /// A map of operations links that can be followed from the response. The key of the
         /// map is a short name for the link.
@@ -165,7 +166,7 @@ impl ResponseBuilder {
     }
 
     /// Add openapi extensions (x-something) to the [`Header`].
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -2,11 +2,12 @@
 //! used to define field properties, enum values, array or object types.
 //!
 //! [schema]: https://spec.openapis.org/oas/latest.html#schema-object
-use std::collections::{BTreeMap, HashMap};
+use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::extensions::Extensions;
 use super::RefOr;
 use super::{builder, security::SecurityScheme, set_value, xml::Xml, Deprecated, Response};
 use crate::{ToResponse, ToSchema};
@@ -147,7 +148,7 @@ impl ComponentsBuilder {
     /// # use utoipa::{ToSchema, openapi::schema::ComponentsBuilder};
     ///  #[derive(ToSchema)]
     ///  struct Value(String);
-    ///  
+    ///
     ///  let _ = ComponentsBuilder::new().schema_from::<Value>().build();
     /// ```
     pub fn schema_from<I: ToSchema>(mut self) -> Self {
@@ -418,7 +419,7 @@ builder! {
 
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -516,7 +517,7 @@ impl OneOfBuilder {
     }
 
     /// Add openapi extensions (`x-something`) for [`OneOf`].
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 
@@ -589,7 +590,7 @@ builder! {
 
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -687,7 +688,7 @@ impl AllOfBuilder {
     }
 
     /// Add openapi extensions (`x-something`) for [`AllOf`].
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 
@@ -756,7 +757,7 @@ builder! {
 
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -848,7 +849,7 @@ impl AnyOfBuilder {
     }
 
     /// Add openapi extensions (`x-something`) for [`AnyOf`].
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 
@@ -1009,7 +1010,7 @@ builder! {
 
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
 
         /// The `content_encoding` keyword specifies the encoding used to store the contents, as specified in
         /// [RFC 2054, part 6.1](https://tools.ietf.org/html/rfc2045) and [RFC 4648](RFC 2054, part 6.1).
@@ -1222,7 +1223,7 @@ impl ObjectBuilder {
     }
 
     /// Add openapi extensions (`x-something`) for [`Object`].
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 
@@ -1507,7 +1508,7 @@ builder! {
 
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -1643,7 +1644,7 @@ impl ArrayBuilder {
     }
 
     /// Add openapi extensions (`x-something`) for [`Array`].
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 
@@ -2604,11 +2605,10 @@ mod tests {
     #[test]
     fn object_with_extensions() {
         let expected = json!("value");
-        let json_value = ObjectBuilder::new()
-            .extensions(Some(
-                [("x-some-extension".to_string(), expected.clone())].into(),
-            ))
+        let extensions = extensions::ExtensionsBuilder::new()
+            .add("x-some-extension", expected.clone())
             .build();
+        let json_value = ObjectBuilder::new().extensions(Some(extensions)).build();
 
         let value = serde_json::to_value(&json_value).unwrap();
         assert_eq!(value.get("x-some-extension"), Some(&expected));
@@ -2617,11 +2617,10 @@ mod tests {
     #[test]
     fn array_with_extensions() {
         let expected = json!("value");
-        let json_value = ArrayBuilder::new()
-            .extensions(Some(
-                [("x-some-extension".to_string(), expected.clone())].into(),
-            ))
+        let extensions = extensions::ExtensionsBuilder::new()
+            .add("x-some-extension", expected.clone())
             .build();
+        let json_value = ArrayBuilder::new().extensions(Some(extensions)).build();
 
         let value = serde_json::to_value(&json_value).unwrap();
         assert_eq!(value.get("x-some-extension"), Some(&expected));
@@ -2630,11 +2629,10 @@ mod tests {
     #[test]
     fn oneof_with_extensions() {
         let expected = json!("value");
-        let json_value = OneOfBuilder::new()
-            .extensions(Some(
-                [("x-some-extension".to_string(), expected.clone())].into(),
-            ))
+        let extensions = extensions::ExtensionsBuilder::new()
+            .add("x-some-extension", expected.clone())
             .build();
+        let json_value = OneOfBuilder::new().extensions(Some(extensions)).build();
 
         let value = serde_json::to_value(&json_value).unwrap();
         assert_eq!(value.get("x-some-extension"), Some(&expected));
@@ -2643,11 +2641,10 @@ mod tests {
     #[test]
     fn allof_with_extensions() {
         let expected = json!("value");
-        let json_value = AllOfBuilder::new()
-            .extensions(Some(
-                [("x-some-extension".to_string(), expected.clone())].into(),
-            ))
+        let extensions = extensions::ExtensionsBuilder::new()
+            .add("x-some-extension", expected.clone())
             .build();
+        let json_value = AllOfBuilder::new().extensions(Some(extensions)).build();
 
         let value = serde_json::to_value(&json_value).unwrap();
         assert_eq!(value.get("x-some-extension"), Some(&expected));
@@ -2656,11 +2653,10 @@ mod tests {
     #[test]
     fn anyof_with_extensions() {
         let expected = json!("value");
-        let json_value = AnyOfBuilder::new()
-            .extensions(Some(
-                [("x-some-extension".to_string(), expected.clone())].into(),
-            ))
+        let extensions = extensions::ExtensionsBuilder::new()
+            .add("x-some-extension", expected.clone())
             .build();
+        let json_value = AnyOfBuilder::new().extensions(Some(extensions)).build();
 
         let value = serde_json::to_value(&json_value).unwrap();
         assert_eq!(value.get("x-some-extension"), Some(&expected));

--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -3,14 +3,11 @@
 //! Refer to [`SecurityScheme`] for usage and more details.
 //!
 //! [security]: https://spec.openapis.org/oas/latest.html#security-scheme-object
-use std::{
-    collections::{BTreeMap, HashMap},
-    iter,
-};
+use std::{collections::BTreeMap, iter};
 
 use serde::{Deserialize, Serialize};
 
-use super::builder;
+use super::{builder, extensions::Extensions};
 
 /// OpenAPI [security requirement][security] object.
 ///
@@ -427,7 +424,7 @@ pub struct OAuth2 {
 
     /// Optional extensions "x-something".
     #[serde(skip_serializing_if = "Option::is_none", flatten)]
-    pub extensions: Option<HashMap<String, serde_json::Value>>,
+    pub extensions: Option<Extensions>,
 }
 
 impl OAuth2 {

--- a/utoipa/src/openapi/tag.rs
+++ b/utoipa/src/openapi/tag.rs
@@ -1,11 +1,9 @@
 //! Implements [OpenAPI Tag Object][tag] types.
 //!
 //! [tag]: https://spec.openapis.org/oas/latest.html#tag-object
-use std::collections::HashMap;
-
 use serde::{Deserialize, Serialize};
 
-use super::{builder, external_docs::ExternalDocs, set_value};
+use super::{builder, extensions::Extensions, external_docs::ExternalDocs, set_value};
 
 builder! {
     TagBuilder;
@@ -33,7 +31,7 @@ builder! {
 
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
-        pub extensions: Option<HashMap<String, serde_json::Value>>,
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -64,7 +62,7 @@ impl TagBuilder {
     }
 
     /// Add openapi extensions (x-something) to the tag.
-    pub fn extensions(mut self, extensions: Option<HashMap<String, serde_json::Value>>) -> Self {
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
 }


### PR DESCRIPTION
I noticed when deserializing an existing spec into `OpenApi` that some fields are getting duplicated into the extensions. This seems to happen because extensions are currently defined as a simple `HashMap<String, serde_json::Value>` (see #763) which is flattened at the respective level. This causes serde to also fill the fields.

<details><summary>Example</summary>

Given the following spec

```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "Sample API",
    "description": "API description in Markdown.",
    "version": "1.0.0"
  },
  "servers": [
    {
      "url": "https://api.example.com/v1"
    }
  ],
  "paths": {
    "/users": {
      "get": {
        "summary": "Returns a list of users.",
        "description": "Optional extended description in Markdown.",
        "responses": {
          "200": {
            "description": "OK",
            "content": {
              "application/json": {
                "schema": {
                  "type": "object"
                }
              }
            }
          }
        }
      }
    }
  },
  "components": {}
}
```

deserializing it into `OpenApi`
```rust
let openapi: OpenApi = serde_json::from_str("{...}").unwrap();
println!("{#?}", openapi.extensions);
```
We see that the `extensions` fields get populated even though no extensions are specified.
```
Some(
    {
        "paths": Object {
            "/users": Object {
                "get": Object {
                    "description": String("Optional extended description in Markdown."),
                    "responses": Object {
                        "200": Object {
                            "content": Object {
                                "application/json": Object {
                                    "schema": Object {
                                        "type": String("object"),
                                    },
                                },
                            },
                            "description": String("OK"),
                        },
                    },
                    "summary": String("Returns a list of users."),
                },
            },
        },
    },
)
```
because of how extensions (or rather the deserialize behavior) is specified
https://github.com/juhaku/utoipa/blob/e0c5aa749ac548cca7fd75544293865efe5d0231/utoipa/src/openapi.rs#L129-L131

</details> 

### Proposed Solution
We wrap the extensions as they are currently implemented in an explicit type for which we control the `Deserialize` behavior, that is, we only allow key-value pair that have the specific `x-` key prefix mentioned in the [spec](https://spec.openapis.org/oas/latest.html#specification-extensions).