### PR TITLE
Chore unify request body and ext request body

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -121,6 +121,7 @@ impl<'a, T> Iterator for TypeTreeValueIter<'a, T> {
 #[derive(Clone)]
 pub struct TypeTree<'t> {
     pub path: Option<Cow<'t, Path>>,
+    #[allow(unused)]
     pub span: Option<Span>,
     pub value_type: ValueType,
     pub generic_type: Option<GenericType>,

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
-use quote::{quote, quote_spanned};
+use quote::ToTokens;
 use syn::spanned::Spanned;
-use syn::{parse_quote, Generics};
+use syn::Generics;
 use syn::{punctuated::Punctuated, token::Comma, ItemFn};
 
 use crate::component::{ComponentSchema, ComponentSchemaProps, Container, TypeTree};
@@ -96,102 +96,79 @@ pub enum ArgumentIn {
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
-pub struct RequestBody<'r> {
-    type_tree: TypeTree<'r>,
+pub struct ExtSchema<'a>(TypeTree<'a>);
+
+impl<'t> From<TypeTree<'t>> for ExtSchema<'t> {
+    fn from(value: TypeTree<'t>) -> ExtSchema<'t> {
+        Self(value)
+    }
 }
 
-impl RequestBody<'_> {
-    #[cfg(any(
-        feature = "actix_extras",
-        feature = "rocket_extras",
-        feature = "axum_extras"
-    ))]
+impl ExtSchema<'_> {
+    fn get_actual_body(&self) -> Cow<'_, TypeTree<'_>> {
+        let actual_body_type = get_actual_body_type(&self.0);
+
+        actual_body_type.map(|actual_body| {
+            if let Some(option_type) = find_option_type_tree(actual_body) {
+                let path = option_type.path.clone();
+                Cow::Owned(TypeTree {
+                    children: Some(vec![actual_body.clone()]),
+                    generic_type: Some(crate::component::GenericType::Option),
+                    value_type: crate::component::ValueType::Object,
+                    span: Some(path.span()),
+                    path,
+                })
+            } else {
+                Cow::Borrowed(actual_body)
+            }
+        }).expect("ExtSchema must have actual request body resoved from TypeTree of handler fn argument")
+    }
+
+    pub fn get_type_tree(&self) -> Result<Option<Cow<'_, TypeTree<'_>>>, Diagnostics> {
+        Ok(Some(Cow::Borrowed(&self.0)))
+    }
+
+    pub fn get_default_content_type(&self) -> Result<Cow<'static, str>, Diagnostics> {
+        let type_tree = &self.0;
+
+        let content_type = if type_tree.is("Bytes") {
+            Cow::Borrowed("application/octet-stream")
+        } else if type_tree.is("Form") {
+            Cow::Borrowed("application/x-www-form-urlencoded")
+        } else {
+            let get_actual_body = self.get_actual_body();
+            let actual_body = get_actual_body.as_ref();
+
+            actual_body.get_default_content_type()
+        };
+
+        Ok(content_type)
+    }
+
     pub fn get_component_schema(&self) -> Result<Option<ComponentSchema>, Diagnostics> {
         use crate::OptionExt;
 
-        let type_tree = &self.type_tree;
+        let type_tree = &self.0;
         let actual_body_type = get_actual_body_type(type_tree);
 
-        actual_body_type.and_then_try(|body_type| {
-            if let Some(component_schema) = body_type.get_component_schema()? {
-                Result::<Option<ComponentSchema>, Diagnostics>::Ok(Some(component_schema))
-            } else {
-                Ok(None)
-            }
-        })
+        actual_body_type.and_then_try(|body_type| body_type.get_component_schema())
     }
 }
 
-impl<'t> From<TypeTree<'t>> for RequestBody<'t> {
-    fn from(value: TypeTree<'t>) -> RequestBody<'t> {
-        Self { type_tree: value }
-    }
-}
+impl ToTokensDiagnostics for ExtSchema<'_> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) -> Result<(), Diagnostics> {
+        let get_actual_body = self.get_actual_body();
+        let type_tree = get_actual_body.as_ref();
 
