### PR TITLE
Fix generic aliases

### DIFF
--- a/utoipa-config/CHANGELOG.md
+++ b/utoipa-config/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add global config for `utiopa` (https://github.com/juhaku/utoipa/pull/1048)
 
+### Fixed
+
+* Fix generic aliases (https://github.com/juhaku/utoipa/pull/1083)
+
 ### Changed
 
 * Fixed broken tests at `utoipa-config`

--- a/utoipa-config/config-test-crate/src/main.rs
+++ b/utoipa-config/config-test-crate/src/main.rs
@@ -15,6 +15,8 @@ struct AliasValues {
     my_value: bool,
 
     date: MyDateTime,
+
+    optional_date: Option<MyDateTime>,
 }
 
 #[allow(unused)]

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed
 
+* Fix generic aliases (https://github.com/juhaku/utoipa/pull/1083)
 * Fix nest path config struct name (https://github.com/juhaku/utoipa/pull/1081)
 * Fix `as` attribute path format (https://github.com/juhaku/utoipa/pull/1080)
 * Fix allow response `content_type` without schema (https://github.com/juhaku/utoipa/pull/1073)

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -696,15 +696,20 @@ impl ComponentSchema {
                 {
                     features.push(Nullable::new().into());
                 }
+                let child = type_tree
+                    .children
+                    .as_ref()
+                    .expect("ComponentSchema generic container type should have children")
+                    .iter()
+                    .next()
+                    .expect("ComponentSchema generic container type should have 1 child");
+                let alias = child.get_alias_type()?;
+                let alias = alias.as_ref().map_try(TypeTree::from_type)?;
+                let child = alias.as_ref().unwrap_or(child);
+
                 let schema = ComponentSchema::new(ComponentSchemaProps {
                     container,
-                    type_tree: type_tree
-                        .children
-                        .as_ref()
-                        .expect("ComponentSchema generic container type should have children")
-                        .iter()
-                        .next()
-                        .expect("ComponentSchema generic container type should have 1 child"),
+                    type_tree: child,
                     features,
                     description,
                 })?;
@@ -713,15 +718,20 @@ impl ComponentSchema {
                 schema_references.extend(schema.schema_references);
             }
             Some(GenericType::Cow | GenericType::Box | GenericType::RefCell) => {
+                let child = type_tree
+                    .children
+                    .as_ref()
+                    .expect("ComponentSchema generic container type should have children")
+                    .iter()
+                    .next()
+                    .expect("ComponentSchema generic container type should have 1 child");
+                let alias = child.get_alias_type()?;
+                let alias = alias.as_ref().map_try(TypeTree::from_type)?;
+                let child = alias.as_ref().unwrap_or(child);
+
                 let schema = ComponentSchema::new(ComponentSchemaProps {
                     container,
-                    type_tree: type_tree
-                        .children
-                        .as_ref()
-                        .expect("ComponentSchema generic container type should have children")
-                        .iter()
-                        .next()
-                        .expect("ComponentSchema generic container type should have 1 child"),
+                    type_tree: child,
                     features,
                     description,
                 })?;
@@ -731,15 +741,20 @@ impl ComponentSchema {
             }
             #[cfg(feature = "rc_schema")]
             Some(GenericType::Arc) | Some(GenericType::Rc) => {
+                let child = type_tree
+                    .children
+                    .as_ref()
+                    .expect("ComponentSchema rc generic container type should have children")
+                    .iter()
+                    .next()
+                    .expect("ComponentSchema rc generic container type should have 1 child");
+                let alias = child.get_alias_type()?;
+                let alias = alias.as_ref().map_try(TypeTree::from_type)?;
+                let child = alias.as_ref().unwrap_or(child);
+
                 let schema = ComponentSchema::new(ComponentSchemaProps {
                     container,
-                    type_tree: type_tree
-                        .children
-                        .as_ref()
-                        .expect("ComponentSchema rc generic container type should have children")
-                        .iter()
-                        .next()
-                        .expect("ComponentSchema rc generic container type should have 1 child"),
+                    type_tree: child,
                     features,
                     description,
                 })?;
@@ -810,14 +825,19 @@ impl ComponentSchema {
                 // additionalProperties denoting the type
                 // maps have 2 child schemas and we are interested the second one of them
                 // which is used to determine the additional properties
+                let child = type_tree
+                    .children
+                    .as_ref()
+                    .expect("ComponentSchema Map type should have children")
+                    .get(1)
+                    .expect("ComponentSchema Map type should have 2 child");
+                let alias = child.get_alias_type()?;
+                let alias = alias.as_ref().map_try(TypeTree::from_type)?;
+                let child = alias.as_ref().unwrap_or(child);
+
                 let schema_property = ComponentSchema::new(ComponentSchemaProps {
                     container,
-                    type_tree: type_tree
-                        .children
-                        .as_ref()
-                        .expect("ComponentSchema Map type should have children")
-                        .get(1)
-                        .expect("ComponentSchema Map type should have 2 child"),
+                    type_tree: child,
                     features,
                     description: None,
                 })?;
@@ -882,6 +902,9 @@ impl ComponentSchema {
         } else {
             child
         };
+        let alias = child.get_alias_type()?;
+        let alias = alias.as_ref().map_try(TypeTree::from_type)?;
+        let child = alias.as_ref().unwrap_or(child);
 
         let component_schema = ComponentSchema::new(ComponentSchemaProps {
             container,


### PR DESCRIPTION
Fix aliases support for generic container types like `Option<T>` and `Vec<T>`. Previously if alias was used within container type it was not recognized and the `TypeTree` was resolved incorrectly.

Fixes #1057