### PR TITLE
Fix option wrapped tailing query parameters

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ### Fixed
 
+* Fix option wrapped tailing query parameters (https://github.com/juhaku/utoipa/pull/1089)
 * Fix doc comment trimming to keep relative indentation. (https://github.com/juhaku/utoipa/pull/1082)
 * Fix generic aliases (https://github.com/juhaku/utoipa/pull/1083)
 * Fix nest path config struct name (https://github.com/juhaku/utoipa/pull/1081)

--- a/utoipa-gen/src/ext/rocket.rs
+++ b/utoipa-gen/src/ext/rocket.rs
@@ -6,7 +6,7 @@ use regex::{Captures, Regex};
 use syn::{parse::Parse, LitStr, Token};
 
 use crate::{
-    component::ValueType,
+    component::{GenericType, ValueType},
     ext::{ArgValue, ArgumentIn, MacroArg, ValueArgument},
     path::HttpMethod,
     Diagnostics, OptionExt,
@@ -136,7 +136,18 @@ fn with_argument_in(named_args: &[MacroArg]) -> impl Fn(FnArg) -> Option<(FnArg,
 
 #[inline]
 fn is_into_params(fn_arg: &FnArg) -> bool {
-    matches!(fn_arg.ty.value_type, ValueType::Object) && fn_arg.ty.generic_type.is_none()
+    let mut ty = &fn_arg.ty;
+
+    if fn_arg.ty.generic_type == Some(GenericType::Option) {
+        ty = fn_arg
+            .ty
+            .children
+            .as_ref()
+            .expect("FnArg Option must have children")
+            .first()
+            .expect("FnArg Option must have 1 child");
+    }
+    matches!(ty.value_type, ValueType::Object) && ty.generic_type.is_none()
 }
 
 #[inline]


### PR DESCRIPTION
This commit fixes the trailing query parameters wrapped in `Option<T>`. Option wrapped query parameters were mistaken to value parameters and treated incorrectly.

Fixes #1070