### PR TITLE
Implement automatic schema collection for requests

### DIFF
--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -545,7 +545,7 @@ impl IntoParamsNames {
 impl Parse for IntoParamsNames {
     fn parse(input: syn::parse::ParseStream, _: Ident) -> syn::Result<Self> {
         Ok(Self(
-            parse_utils::parse_punctuated_within_parenthesis::<LitStr>(input)?
+            parse_utils::parse_comma_separated_within_parenthesis::<LitStr>(input)?
                 .iter()
                 .map(LitStr::value)
                 .collect(),
@@ -877,7 +877,7 @@ impl Parse for Discriminator {
                     unexpected => {
                         return Err(Error::new(
                             property.span(),
-                            &format!(
+                            format!(
                                 "unexpected identifier {}, expected any of: property_name, mapping",
                                 unexpected
                             ),

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{
     parse::Parse, punctuated::Punctuated, spanned::Spanned, token::Comma, Attribute, Data, Field,
     Generics, Ident,
@@ -463,7 +463,7 @@ impl ToTokensDiagnostics for Param<'_> {
                     generics: self.generics,
                 },
             })?;
-            let schema_tokens = crate::as_tokens_or_diagnostics!(&schema);
+            let schema_tokens = schema.to_token_stream();
 
             tokens.extend(quote! { .schema(Some(#schema_tokens)).build() });
         }

--- a/utoipa-gen/src/path/example.rs
+++ b/utoipa-gen/src/path/example.rs
@@ -9,7 +9,7 @@ use crate::{parse_utils, AnyValue};
 // (name = (summary = "...", description = "...", value = "..", external_value = "..."))
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
-pub(super) struct Example {
+pub struct Example {
     pub(super) name: String,
     pub(super) summary: Option<String>,
     pub(super) description: Option<String>,

--- a/utoipa-gen/src/path/media_type.rs
+++ b/utoipa-gen/src/path/media_type.rs
@@ -1,0 +1,358 @@
+use std::borrow::Cow;
+use std::ops::Deref;
+
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::token::{Comma, Paren};
+use syn::{Error, Generics, Ident, Token, Type};
+
+use crate::component::features::attributes::Inline;
+use crate::component::features::Feature;
+use crate::component::{ComponentSchema, ComponentSchemaProps, Container, TypeTree, ValueType};
+use crate::{parse_utils, AnyValue, Array, Diagnostics, ToTokensDiagnostics};
+
+use super::example::Example;
+use super::PathTypeTree;
+
+/// Parse OpenAPI Media Type object params
+/// ( Schema )
+/// ( Schema = "content/type" )
+/// ( "content/type", ),
+/// ( "content/type", example = ..., examples(..., ...), encoding(...) )
+#[derive(Default)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct MediaTypeAttr<'a> {
+    pub content_type: Option<parse_utils::LitStrOrExpr>, // if none, true guess
+    pub schema: Schema<DefaultSchema<'a>>,
+    pub example: Option<AnyValue>,
+    pub examples: Punctuated<Example, Comma>,
+    // econding: String, // TODO parse encoding
+}
+
+impl Parse for MediaTypeAttr<'_> {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut media_type = MediaTypeAttr::default();
+
+        let fork = input.fork();
+        let is_schema = fork.parse::<DefaultSchema>().is_ok();
+        if is_schema {
+            let schema = input.parse::<Schema<DefaultSchema>>()?;
+
+            let content_type = if input.parse::<Option<Token![=]>>()?.is_some() {
+                Some(
+                    input
+                        .parse::<parse_utils::LitStrOrExpr>()
+                        .map_err(|error| {
+                            Error::new(
+                                error.span(),
+                                format!(
+                                    "missing content type e.g. `\"application/json\"`, {error}"
+                                ),
+                            )
+                        })?,
+                )
+            } else {
+                None
+            };
+            media_type.schema = schema;
+            media_type.content_type = content_type;
+        } else {
+            // if schema, the content type is required
+            let content_type = input
+                .parse::<parse_utils::LitStrOrExpr>()
+                .map_err(|error| {
+                    Error::new(
+                        error.span(),
+                        format!("unexpected content, should be `schema`, `schema = content_type` or `content_type`, {error}"),
+                    )
+                })?;
+            media_type.content_type = Some(content_type);
+        }
+
+        if !input.is_empty() {
+            input.parse::<Comma>()?;
+        }
+
+        while !input.is_empty() {
+            let attribute = input.parse::<Ident>()?;
+            MediaTypeAttr::parse_named_attributes(&mut media_type, input, &attribute)?;
+        }
+
+        Ok(media_type)
+    }
+}
+
+impl<'m> MediaTypeAttr<'m> {
+    pub fn parse_schema(input: ParseStream) -> syn::Result<Schema<DefaultSchema<'m>>> {
+        Ok(Schema {
+            inner: input.parse()?,
+        })
+    }
+
+    pub fn parse_named_attributes(
+        media_type: &mut MediaTypeAttr,
+        input: ParseStream,
+        attribute: &Ident,
+    ) -> syn::Result<()> {
+        let name = &*attribute.to_string();
+
+        match name {
+            "example" => media_type.example = Some(parse_utils::parse_next(input, || AnyValue::parse_any(input))?),
+            "examples" => media_type.examples = parse_utils::parse_comma_separated_within_parenthesis(input)?,
+            // // TODO implement encoding support
+            // "encoding" => (),
+            unexpected => return Err(syn::Error::new(attribute.span(), format!("unexpected attribute: {unexpected}, expected any of: schema, example, examples"))),
+        }
+
+        if !input.is_empty() {
+            input.parse::<Comma>()?;
+        }
+
+        Ok(())
+    }
+}
+
+impl ToTokensDiagnostics for MediaTypeAttr<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) -> Result<(), Diagnostics> {
+        let schema = &self.schema.try_to_token_stream()?;
+        let schema_tokens = if schema.is_empty() {
+            None
+        } else {
+            Some(quote! { .schema(Some(#schema)) })
+        };
+        let example = self
+            .example
+            .as_ref()
+            .map(|example| quote!( .example(Some(#example)) ));
+
+        let examples = self
+            .examples
+            .iter()
+            .map(|example| {
+                let name = &example.name;
+                quote!( (#name, #example) )
+            })
+            .collect::<Array<TokenStream>>();
+        let examples = if !examples.is_empty() {
+            Some(quote!( .examples_from_iter(#examples) ))
+        } else {
+            None
+        };
+
+        tokens.extend(quote! {
+            utoipa::openapi::content::ContentBuilder::new()
+                #schema_tokens
+                #example
+                #examples
+                .into()
+        });
+
+        Ok(())
+    }
+}
+
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Default)]
+pub struct Schema<T: Parse + Default> {
+    inner: T,
+}
+
+impl<T> Deref for Schema<T>
+where
+    T: Parse + Default,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T> Parse for Schema<T>
+where
+    T: Parse + Default,
+{
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            inner: input.parse()?,
+        })
+    }
+}
+
+impl<T> ToTokens for Schema<T>
+where
+    T: ToTokens + Parse + Default,
+{
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        self.inner.to_tokens(tokens);
+    }
+}
+
+impl<T> AsRef<T> for Schema<T>
+where
+    T: Parse + Default,
+{
+    fn as_ref(&self) -> &T {
+        &self.inner
+    }
+}
+
+pub trait MediaTypePathExt<'a> {
+    fn get_component_schema(&self) -> Result<Option<ComponentSchema>, Diagnostics>;
+}
+
+#[cfg_attr(feature = "debug", derive(Debug))]
+#[derive(Default)]
+pub enum DefaultSchema<'d> {
+    Ref(parse_utils::LitStrOrExpr),
+    TypePath(ParsedType<'d>),
+    /// for cases where the schema is irrelevant but we just want to return generic
+    /// `content_type` without actual schema.
+    #[default]
+    None,
+}
+
+impl ToTokensDiagnostics for DefaultSchema<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) -> Result<(), Diagnostics> {
+        match self {
+            Self::Ref(reference) => tokens.extend(quote! {
+                utoipa::openapi::schema::Ref::new(#reference)
+            }),
+            Self::TypePath(parsed) => {
+                let is_inline = parsed.is_inline;
+                let type_tree = &parsed.to_type_tree()?;
+
+                let component_tokens = ComponentSchema::new(ComponentSchemaProps {
+                    type_tree,
+                    features: vec![Inline::from(is_inline).into()],
+                    description: None,
+                    container: &Container {
+                        generics: &Generics::default(),
+                    },
+                })?
+                .to_token_stream();
+
+                component_tokens.to_tokens(tokens);
+            }
+            // nada
+            Self::None => (),
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> MediaTypePathExt<'a> for TypeTree<'a> {
+    fn get_component_schema(&self) -> Result<Option<ComponentSchema>, Diagnostics> {
+        let generics = &if matches!(self.value_type, ValueType::Tuple) {
+            Generics::default()
+        } else {
+            self.get_path_generics()?
+        };
+
+        let component_schema = ComponentSchema::new(ComponentSchemaProps {
+            container: &Container { generics },
+            type_tree: self,
+            description: None,
+            // get the actual schema, not the reference
+            features: vec![Feature::Inline(true.into())],
+        })?;
+
+        Ok(Some(component_schema))
+    }
+}
+
+impl DefaultSchema<'_> {
+    pub fn get_default_content_type(&self) -> Result<Cow<'static, str>, Diagnostics> {
+        match self {
+            Self::TypePath(path) => {
+                let type_tree = path.to_type_tree()?;
+                Ok(type_tree.get_default_content_type())
+            }
+            Self::Ref(_) => Ok(Cow::Borrowed("application/json")),
+            Self::None => Ok(Cow::Borrowed("")),
+        }
+    }
+
+    pub fn get_component_schema(&self) -> Result<Option<ComponentSchema>, Diagnostics> {
+        match self {
+            Self::TypePath(path) => {
+                let type_tree = path.to_type_tree()?;
+                let v = type_tree.get_component_schema()?;
+
+                Ok(v)
+            }
+            _ => Ok(None),
+        }
+    }
+
+    pub fn get_type_tree(&self) -> Result<Option<TypeTree<'_>>, Diagnostics> {
+        match self {
+            Self::TypePath(path) => path.to_type_tree().map(Some),
+            _ => Ok(None),
+        }
+    }
+}
+
+impl Parse for DefaultSchema<'_> {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let fork = input.fork();
+        let is_ref = if (fork.parse::<Option<Token![ref]>>()?).is_some() {
+            fork.peek(Paren)
+        } else {
+            false
+        };
+
+        if is_ref {
+            input.parse::<Token![ref]>()?;
+            let ref_stream;
+            syn::parenthesized!(ref_stream in input);
+
+            ref_stream.parse().map(Self::Ref)
+        } else {
+            input.parse().map(Self::TypePath)
+        }
+    }
+}
+
+// inline(syn::TypePath) | syn::TypePath
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct ParsedType<'i> {
+    ty: Cow<'i, Type>,
+    is_inline: bool,
+}
+
+impl ParsedType<'_> {
+    /// Get's the underlying [`syn::Type`] as [`TypeTree`].
+    fn to_type_tree(&self) -> Result<TypeTree, Diagnostics> {
+        TypeTree::from_type(&self.ty)
+    }
+}
+
+impl Parse for ParsedType<'_> {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let fork = input.fork();
+        let is_inline = if let Some(ident) = fork.parse::<Option<syn::Ident>>()? {
+            ident == "inline" && fork.peek(Paren)
+        } else {
+            false
+        };
+
+        let ty = if is_inline {
+            input.parse::<syn::Ident>()?;
+            let inlined;
+            syn::parenthesized!(inlined in input);
+
+            inlined.parse::<Type>()?
+        } else {
+            input.parse::<Type>()?
+        };
+
+        Ok(ParsedType {
+            ty: Cow::Owned(ty),
+            is_inline,
+        })
+    }
+}

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -178,16 +178,15 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                 let required: Required = (!type_tree.is_option()).into();
 
                 to_tokens(
-                    as_tokens_or_diagnostics!(&ComponentSchema::new(
-                        component::ComponentSchemaProps {
-                            type_tree,
-                            features: self.features.clone(),
-                            description: None,
-                            container: &Container {
-                                generics: &Generics::default(),
-                            }
-                        }
-                    )?),
+                    ComponentSchema::new(component::ComponentSchemaProps {
+                        type_tree,
+                        features: self.features.clone(),
+                        description: None,
+                        container: &Container {
+                            generics: &Generics::default(),
+                        },
+                    })?
+                    .to_token_stream(),
                     required,
                 );
                 Ok(())
@@ -200,16 +199,15 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                 schema_features.push(Feature::Inline(inline_type.is_inline.into()));
 
                 to_tokens(
-                    as_tokens_or_diagnostics!(&ComponentSchema::new(
-                        component::ComponentSchemaProps {
-                            type_tree: &type_tree,
-                            features: schema_features,
-                            description: None,
-                            container: &Container {
-                                generics: &Generics::default(),
-                            }
-                        }
-                    )?),
+                    ComponentSchema::new(component::ComponentSchemaProps {
+                        type_tree: &type_tree,
+                        features: schema_features,
+                        description: None,
+                        container: &Container {
+                            generics: &Generics::default(),
+                        },
+                    })?
+                    .to_token_stream(),
                     required,
                 );
                 Ok(())

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -127,11 +127,11 @@ impl Parse for ResponseTuple<'_> {
                 }
                 "content" => {
                     response.as_value(input.span())?.content =
-                        parse_utils::parse_punctuated_within_parenthesis(input)?;
+                        parse_utils::parse_comma_separated_within_parenthesis(input)?;
                 }
                 "links" => {
                     response.as_value(input.span())?.links =
-                        parse_utils::parse_punctuated_within_parenthesis(input)?;
+                        parse_utils::parse_comma_separated_within_parenthesis(input)?;
                 }
                 "response" => {
                     response.set_ref_type(
@@ -309,8 +309,7 @@ impl ToTokensDiagnostics for ResponseTuple<'_> {
                         PathType::InlineSchema(schema, _) => schema.to_token_stream(),
                     };
 
-                    let mut content =
-                        quote! { utoipa::openapi::ContentBuilder::new().schema(#content_schema) };
+                    let mut content = quote! { utoipa::openapi::ContentBuilder::new().schema(Some(#content_schema)) };
 
                     if let Some(ref example) = example {
                         content.extend(quote! {
@@ -700,7 +699,9 @@ impl Parse for Content<'_> {
                     })?)
                 }
                 "examples" => {
-                    examples = Some(parse_utils::parse_punctuated_within_parenthesis(&content)?)
+                    examples = Some(parse_utils::parse_comma_separated_within_parenthesis(
+                        &content,
+                    )?)
                 }
                 _ => {
                     return Err(Error::new(

--- a/utoipa-gen/src/path/response/link.rs
+++ b/utoipa-gen/src/path/response/link.rs
@@ -59,12 +59,12 @@ impl Parse for Link {
                 "operation_ref" => link.operation_ref = Some(parse_utils::parse_next_literal_str_or_expr(&inner)?),
                 "operation_id" => link.operation_id = Some(parse_utils::parse_next_literal_str_or_expr(&inner)?),
                 "parameters" => {
-                    link.parameters = parse_utils::parse_punctuated_within_parenthesis(&inner)?;
+                    link.parameters = parse_utils::parse_comma_separated_within_parenthesis(&inner)?;
                 },
                 "request_body" => link.request_body = Some(parse_utils::parse_next(&inner, || { AnyValue::parse_any(&inner)})?),
                 "description" => link.description = Some(parse_utils::parse_next_literal_str_or_expr(&inner)?),
                 "server" => link.server = Some(inner.call(Server::parse)?),
-                _ => return Err(syn::Error::new(ident.span(), &format!("unexpected attribute: {attribute}, expected any of: operation_ref, operation_id, parameters, request_body, description, server")))
+                _ => return Err(syn::Error::new(ident.span(), format!("unexpected attribute: {attribute}, expected any of: operation_ref, operation_id, parameters, request_body, description, server")))
             }
 
             if !inner.is_empty() {

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -1100,8 +1100,17 @@ fn path_derive_custom_generic_wrapper() {
     struct Doc;
 
     let doc = serde_json::to_value(Doc::openapi()).unwrap();
+    let schemas = doc.pointer("/components/schemas").unwrap();
     let operation = doc.pointer("/paths/~1item/post").unwrap();
 
+    assert_json_eq!(
+        &schemas,
+        json!({
+            "Item": {
+                "type": "string"
+            }
+        })
+    );
     assert_json_eq!(
         &operation.pointer("/requestBody"),
         json!({

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1434,6 +1434,8 @@ fn derive_mixed_enum() {
 
 #[test]
 fn derive_mixed_enum_deprecated_variants() {
+    #![allow(deprecated)]
+
     #[derive(Serialize, ToSchema)]
     struct Foo(String);
 

--- a/utoipa-gen/tests/testdata/openapi_schemas_resolve_inner_schema_references
+++ b/utoipa-gen/tests/testdata/openapi_schemas_resolve_inner_schema_references
@@ -1,0 +1,259 @@
+
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "utoipa-gen",
+    "description": "Code generation implementation for utoipa",
+    "contact": {
+      "name": "Juha Kukkonen",
+      "email": "juha7kukkonen@gmail.com"
+    },
+    "license": {
+      "name": "MIT OR Apache-2.0"
+    },
+    "version": "5.0.0-beta.0"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Account": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "Boo": {
+        "type": "object",
+        "required": [
+          "boo"
+        ],
+        "properties": {
+          "boo": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Element_String": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "One"
+            ],
+            "properties": {
+              "One": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "Many"
+            ],
+            "properties": {
+              "Many": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Element_Yeah": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "One"
+            ],
+            "properties": {
+              "One": {
+                "$ref": "#/components/schemas/Yeah"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "Many"
+            ],
+            "properties": {
+              "Many": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Yeah"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "EnumMixedContent": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "ContentZero"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "One"
+            ],
+            "properties": {
+              "One": {
+                "$ref": "#/components/schemas/Foobar"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "NamedSchema"
+            ],
+            "properties": {
+              "NamedSchema": {
+                "type": "object",
+                "required": [
+                  "value",
+                  "value2",
+                  "foo",
+                  "int",
+                  "f"
+                ],
+                "properties": {
+                  "f": {
+                    "type": "boolean"
+                  },
+                  "foo": {
+                    "$ref": "#/components/schemas/ThisIsNone"
+                  },
+                  "int": {
+                    "type": "integer",
+                    "format": "int32"
+                  },
+                  "value": {
+                    "$ref": "#/components/schemas/Account"
+                  },
+                  "value2": {
+                    "$ref": "#/components/schemas/Boo"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "Many"
+            ],
+            "properties": {
+              "Many": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Person"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Foob": {
+        "type": "object",
+        "required": [
+          "item",
+          "item2"
+        ],
+        "properties": {
+          "item": {
+            "$ref": "#/components/schemas/Element_String"
+          },
+          "item2": {
+            "$ref": "#/components/schemas/Element_Yeah"
+          }
+        }
+      },
+      "Foobar": {
+        "default": null
+      },
+      "OneOfOne": {
+        "$ref": "#/components/schemas/Person"
+      },
+      "OneOfYeah": {
+        "$ref": "#/components/schemas/Yeah"
+      },
+      "Person": {
+        "type": "object",
+        "required": [
+          "name",
+          "foo_bar",
+          "accounts"
+        ],
+        "properties": {
+          "accounts": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/Account"
+                }
+              ]
+            }
+          },
+          "foo_bar": {
+            "$ref": "#/components/schemas/Foobar"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ThisIsNone": {
+        "default": null
+      },
+      "Yeah": {
+        "type": "object",
+        "required": [
+          "name",
+          "foo_bar",
+          "accounts"
+        ],
+        "properties": {
+          "accounts": {
+            "type": "array",
+            "items": {
+              "allOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/components/schemas/Account"
+                }
+              ]
+            }
+          },
+          "foo_bar": {
+            "$ref": "#/components/schemas/Foobar"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -774,7 +774,7 @@ impl<K: PartialSchema, V: ToSchema> PartialSchema for std::collections::HashMap<
 ///                                 .description("Pet found successfully")
 ///                                 .content("application/json",
 ///                                     utoipa::openapi::Content::new(
-///                                         utoipa::openapi::Ref::from_schema_name("Pet"),
+///                                         Some(utoipa::openapi::Ref::from_schema_name("Pet")),
 ///                                     ),
 ///                             ),
 ///                         )
@@ -1182,6 +1182,15 @@ pub mod __dev {
         fn schema() -> crate::openapi::RefOr<crate::openapi::schema::Schema> {
             T::compose(Vec::new())
         }
+    }
+
+    pub trait SchemaReferences {
+        fn schemas(
+            schemas: &mut Vec<(
+                String,
+                utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+            )>,
+        );
     }
 }
 

--- a/utoipa/src/openapi/content.rs
+++ b/utoipa/src/openapi/content.rs
@@ -19,7 +19,8 @@ builder! {
     #[non_exhaustive]
     pub struct Content {
         /// Schema used in response body or request body.
-        pub schema: RefOr<Schema>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub schema: Option<RefOr<Schema>>,
 
         /// Example for request body or response body.
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -47,9 +48,9 @@ builder! {
 
 impl Content {
     /// Construct a new [`Content`] object for provided _`schema`_.
-    pub fn new<I: Into<RefOr<Schema>>>(schema: I) -> Self {
+    pub fn new<I: Into<RefOr<Schema>>>(schema: Option<I>) -> Self {
         Self {
-            schema: schema.into(),
+            schema: schema.map(|schema| schema.into()),
             ..Self::default()
         }
     }
@@ -57,8 +58,8 @@ impl Content {
 
 impl ContentBuilder {
     /// Add schema.
-    pub fn schema<I: Into<RefOr<Schema>>>(mut self, component: I) -> Self {
-        set_value!(self schema component.into())
+    pub fn schema<I: Into<RefOr<Schema>>>(mut self, schema: Option<I>) -> Self {
+        set_value!(self schema schema.map(|schema| schema.into()))
     }
 
     /// Add example of schema.

--- a/utoipa/src/openapi/request_body.rs
+++ b/utoipa/src/openapi/request_body.rs
@@ -98,7 +98,7 @@ impl RequestBodyExt for RequestBody {
     fn json_schema_ref(mut self, ref_name: &str) -> RequestBody {
         self.content.insert(
             "application/json".to_string(),
-            crate::openapi::Content::new(crate::openapi::Ref::from_schema_name(ref_name)),
+            crate::openapi::Content::new(Some(crate::openapi::Ref::from_schema_name(ref_name))),
         );
         self
     }
@@ -109,7 +109,7 @@ impl RequestBodyExt for RequestBodyBuilder {
     fn json_schema_ref(self, ref_name: &str) -> RequestBodyBuilder {
         self.content(
             "application/json",
-            crate::openapi::Content::new(crate::openapi::Ref::from_schema_name(ref_name)),
+            crate::openapi::Content::new(Some(crate::openapi::Ref::from_schema_name(ref_name))),
         )
     }
 }
@@ -137,7 +137,7 @@ mod tests {
             .required(Some(Required::True))
             .content(
                 "application/json",
-                Content::new(crate::openapi::Ref::from_schema_name("EmailPayload")),
+                Content::new(Some(crate::openapi::Ref::from_schema_name("EmailPayload"))),
             )
             .build();
         let serialized = serde_json::to_string_pretty(&request_body)?;

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -233,7 +233,7 @@ impl ResponseExt for Response {
     fn json_schema_ref(mut self, ref_name: &str) -> Response {
         self.content.insert(
             "application/json".to_string(),
-            Content::new(crate::openapi::Ref::from_schema_name(ref_name)),
+            Content::new(Some(crate::openapi::Ref::from_schema_name(ref_name))),
         );
         self
     }
@@ -244,7 +244,7 @@ impl ResponseExt for ResponseBuilder {
     fn json_schema_ref(self, ref_name: &str) -> ResponseBuilder {
         self.content(
             "application/json",
-            Content::new(crate::openapi::Ref::from_schema_name(ref_name)),
+            Content::new(Some(crate::openapi::Ref::from_schema_name(ref_name))),
         )
     }
 }
@@ -268,7 +268,9 @@ mod tests {
             .description("A sample response")
             .content(
                 "application/json",
-                Content::new(crate::openapi::Ref::from_schema_name("MySchemaPayload")),
+                Content::new(Some(crate::openapi::Ref::from_schema_name(
+                    "MySchemaPayload",
+                ))),
             )
             .build();
         let serialized = serde_json::to_string_pretty(&request_body)?;


### PR DESCRIPTION
This PR implements functionality to recognize recursive schemas within types implementing `ToSchema` trait by (derive). These schema references will be collected to the single list of schemas which are added to the schema automatically from their usage point.

If schema is registered at `schemas(MyType)` for `OpenApi` then the type and it's schema references found recursively will be registered to the `OpenApi`.

If the type is defined in `#[utoipa::path(request_body = ...)]` the schema and it's recursively found schema references will be automatically added to the schema when the handler is registered to the `OpenApi`.

If the framework supports request body from http handler function arguments (like `actix_web`, `axum`) then the schema will be added to the `OpenApi` as well with recursively found schema references when the handler is registered to the `OpenApi`.

This commit also refactors the parsing for `#[utoipa::path(request_body = ...)]` Which enables the support for automatic schema reference recognition and collection. This also comes with the possibility to only add `request_body(content_type = "my/type")` without the schema if wanted. More over from now on the `request_body` supports defining multiple content objects allowing users to define multiple request body content's like the responses support.

 ### Breaking changes

This `request_body` parsing is in over all breaking change and the changed spec need be checked from the docs or tests. In short the `content_type = ...` does not support anymore array syntax. E.g. `content_type = [...]` is not possible anymore. Instead to support multiple content types in request body on must define multiple content objects similar to responses.
```text
 request_body(
    content(
        (Item = "content/type"),
        (Item = "content/type2"),
    )
 )
```

Example of supported syntax to demonstrate the automatic schema collecting from `test_collect_schemas` handler when registered to the `OpenApi`. Same way if `Person` was declared to `OpenApi` via `schemas(Person)` then `Account` would also get registered.
```rust
 #[derive(ToSchema)]
 struct Account {
     id: i32,
 }

 #[derive(ToSchema)]
 struct Person {
     name: String,
     account: Account,
 }

 #[utoipa::path(
     post,
     request_body = Person,
     path = "/test-collect-schemas",
     responses(
         (status = 200, description = "success response")
     ),
 )]
 async fn test_collect_schemas(_body: Person) -> &'static str {
     ""
 }

 #[derive(OpenApi)]
 #[openapi(paths(test_collect_schemas))]
 struct ApiDoc;
```

Fixes #692

Relates #662 #591 #965 #779