### PR TITLE
Auto collect tuple responses schema references

### DIFF
--- a/utoipa-gen/src/component/schema/enums.rs
+++ b/utoipa-gen/src/component/schema/enums.rs
@@ -1005,7 +1005,7 @@ where
 
 /// `RefOrOwned` is simple `Cow` like type to wrap either `ref` or owned value. This allows passing
 /// either owned or referenced values as if they were owned like the `Cow` does but this works with
-/// non clonable types. Thus values cannot be modified but they can be passed down as re-referenced
+/// non cloneable types. Thus values cannot be modified but they can be passed down as re-referenced
 /// values by dereffing the original value. `Roo::Ref(original.deref())`.
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum Roo<'t, T> {

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1041,15 +1041,11 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///   that free form _`ref`_ is accessible via OpenAPI doc or Swagger UI, users are responsible for making
 ///   these guarantees.
 ///
-/// * `content_type = "..."` or `content_type = [...]` Can be used to override the default behavior of auto resolving the content type
-///   from the `body` attribute. If defined the value should be valid content type such as
-///   _`application/json`_. By default the content type is _`text/plain`_ for
-///   [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and
-///   _`application/json`_ for struct and mixed enum types.
-///   Content type can also be slice of **content_type** values if the endpoint support returning multiple
-///   response content types. E.g _`["application/json", "text/xml"]`_ would indicate that endpoint can return both
-///   _`json`_ and _`xml`_ formats. **The order** of the content types define the default example show first in
-///   the Swagger UI. Swagger UI will use the first _`content_type`_ value as a default example.
+/// * `content_type = "..."` Can be used to override the default behavior
+///   of auto resolving the content type from the `body` attribute. If defined the value should be valid
+///   content type such as _`application/json`_ . By default the content type is _`text/plain`_
+///   for [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and _`application/json`_
+///   for struct and mixed enum types.
 ///
 /// * `headers(...)` Slice of response headers that are returned back to a caller.
 ///
@@ -1059,10 +1055,8 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// * `response = ...` Type what implements [`ToResponse`][to_response_trait] trait. This can alternatively be used to
 ///    define response attributes. _`response`_ attribute cannot co-exist with other than _`status`_ attribute.
 ///
-/// * `content((...), (...))` Can be used to define multiple return types for single response status. Supported format for single
-///   _content_ is `(content_type = response_body, example = "...", examples(...))`. _`example`_
-///   and _`examples`_ are optional arguments. Examples attribute behaves exactly same way as in
-///   the response and is mutually exclusive with the example attribute.
+/// * `content((...), (...))` Can be used to define multiple return types for single response status. Supports same syntax as
+///   [multiple request body content][`macro@path#multiple-request-body-content`].
 ///
 /// * `examples(...)` Define multiple examples for single response. This attribute is mutually
 ///   exclusive to the _`example`_ attribute and if both are defined this will override the _`example`_.
@@ -1156,13 +1150,6 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///         headers(...),
 ///         example = json!({"id": 1, "name": "bob the cat"})
 ///     )
-/// )
-/// ```
-///
-/// **Response with multiple response content types:**
-/// ```text
-/// responses(
-///     (status = 200, description = "Success response", body = Pet, content_type = ["application/json", "text/xml"])
 /// )
 /// ```
 ///
@@ -1628,8 +1615,8 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///     path = "/user",
 ///     responses(
 ///         (status = 200, content(
-///                 ("application/vnd.user.v1+json" = User1, example = json!({"id": "id".to_string()})),
-///                 ("application/vnd.user.v2+json" = User2, example = json!({"id": 2}))
+///                 (User1 = "application/vnd.user.v1+json", example = json!({"id": "id".to_string()})),
+///                 (User2 = "application/vnd.user.v2+json", example = json!({"id": 2}))
 ///             )
 ///         )
 ///     )
