### PR TITLE
Add auto collect schemas for utoipa-axum

### DIFF
--- a/examples/axum-utoipa-bindings/src/main.rs
+++ b/examples/axum-utoipa-bindings/src/main.rs
@@ -52,13 +52,9 @@ async fn main() -> Result<(), io::Error> {
 mod customer {
     use axum::Json;
     use serde::Serialize;
-    use utoipa::{OpenApi, ToSchema};
+    use utoipa::ToSchema;
     use utoipa_axum::router::OpenApiRouter;
     use utoipa_axum::routes;
-
-    #[derive(OpenApi)]
-    #[openapi(components(schemas(Customer)))]
-    struct CustomerApi;
 
     /// This is the customer
     #[derive(ToSchema, Serialize)]
@@ -68,7 +64,7 @@ mod customer {
 
     /// expose the Customer OpenAPI to parent module
     pub fn router() -> OpenApiRouter {
-        OpenApiRouter::with_openapi(CustomerApi::openapi()).routes(routes!(get_customer))
+        OpenApiRouter::new().routes(routes!(get_customer))
     }
 
     /// Get customer
@@ -85,13 +81,9 @@ mod customer {
 mod order {
     use axum::Json;
     use serde::{Deserialize, Serialize};
-    use utoipa::{OpenApi, ToSchema};
+    use utoipa::ToSchema;
     use utoipa_axum::router::OpenApiRouter;
     use utoipa_axum::routes;
-
-    #[derive(OpenApi)]
-    #[openapi(components(schemas(Order, OrderRequest)))]
-    struct OrderApi;
 
     /// This is the order
     #[derive(ToSchema, Serialize)]
@@ -107,7 +99,7 @@ mod order {
 
     /// expose the Order OpenAPI to parent module
     pub fn router() -> OpenApiRouter {
-        OpenApiRouter::with_openapi(OrderApi::openapi()).routes(routes!(get_order, create_order))
+        OpenApiRouter::new().routes(routes!(get_order, create_order))
     }
 
     /// Get static order object

--- a/utoipa-axum/Cargo.toml
+++ b/utoipa-axum/Cargo.toml
@@ -16,13 +16,17 @@ debug = []
 
 [dependencies]
 axum = { version = "0.7", default-features = false }
-utoipa = { version = "5.0.0-beta", path = "../utoipa", default-features = false, features = ["macros"] }
+utoipa = { version = "5.0.0-beta", path = "../utoipa", default-features = false, features = [
+    "macros",
+] }
 tower-service = "0.3"
 tower-layer = "0.3.2"
 paste = "1.0"
 
 [dev-dependencies]
 utoipa = { path = "../utoipa", features = ["debug"] }
+axum = { version = "0.7", default-features = false, features = ["json"] }
+serde = "1"
 
 [package.metadata.docs.rs]
 features = []

--- a/utoipa-axum/README.md
+++ b/utoipa-axum/README.md
@@ -27,21 +27,21 @@ utoipa_axum = "0.1"
 Use `OpenApiRouter` to collect handlers with `#[utoipa::path]` macro to compose service and form OpenAPI spec.
 
 ```rust
+use utoipa_axum::{routes, PathItemExt, router::OpenApiRouter};
+
 #[derive(utoipa::ToSchema)]
-struct Todo {
+struct User {
     id: i32,
 }
 
-#[derive(utoipa::OpenApi)]
-#[openapi(components(schemas(Todo)))]
-struct Api;
+#[utoipa::path(get, path = "/user", responses((status = OK, body = User)))]
+async fn get_user() -> Json<User> {
+    Json(User { id: 1 })
+}
 
-let mut router: OpenApiRouter = OpenApiRouter::with_openapi(Api::openapi())
-    .routes(routes!(search_user))
-    .routes(routes!(get_user, post_user, delete_user));
-
-let api = router.to_openapi();
-let axum_router: axum::Router = router.into();
+let (router, api) = OpenApiRouter::new()
+    .routes(routes!(get_user))
+    .split_for_parts();
 ```
 
 ## License

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -663,6 +663,8 @@ fn path_response_with_inline_ref_type() {
 
 #[test]
 fn path_response_default_no_value_nor_ref() {
+    #![allow(unused)]
+
     /// Post some secret inner handler
     #[utoipa::path(post, path = "/api/inner/secret", responses((status = OK)))]
     pub async fn post_secret() {}


### PR DESCRIPTION
Add support for auto collecting schemas from handlers annotated with `#[utoipa::path(...)]` macro used with `utoipa-axum` `routes!` macro.

Update examples and docs.

From now on the there is no need to merge schemas from separate OpenApi since the schemas will get collected from the handlers.
```rust
 #[derive(utoipa::ToSchema)]
 struct User {
     id: i32,
 }

 #[utoipa::path(get, path = "/user", responses((status = OK, body = User)))]
 async fn get_user() -> Json<User> {
     Json(User { id: 1 })
 }

 let (router, api) = OpenApiRouter::new()
     .routes(routes!(get_user))
     .split_for_parts();
```