### PR TITLE
Fix nest path config struct name

### DIFF
--- a/.github/actions/gitlog/gitlog.sh
+++ b/.github/actions/gitlog/gitlog.sh
@@ -70,11 +70,15 @@ mapfile -t log_lines < <(git log --pretty=format:'(%h) %s' $ancestry_path "$comm
 function is_crate_related {
     commit="$1"
     changes="$(git diff --name-only "$commit"~ "$commit" | awk -F / '{print $1}' | xargs)"
+    IFS=" " read -r -a change_dirs <<<"$changes"
 
     is_related=false
-    if [[ "$changes" == *"$crate"* ]]; then
-        is_related=true
-    fi
+    for change in "${change_dirs[@]}"; do
+        if [[ "$change" == "$crate" ]]; then
+            is_related=true
+            break
+        fi
+    done
 
     echo $is_related
 }

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+* Fix nest path config struct name (https://github.com/juhaku/utoipa/pull/1081)
 * Fix `as` attribute path format (https://github.com/juhaku/utoipa/pull/1080)
 * Fix allow response `content_type` without schema (https://github.com/juhaku/utoipa/pull/1073)
 * Fix negative value parsing on schema attributes (https://github.com/juhaku/utoipa/pull/1031)

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -691,9 +691,14 @@ fn impl_paths(handler_paths: Option<&Punctuated<ExprPath, Comma>>) -> Paths {
         .flatten()
         .map(|handler| {
             let segments = handler.path.segments.iter().collect::<Vec<_>>();
+            let handler_config_name = segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("_");
             let handler_fn = &segments.last().unwrap().ident;
             let handler_ident = path::format_path_ident(Cow::Borrowed(handler_fn));
-            let handler_ident_nested = format_ident!("_{}", handler_ident.as_ref());
+            let handler_ident_config = format_ident!("{}_config", handler_config_name);
 
             let tag = segments
                 .iter()
@@ -713,7 +718,7 @@ fn impl_paths(handler_paths: Option<&Punctuated<ExprPath, Comma>>) -> Paths {
                 .join("::"),
             )
             .unwrap();
-            (usage, tag, handler_ident_nested)
+            (usage, tag, handler_ident_config)
         })
         .collect::<Vec<_>>();
 
@@ -749,12 +754,15 @@ fn impl_paths(handler_paths: Option<&Punctuated<ExprPath, Comma>>) -> Paths {
         quote! { #handlers_impls utoipa::openapi::path::PathsBuilder::new() },
         |mut paths, handler| {
             let segments = handler.path.segments.iter().collect::<Vec<_>>();
-            let handler_fn = &segments.last().unwrap().ident;
-            let handler_ident_nested =
-                format_ident!("_{}", path::format_path_ident(Cow::Borrowed(handler_fn)));
+            let handler_config_name = segments
+                .iter()
+                .map(|segment| segment.ident.to_string())
+                .collect::<Vec<_>>()
+                .join("_");
+            let handler_ident_config = format_ident!("{}_config", handler_config_name);
 
             paths.extend(quote! {
-                .path_from::<#handler_ident_nested>()
+                .path_from::<#handler_ident_config>()
             });
 
             paths


### PR DESCRIPTION
Fix the auto generated struct name of path config introduced with nest functionality. From now on it uses fully qualified path name to avoid conflicts.

Fixes #1069