@@ -2525,15 +2512,11 @@ pub fn into_params(input: TokenStream) -> TokenStream {
 /// * `description = "..."` Define description for the response as str. This can be used to
 ///   override the default description resolved from doc comments if present.
 ///
-/// * `content_type = "..." | content_type = [...]` Can be used to override the default behavior of auto resolving the content type
-///   from the `body` attribute. If defined the value should be valid content type such as
-///   _`application/json`_. By default the content type is _`text/plain`_ for
-///   [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and
-///   _`application/json`_ for struct and mixed enum types.
-///   Content type can also be slice of **content_type** values if the endpoint support returning multiple
-///    response content types. E.g _`["application/json", "text/xml"]`_ would indicate that endpoint can return both
-///    _`json`_ and _`xml`_ formats. **The order** of the content types define the default example show first in
-///    the Swagger UI. Swagger UI will use the first _`content_type`_ value as a default example.
+/// * `content_type = "..."` Can be used to override the default behavior
+///   of auto resolving the content type from the `body` attribute. If defined the value should be valid
+///   content type such as _`application/json`_ . By default the content type is _`text/plain`_
+///   for [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and _`application/json`_
+///   for struct and mixed enum types.
 ///
 /// * `headers(...)` Slice of response headers that are returned back to a caller.
 ///
@@ -2692,15 +2675,11 @@ pub fn to_response(input: TokenStream) -> TokenStream {
 /// * `description = "..."` Define description for the response as str. This can be used to
 ///   override the default description resolved from doc comments if present.
 ///
-/// * `content_type = "..." | content_type = [...]` Can be used to override the default behavior of auto resolving the content type
-///   from the `body` attribute. If defined the value should be valid content type such as
-///   _`application/json`_. By default the content type is _`text/plain`_ for
-///   [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and
-///   _`application/json`_ for struct and mixed enum types.
-///   Content type can also be slice of **content_type** values if the endpoint support returning multiple
-///    response content types. E.g _`["application/json", "text/xml"]`_ would indicate that endpoint can return both
-///    _`json`_ and _`xml`_ formats. **The order** of the content types define the default example show first in
-///    the Swagger UI. Swagger UI will use the first _`content_type`_ value as a default example.
+/// * `content_type = "..."` Can be used to override the default behavior
+///   of auto resolving the content type from the `body` attribute. If defined the value should be valid
+///   content type such as _`application/json`_ . By default the content type is _`text/plain`_
+///   for [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and _`application/json`_
+///   for struct and mixed enum types.
 ///
 /// * `headers(...)` Slice of response headers that are returned back to a caller.
 ///

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -24,12 +24,12 @@ use crate::{
             },
             Feature, ToTokensExt,
         },
-        ComponentSchema, Container,
+        ComponentSchema, Container, TypeTree,
     },
     parse_utils, Diagnostics, Required, ToTokensDiagnostics,
 };
 
-use super::InlineType;
+use super::media_type::ParsedType;
 
 /// Parameter of request such as in path, header, query or cookie
 ///