-impl<'r> MediaTypePathExt<'r> for RequestBody<'r> {
-    fn get_component_schema(&self) -> Result<Option<ComponentSchema>, Diagnostics> {
-        self.type_tree.get_component_schema()
-    }
-}
-
-impl ToTokensDiagnostics for RequestBody<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostics> {
-        let mut actual_body = get_actual_body_type(&self.type_tree)
-            .expect("should have found actual request body TypeTree")
-            .clone();
-
-        if let Some(option) = find_option_type_tree(&self.type_tree) {
-            let path = option.path.clone();
-            actual_body = TypeTree {
-                children: Some(vec![actual_body]),
-                generic_type: Some(crate::component::GenericType::Option),
-                value_type: crate::component::ValueType::Object,
-                span: Some(path.span()),
-                path,
-            }
-        };
-
-        let required = if actual_body.is_option() {
-            quote!(utoipa::openapi::Required::False)
-        } else {
-            quote!(utoipa::openapi::Required::True)
-        };
-
-        let mut create_body_tokens =
-            |content_type: &str, actual_body: &TypeTree| -> Result<(), Diagnostics> {
-                let schema = &ComponentSchema::new(ComponentSchemaProps {
-                    type_tree: actual_body,
-                    features: Vec::new(),
-                    description: None,
-                    container: &Container {
-                        generics: &Generics::default(),
-                    },
-                })?;
-
-                tokens.extend(quote_spanned! {actual_body.span.unwrap()=>
-                    utoipa::openapi::request_body::RequestBodyBuilder::new()
-                        .content(#content_type,
-                            utoipa::openapi::content::Content::new(Some(#schema))
-                        )
-                        .required(Some(#required))
-                        .description(Some(""))
-                        .build()
-                });
-                Ok(())
-            };
-
-        if self.type_tree.is("Bytes") {
-            let bytes_as_bytes_vec = parse_quote!(Vec<u8>);
-            let ty = TypeTree::from_type(&bytes_as_bytes_vec)?;
-            create_body_tokens("application/octet-stream", &ty)?;
-        } else if self.type_tree.is("Form") {
-            create_body_tokens("application/x-www-form-urlencoded", &actual_body)?;
-        } else {
-            create_body_tokens(
-                actual_body.get_default_content_type().as_ref(),
-                &actual_body,
-            )?;
-        };
+        let component_tokens = ComponentSchema::new(ComponentSchemaProps {
+            type_tree,
+            features: Vec::new(),
+            description: None,
+            container: &Container {
+                generics: &Generics::default(),
+            },
+        })?;
+        component_tokens.to_tokens(tokens);
 
         Ok(())
     }
@@ -300,7 +277,7 @@ pub struct ResolvedOperation {
 pub type Arguments<'a> = (
     Option<Vec<ValueArgument<'a>>>,
     Option<Vec<IntoParamsType<'a>>>,
-    Option<RequestBody<'a>>,
+    Option<ExtSchema<'a>>,
 );
 
 #[allow(unused)]

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -5,7 +5,7 @@ use paste::paste;
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::HashMap;
-use utoipa::openapi::{self, Components, RefOr, Schema};
+use utoipa::openapi::RefOr;
 use utoipa::openapi::{Object, ObjectBuilder};
 use utoipa::{
     openapi::{Response, ResponseBuilder, ResponsesBuilder},

--- a/utoipa-gen/tests/path_derive_actix.rs
+++ b/utoipa-gen/tests/path_derive_actix.rs
@@ -879,7 +879,6 @@ fn path_with_all_args() {
     assert_json_eq!(
         &operation.pointer("/requestBody"),
         json!({
-            "description": "",
             "content": {
                 "application/json": {
                     "schema": {
@@ -940,7 +939,6 @@ fn path_with_all_args_using_uuid() {
     assert_json_eq!(
         &operation.pointer("/requestBody"),
         json!({
-            "description": "",
             "content": {
                 "application/json": {
                     "schema": {
@@ -1019,7 +1017,6 @@ fn path_with_all_args_using_custom_uuid() {
     assert_json_eq!(
         &operation.pointer("/requestBody"),
         json!({
-            "description": "",
             "content": {
                 "application/json": {
                     "schema": {
@@ -1114,7 +1111,6 @@ fn path_derive_custom_generic_wrapper() {
     assert_json_eq!(
         &operation.pointer("/requestBody"),
         json!({
-            "description": "",
             "content": {
                 "application/json": {
                     "schema": {

--- a/utoipa-gen/tests/path_derive_axum_test.rs
+++ b/utoipa-gen/tests/path_derive_axum_test.rs
@@ -447,7 +447,6 @@ fn path_with_path_query_body_resolved() {
     assert_json_eq!(
         &operation.pointer("/requestBody"),
         json!({
-            "description": "",
             "content": {
                 "application/json": {
                     "schema": {

--- a/utoipa-gen/tests/path_derive_rocket.rs
+++ b/utoipa-gen/tests/path_derive_rocket.rs
@@ -532,7 +532,6 @@ fn path_with_all_args_and_body() {
                     }
                 }
             },
-            "description": "",
             "required": true
         })
     );


### PR DESCRIPTION
This commit unifies to logic for parsed request body and ext request body from handler function argument. Prior to this commit they had separate implementations for `ToTokens` but that is changed in this commit for being overly superfluous and error prone. Now they share same `ToTokens` logic where only difference is how the `ComponentSchema` is resolved for the different types of request bodies.