### PR TITLE
Fix allow response `content_type` without schema

### DIFF
--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -421,7 +421,8 @@ impl ToTokensDiagnostics for ResponseTuple<'_> {
                 });
 
                 for media_type in value.content.iter().filter(|media_type| {
-                    !matches!(media_type.schema, Schema::Default(DefaultSchema::None))
+                    !(matches!(media_type.schema, Schema::Default(DefaultSchema::None))
+                        && media_type.content_type.is_none())
                 }) {
                     let default_content_type = media_type.schema.get_default_content_type()?;
 

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -685,3 +685,33 @@ fn path_response_default_no_value_nor_ref() {
         })
     )
 }
+
+#[test]
+fn path_response_with_no_schema() {
+    #![allow(unused)]
+
+    /// Post some secret inner handler
+    #[utoipa::path(post, path = "/api/inner/secret", responses(
+        (status = OK, content_type = "application/octet-stream")
+    ))]
+    pub async fn post_secret() {}
+
+    let operation = __path_post_secret::operation();
+    let value = serde_json::to_value(operation).expect("operation is JSON serializable");
+
+    assert_json_eq!(
+        value,
+        json!({
+            "operationId": "post_secret",
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/octet-stream": {}
+                    },
+                    "description": ""
+                }
+            },
+            "summary": "Post some secret inner handler"
+        })
+    )
+}


### PR DESCRIPTION
Fix allow response with `content_type` without schema.

```rust
 #[utoipa::path(post, path = "/api/secret", responses(
     (status = OK, content_type = "application/octet-stream")
 ))]
 async fn post_secret() {}
```

Fixes #965 Fixes #779