@@ -192,7 +192,7 @@ impl ToTokensDiagnostics for ParameterSchema<'_> {
                 Ok(())
             }
             ParameterType::Parsed(inline_type) => {
-                let type_tree = inline_type.as_type_tree()?;
+                let type_tree = TypeTree::from_type(inline_type.ty.as_ref())?;
                 let required: Required = (!type_tree.is_option()).into();
                 let mut schema_features = Vec::<Feature>::new();
                 schema_features.clone_from(&self.features);
@@ -224,7 +224,7 @@ enum ParameterType<'p> {
         feature = "axum_extras"
     ))]
     External(crate::component::TypeTree<'p>),
-    Parsed(InlineType<'p>),
+    Parsed(ParsedType<'p>),
 }
 
 #[derive(Default)]

--- a/utoipa-gen/src/path/response/header.rs
+++ b/utoipa-gen/src/path/response/header.rs
@@ -1,0 +1,165 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::{Error, Generics, Ident, LitStr, Token};
+
+use crate::component::features::attributes::Inline;
+use crate::component::{ComponentSchema, Container, TypeTree};
+use crate::path::media_type::ParsedType;
+use crate::{parse_utils, Diagnostics, ToTokensDiagnostics};
+
+/// Parsed representation of response header defined in `#[utoipa::path(..)]` attribute.
+///
+/// Supported configuration format is `("x-my-header-name" = type, description = "optional description of header")`.
+/// The `= type` and the `description = ".."` are optional configurations thus so the same configuration
+/// could be written as follows: `("x-my-header-name")`.
+///
+/// The `type` can be any typical type supported as a header argument such as `String, i32, u64, bool` etc.
+/// and if not provided it will default to `String`.
+///
+/// # Examples
+///
+/// Example of 200 success response which does return nothing back in response body, but returns a
+/// new csrf token in response headers.
+/// ```text
+/// #[utoipa::path(
+///     ...
+///     responses = [
+///         (status = 200, description = "success response",
+///             headers = [
+///                 ("xrfs-token" = String, description = "New csrf token sent back in response header")
+///             ]
+///         ),
+///     ]
+/// )]
+/// ```
+///
+/// Example with default values.
+/// ```text
+/// #[utoipa::path(
+///     ...
+///     responses = [
+///         (status = 200, description = "success response",
+///             headers = [
+///                 ("xrfs-token")
+///             ]
+///         ),
+///     ]
+/// )]
+/// ```
+///
+/// Example with multiple headers with default values.
+/// ```text
+/// #[utoipa::path(
+///     ...
+///     responses = [
+///         (status = 200, description = "success response",
+///             headers = [
+///                 ("xrfs-token"),
+///                 ("another-header"),
+///             ]
+///         ),
+///     ]
+/// )]
+/// ```
+#[derive(Default)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct Header {
+    pub name: String,
+    value_type: Option<ParsedType<'static>>,
+    description: Option<String>,
+}
+
+impl Parse for Header {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        let mut header = Header {
+            name: input.parse::<LitStr>()?.value(),
+            ..Default::default()
+        };
+
+        if input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+
+            header.value_type = Some(input.parse().map_err(|error| {
+                Error::new(
+                    error.span(),
+                    format!("unexpected token, expected type such as String, {error}"),
+                )
+            })?);
+        }
+
+        if !input.is_empty() {
+            input.parse::<Token![,]>()?;
+        }
+
+        if input.peek(syn::Ident) {
+            input
+                .parse::<Ident>()
+                .map_err(|error| {
+                    Error::new(
+                        error.span(),
+                        format!("unexpected attribute, expected: description, {error}"),
+                    )
+                })
+                .and_then(|ident| {
+                    if ident != "description" {
+                        return Err(Error::new(
+                            ident.span(),
+                            "unexpected attribute, expected: description",
+                        ));
+                    }
+                    Ok(ident)
+                })?;
+            input.parse::<Token![=]>()?;
+            header.description = Some(input.parse::<LitStr>()?.value());
+        }
+
+        Ok(header)
+    }
+}
+
+impl ToTokensDiagnostics for Header {
+    fn to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostics> {
+        if let Some(header_type) = &self.value_type {
+            // header property with custom type
+            let type_tree = TypeTree::from_type(header_type.ty.as_ref())?;
+
+            let media_type_schema = ComponentSchema::new(crate::component::ComponentSchemaProps {
+                type_tree: &type_tree,
+                features: vec![Inline::from(header_type.is_inline).into()],
+                description: None,
+                container: &Container {
+                    generics: &Generics::default(),
+                },
+            })?
+            .to_token_stream();
+
+            tokens.extend(quote! {
+                utoipa::openapi::HeaderBuilder::new().schema(#media_type_schema)
+            })
+        } else {
+            // default header (string type)
+            tokens.extend(quote! {
+                Into::<utoipa::openapi::HeaderBuilder>::into(utoipa::openapi::Header::default())
+            })
+        };
+
+        if let Some(ref description) = self.description {
+            tokens.extend(quote! {
+                .description(Some(#description))
+            })
+        }
+
+        tokens.extend(quote! { .build() });
+
+        Ok(())
+    }
+}
+
+#[inline]
+pub fn headers(input: ParseStream) -> syn::Result<Vec<Header>> {
+    let headers;
+    syn::parenthesized!(headers in input);
+
+    parse_utils::parse_groups_collect(&headers)
+}

--- a/utoipa-gen/tests/response_derive_test.rs
+++ b/utoipa-gen/tests/response_derive_test.rs
@@ -205,50 +205,6 @@ fn derive_response_with_attributes() {
 }
 
 #[test]
-fn derive_response_with_multiple_content_types() {
-    #[derive(ToSchema, ToResponse)]
-    #[response(content_type = ["application/json", "text/xml"] )]
-    #[allow(unused)]
-    struct Person {
-        name: String,
-    }
-    let (name, v) = <Person as utoipa::ToResponse>::response();
-    let value = serde_json::to_value(v).unwrap();
-
-    assert_eq!("Person", name);
-    assert_json_eq!(
-        value,
-        json!({
-            "content": {
-                "application/json": {
-                    "schema": {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object",
-                        "required": ["name"]
-                    }
-                },
-                "text/xml": {
-                    "schema": {
-                        "properties": {
-                            "name": {
-                                "type": "string"
-                            }
-                        },
-                        "type": "object",
-                        "required": ["name"]
-                    }
-                }
-            },
-            "description": ""
-        })
-    )
-}
-
-#[test]
 fn derive_response_multiple_examples() {
     #[derive(ToSchema, ToResponse)]
     #[response(examples(


### PR DESCRIPTION
Refactor Tuple responses parsing unifying it with request body parsing. This allows reusing same components when serialized to tokens making it less error prone and removing duplication.

This also removes the `content_type = [...]` array format from `ToResponse` and `IntoResponses` derive types as well as from tuple style responses. Same as with request bodies the multiple content types need to defined with `content(...)` attribute.

Implement auto collect response schema references from tuple style responses within `#[utoipa::path(...)]` attribute macro. Schema references will be collected recursively in same manner as for request bodies.

### Breaking

The `content_type = [...]` array format is no longer supported. And instead `content(...)` is to be used instead for defining multiple content types.

Example of supported syntax. The `User` will be automatically collected to OpenApi when `get_user` path is registered to the `OpenApi`.
```rust
 #[derive(utoipa::ToSchema)]
 struct User {
     name: String,
 }

 #[utoipa::path(
     get,
     path = "/user",
     responses(
         (status = 200, body = User)
     )
 )]
 fn get_user() {}
```