### PR TITLE
Generate `ToSchema` generic bounds on impl instead of requiring it on definition

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -20,6 +20,7 @@
 * Add support for description and summary overriding (https://github.com/juhaku/utoipa/pull/948)
 * Add nest `OpenApi` support (https://github.com/juhaku/utoipa/pull/930)
 * Add support for additional tags via `tags` (https://github.com/juhaku/utoipa/pull/916)
+* Add `bound` attribute for customizing generic impl bounds. (https://github.com/juhaku/utoipa/pull/1079)
 
 ### Fixed
 

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -101,6 +101,7 @@ pub enum Feature {
     ContentEncoding(attributes::ContentEncoding),
     ContentMediaType(attributes::ContentMediaType),
     Discriminator(attributes::Discriminator),
+    Bound(attributes::Bound),
     MultipleOf(validation::MultipleOf),
     Maximum(validation::Maximum),
     Minimum(validation::Minimum),
@@ -212,6 +213,10 @@ impl ToTokensDiagnostics for Feature {
             Feature::ContentEncoding(content_encoding) => quote! { .content_encoding(#content_encoding) },
             Feature::ContentMediaType(content_media_type) => quote! { .content_media_type(#content_media_type) },
             Feature::Discriminator(discriminator) => quote! { .discriminator(Some(#discriminator)) },
+            Feature::Bound(_) => {
+                // specially handled on generating impl blocks.
+                TokenStream::new()
+            }
             Feature::RenameAll(_) => {
                 return Err(Diagnostics::new("RenameAll feature does not support `ToTokens`"))
             }
@@ -294,6 +299,7 @@ impl Display for Feature {
             Feature::ContentEncoding(content_encoding) => content_encoding.fmt(f),
             Feature::ContentMediaType(content_media_type) => content_media_type.fmt(f),
             Feature::Discriminator(discriminator) => discriminator.fmt(f),
+            Feature::Bound(bound) => bound.fmt(f),
         }
     }
 }
@@ -342,6 +348,7 @@ impl Validatable for Feature {
             Feature::ContentEncoding(content_encoding) => content_encoding.is_validatable(),
             Feature::ContentMediaType(content_media_type) => content_media_type.is_validatable(),
             Feature::Discriminator(discriminator) => discriminator.is_validatable(),
+            Feature::Bound(bound) => bound.is_validatable(),
         }
     }
 }
@@ -388,6 +395,7 @@ is_validatable! {
     attributes::ContentEncoding,
     attributes::ContentMediaType,
     attributes::Discriminator,
+    attributes::Bound,
     validation::MultipleOf = true,
     validation::Maximum = true,
     validation::Minimum = true,
@@ -615,6 +623,7 @@ impl_feature_into_inner! {
     attributes::Required,
     attributes::AdditionalProperties,
     attributes::Discriminator,
+    attributes::Bound,
     validation::MultipleOf,
     validation::Maximum,
     validation::Minimum,

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -6,9 +6,9 @@ use syn::{
 use crate::{
     component::features::{
         attributes::{
-            AdditionalProperties, As, ContentEncoding, ContentMediaType, Deprecated, Description,
-            Discriminator, Example, Examples, Format, Inline, Nullable, ReadOnly, Rename,
-            RenameAll, Required, SchemaWith, Title, ValueType, WriteOnly, XmlAttr,
+            AdditionalProperties, As, Bound, ContentEncoding, ContentMediaType, Deprecated,
+            Description, Discriminator, Example, Examples, Format, Inline, Nullable, ReadOnly,
+            Rename, RenameAll, Required, SchemaWith, Title, ValueType, WriteOnly, XmlAttr,
         },
         impl_into_inner, impl_merge, parse_features,
         validation::{
@@ -36,7 +36,8 @@ impl Parse for NamedFieldStructFeatures {
             As,
             crate::component::features::attributes::Default,
             Deprecated,
-            Description
+            Description,
+            Bound
         )))
     }
 }
@@ -57,7 +58,8 @@ impl Parse for UnnamedFieldStructFeatures {
             ValueType,
             As,
             Deprecated,
-            Description
+            Description,
+            Bound
         )))
     }
 }
@@ -76,7 +78,8 @@ impl Parse for EnumFeatures {
             RenameAll,
             As,
             Deprecated,
-            Description
+            Description,
+            Bound
         )))
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -571,12 +571,12 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 /// # use std::borrow::Cow;
 ///  #[derive(ToSchema)]
 ///  #[schema(as = path::MyType<T>)]
-///  struct Type<T: ToSchema> {
+///  struct Type<T> {
 ///      t: T,
 ///  }
 ///
 ///  #[derive(ToSchema)]
-///  struct Person<'p, T: Sized + ToSchema, P: ToSchema> {
+///  struct Person<'p, T: Sized, P> {
 ///      id: usize,
 ///      name: Option<Cow<'p, str>>,
 ///      field: T,
@@ -585,7 +585,7 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 ///
 ///  #[derive(ToSchema)]
 ///  #[schema(as = path::to::PageList)]
-///  struct Page<T: ToSchema> {
+///  struct Page<T> {
 ///      total: usize,
 ///      page: usize,
 ///      pages: usize,
@@ -594,7 +594,7 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 ///
 ///  #[derive(ToSchema)]
 ///  #[schema(as = path::to::Element<T>)]
-///  enum E<T: ToSchema> {
+///  enum E<T> {
 ///      One(T),
 ///      Many(Vec<T>),
 ///  }

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -540,7 +540,7 @@ fn openapi_schemas_resolve_schema_references() {
     use utoipa::ToSchema;
 
     #[derive(ToSchema)]
-    enum Element<T: ToSchema> {
+    enum Element<T> {
         One(T),
         Many(Vec<T>),
     }

--- a/utoipa-gen/tests/openapi_derive_test.rs
+++ b/utoipa-gen/tests/openapi_derive_test.rs
@@ -74,7 +74,7 @@ struct B {
 }
 
 #[derive(Deserialize, Serialize, ToSchema)]
-struct C<T: ToSchema, R: ToSchema> {
+struct C<T, R> {
     field_1: R,
     field_2: T,
 }

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -2535,7 +2535,7 @@ fn derive_path_test_collect_generic_array_request_body() {
     }
 
     #[derive(ToSchema)]
-    struct CreateRequest<T: ToSchema> {
+    struct CreateRequest<T> {
         value: T,
     }
 
@@ -2624,7 +2624,7 @@ fn derive_path_test_collect_generic_request_body() {
     }
 
     #[derive(ToSchema)]
-    struct CreateRequest<T: ToSchema> {
+    struct CreateRequest<T> {
         value: T,
     }
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3515,6 +3515,7 @@ fn derive_parse_serde_field_attributes() {
     let post = api_doc! {
         #[derive(Serialize)]
         #[serde(rename_all = "camelCase")]
+        #[schema(bound = "")]
         struct Post<S> {
             #[serde(rename = "uuid")]
             id: String,

--- a/utoipa-gen/tests/schema_generics.rs
+++ b/utoipa-gen/tests/schema_generics.rs
@@ -1,7 +1,29 @@
 use std::borrow::Cow;
+use std::marker::PhantomData;
 
 use utoipa::openapi::{Info, RefOr, Schema};
+use utoipa::openapi::{RefOr, Schema};
+use serde::Serialize;
+use utoipa::openapi::{RefOr, Schema};
 use utoipa::{schema, OpenApi, ToSchema};
+
+#[test]
+fn generic_schema_custom_bound() {
+    #![allow(unused)]
+
+    #[derive(Serialize, ToSchema)]
+    #[schema(bound = "T: Clone + Sized, T: Sized")]
+    struct Type<T> {
+        #[serde(skip)]
+        t: PhantomData<T>,
+    }
+
+    #[derive(Clone)]
+    struct NoToSchema;
+    fn assert_is_to_schema<T: ToSchema>() {}
+
+    assert_is_to_schema::<Type<NoToSchema>>();
+}
 
 #[test]
 fn generic_schema_full_api() {
@@ -9,12 +31,12 @@ fn generic_schema_full_api() {
 
     #[derive(ToSchema)]
     #[schema(as = path::MyType<T>)]
-    struct Type<T: ToSchema> {
+    struct Type<T> {
         t: T,
     }
 
     #[derive(ToSchema)]
-    struct Person<'p, T: Sized + ToSchema, P: ToSchema> {
+    struct Person<'p, T: Sized, P> {
         id: usize,
         name: Option<Cow<'p, str>>,
         field: T,
@@ -23,7 +45,7 @@ fn generic_schema_full_api() {
 
     #[derive(ToSchema)]
     #[schema(as = path::to::PageList)]
-    struct Page<T: ToSchema> {
+    struct Page<T> {
         total: usize,
         page: usize,
         pages: usize,
@@ -32,10 +54,13 @@ fn generic_schema_full_api() {
 
     #[derive(ToSchema)]
     #[schema(as = path::to::Element<T>)]
-    enum E<T: ToSchema> {
+    enum E<T> {
         One(T),
         Many(Vec<T>),
     }
+
+    struct NoToSchema;
+    fn assert_no_need_to_schema_outside_api(_: Type<NoToSchema>) {}
 
     #[utoipa::path(
         get,
@@ -80,12 +105,12 @@ fn schema_macro_run() {
 
     #[derive(ToSchema)]
     #[schema(as = path::MyType<T>)]
-    struct Type<T: ToSchema> {
+    struct Type<T> {
         t: T,
     }
 
     #[derive(ToSchema)]
-    struct Person<'p, T: Sized + ToSchema, P: ToSchema> {
+    struct Person<'p, T: Sized, P> {
         id: usize,
         name: Option<Cow<'p, str>>,
         field: T,
@@ -94,7 +119,7 @@ fn schema_macro_run() {
 
     #[derive(ToSchema)]
     #[schema(as = path::to::PageList)]
-    struct Page<T: ToSchema> {
+    struct Page<T> {
         total: usize,
         page: usize,
         pages: usize,

--- a/utoipa-gen/tests/schema_generics.rs
+++ b/utoipa-gen/tests/schema_generics.rs
@@ -1,10 +1,8 @@
 use std::borrow::Cow;
 use std::marker::PhantomData;
 
-use utoipa::openapi::{Info, RefOr, Schema};
-use utoipa::openapi::{RefOr, Schema};
 use serde::Serialize;
-use utoipa::openapi::{RefOr, Schema};
+use utoipa::openapi::{Info, RefOr, Schema};
 use utoipa::{schema, OpenApi, ToSchema};
 
 #[test]

--- a/utoipa-gen/tests/utoipa_gen_test.rs
+++ b/utoipa-gen/tests/utoipa_gen_test.rs
@@ -112,7 +112,7 @@ struct B {
 }
 
 #[derive(Deserialize, Serialize, ToSchema)]
-struct C<T: ToSchema, R: ToSchema> {
+struct C<T, R> {
     field_1: R,
     field_2: T,
 }


### PR DESCRIPTION
Fixes #1078

```rust
#[derive(ToSchema)]
struct Signed<T> { .. }
/// generates
impl<T> ToSchema for Signed<T> where T: ToSchema /* <- introduced by this PR */ { .. }
```

- Each generic types now automatically get a `ToSchema` bound in where clause of generated `impl` blocks. Thus the user does not need to explicitly add `ToSchema` bounds on struct definitions.

- Attribute `schema(bound = ..)` is introduced for struct or enum containers to opt-out the automatic `ToSchema` bounds addition, by manually provide where clause bounds for the generated impl blocks. The attribute is inspired by [`serde(bound = ..)`](https://serde.rs/container-attrs.html#bound).
  Eg. `schema(bound = "")` can be used to remove bounds in case of `PhantomData` types.

This PR is based on 61c98bb9b40842ce84f6a67a572f4f4afc989610 instead of `master` because `master` is already failing the test after the rc version bump (snapshot assertion failure in `openapi_schemas_resolve_schema_references` and friends). It does not conflict anyway.