### PR TITLE
Add support for `schema(ignore)` and `param(ignore)`

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Add support for `schema(ignore)` and `param(ignore)` (https://github.com/juhaku/utoipa/pull/1090)
 * Add support for `property_names` for object (https://github.com/juhaku/utoipa/pull/1084)
 * Add `bound` attribute for customizing generic impl bounds. (https://github.com/juhaku/utoipa/pull/1079)
 * Add auto collect schemas for utoipa-axum (https://github.com/juhaku/utoipa/pull/1072)

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -102,6 +102,7 @@ pub enum Feature {
     ContentMediaType(attributes::ContentMediaType),
     Discriminator(attributes::Discriminator),
     Bound(attributes::Bound),
+    Ignore(attributes::Ignore),
     MultipleOf(validation::MultipleOf),
     Maximum(validation::Maximum),
     Minimum(validation::Minimum),
@@ -239,6 +240,7 @@ impl ToTokensDiagnostics for Feature {
                 let name = <attributes::Required as FeatureLike>::get_name();
                 quote! { .#name(#required) }
             }
+            Feature::Ignore(_) => return Err(Diagnostics::new("Feature::Ignore does not support ToTokens")),
         };
 
         tokens.extend(feature);
@@ -300,6 +302,7 @@ impl Display for Feature {
             Feature::ContentMediaType(content_media_type) => content_media_type.fmt(f),
             Feature::Discriminator(discriminator) => discriminator.fmt(f),
             Feature::Bound(bound) => bound.fmt(f),
+            Feature::Ignore(ignore) => ignore.fmt(f),
         }
     }
 }
@@ -349,6 +352,7 @@ impl Validatable for Feature {
             Feature::ContentMediaType(content_media_type) => content_media_type.is_validatable(),
             Feature::Discriminator(discriminator) => discriminator.is_validatable(),
             Feature::Bound(bound) => bound.is_validatable(),
+            Feature::Ignore(ignore) => ignore.is_validatable(),
         }
     }
 }
@@ -396,6 +400,7 @@ is_validatable! {
     attributes::ContentMediaType,
     attributes::Discriminator,
     attributes::Bound,
+    attributes::Ignore,
     validation::MultipleOf = true,
     validation::Maximum = true,
     validation::Minimum = true,
@@ -624,6 +629,7 @@ impl_feature_into_inner! {
     attributes::AdditionalProperties,
     attributes::Discriminator,
     attributes::Bound,
+    attributes::Ignore,
     validation::MultipleOf,
     validation::Maximum,
     validation::Minimum,

--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -982,3 +982,25 @@ impl From<Bound> for Feature {
         Feature::Bound(value)
     }
 }
+
+// Nothing to parse, it will be parsed true via `parse_features!` when defined as `ignore`
+impl_feature! {
+    #[derive(Clone)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct Ignore;
+}
+
+impl Parse for Ignore {
+    fn parse(_: ParseStream, _: Ident) -> syn::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(Self)
+    }
+}
+
+impl From<Ignore> for Feature {
+    fn from(value: Ignore) -> Self {
+        Self::Ignore(value)
+    }
+}

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -13,7 +13,7 @@ use crate::{
         features::{
             self,
             attributes::{
-                AdditionalProperties, AllowReserved, Example, Explode, Format, Inline,
+                AdditionalProperties, AllowReserved, Example, Explode, Format, Ignore, Inline,
                 IntoParamsNames, Nullable, ReadOnly, Rename, RenameAll, SchemaWith, Style,
                 WriteOnly, XmlAttr,
             },
@@ -109,20 +109,26 @@ impl ToTokensDiagnostics for IntoParams {
         let params = self
             .get_struct_fields(&names.as_ref())?
             .enumerate()
-            .map(|(index, field)| match serde::parse_value(&field.attrs) {
-                Ok(serde_value) => Ok((index, field, serde_value)),
-                Err(diagnostics) => Err(diagnostics)
+            .map(|(index, field)| {
+                let field_features = match parse_field_features(field) {
+                    Ok(features) => features,
+                    Err(error) => return Err(error),
+                };
+                match serde::parse_value(&field.attrs) {
+                    Ok(serde_value) => Ok((index, field, serde_value, field_features)),
+                    Err(diagnostics) => Err(diagnostics)
+                }
             })
             .collect::<Result<Vec<_>, Diagnostics>>()?
             .into_iter()
-            .filter_map(|(index, field, field_serde_params)| {
-                if !field_serde_params.skip {
-                    Some((index, field, field_serde_params))
-                } else {
+            .filter_map(|(index, field, field_serde_params, field_features)| {
+                if field_serde_params.skip || field_features.iter().any(|feature| matches!(feature, Feature::Ignore(_))) {
                     None
+                } else {
+                    Some((index, field, field_serde_params, field_features))
                 }
             })
-            .map(|(index, field, field_serde_params)| {
+            .map(|(index, field, field_serde_params, field_features)| {
                 let name = names.as_ref()
                     .map_try(|names| names.get(index).ok_or_else(|| Diagnostics::with_span(
                         ident.span(),
@@ -132,10 +138,7 @@ impl ToTokensDiagnostics for IntoParams {
                     Ok(name) => name,
                     Err(diagnostics) => return Err(diagnostics)
                 };
-                let param = Param {
-                    field,
-                    field_serde_params,
-                    container_attributes: FieldParamContainerAttributes {
+                let param = Param::new(field, field_serde_params, field_features, FieldParamContainerAttributes {
                         rename_all: rename_all.as_ref().and_then(|feature| {
                             match feature {
                                 Feature::RenameAll(rename_all) => Some(rename_all),
@@ -145,16 +148,10 @@ impl ToTokensDiagnostics for IntoParams {
                         style: &style,
                         parameter_in: &parameter_in,
                         name,
-                    },
-                    serde_container: &serde_container,
-                    generics: &self.generics
-                };
+                    }, &serde_container, &self.generics)?;
 
-                let mut param_tokens = TokenStream::new();
-                match ToTokensDiagnostics::to_tokens(&param, &mut param_tokens) {
-                    Ok(_) => Ok(param_tokens),
-                    Err(diagnostics) => Err(diagnostics)
-                }
+
+                Ok(param.to_token_stream())
             })
             .collect::<Result<Array<TokenStream>, Diagnostics>>()?;
 
@@ -168,6 +165,22 @@ impl ToTokensDiagnostics for IntoParams {
 
         Ok(())
     }
+}
+
+fn parse_field_features(field: &Field) -> Result<Vec<Feature>, Diagnostics> {
+    Ok(field
+        .attrs
+        .iter()
+        .filter(|attribute| attribute.path().is_ident("param"))
+        .map(|attribute| {
+            attribute
+                .parse_args::<FieldFeatures>()
+                .map(FieldFeatures::into_inner)
+        })
+        .collect::<Result<Vec<_>, syn::Error>>()?
+        .into_iter()
+        .reduce(|acc, item| acc.merge(item))
+        .unwrap_or_default())
 }
 
 impl IntoParams {
@@ -286,47 +299,132 @@ impl Parse for FieldFeatures {
             Pattern,
             MaxItems,
             MinItems,
-            AdditionalProperties
+            AdditionalProperties,
+            Ignore
         )))
     }
 }
 
 #[cfg_attr(feature = "debug", derive(Debug))]
-struct Param<'a> {
-    /// Field in the container used to create a single parameter.
-    field: &'a Field,
-    //// Field serde params parsed from field attributes.
-    field_serde_params: SerdeValue,
-    /// Attributes on the container which are relevant for this macro.
-    container_attributes: FieldParamContainerAttributes<'a>,
-    /// Either serde rename all rule or into_params rename all rule if provided.
-    serde_container: &'a SerdeContainer,
-    /// Container gnerics
-    generics: &'a Generics,
+struct Param {
+    tokens: TokenStream,
 }
 
-impl Param<'_> {
+impl Param {
+    fn new(
+        field: &Field,
+        field_serde_params: SerdeValue,
+        field_features: Vec<Feature>,
+        container_attributes: FieldParamContainerAttributes<'_>,
+        serde_container: &SerdeContainer,
+        generics: &Generics,
+    ) -> Result<Self, Diagnostics> {
+        let mut tokens = TokenStream::new();
+        let field_serde_params = &field_serde_params;
+        let ident = &field.ident;
+        let mut name = &*ident
+            .as_ref()
+            .map(|ident| ident.to_string())
+            .or_else(|| container_attributes.name.cloned())
+            .ok_or_else(||
+                Diagnostics::with_span(field.span(), "No name specified for unnamed field.")
+                    .help("Try adding #[into_params(names(...))] container attribute to specify the name for this field")
+            )?;
+
+        if name.starts_with("r#") {
+            name = &name[2..];
+        }
+
+        let (schema_features, mut param_features) =
+            Param::resolve_field_features(field_features, &container_attributes)
+                .map_err(Diagnostics::from)?;
+
+        let rename = pop_feature!(param_features => Feature::Rename(_) as Option<Rename>)
+            .map(|rename| rename.into_value());
+        let rename_to = field_serde_params
+            .rename
+            .as_deref()
+            .map(Cow::Borrowed)
+            .or(rename.map(Cow::Owned));
+        let rename_all = serde_container.rename_all.as_ref().or(container_attributes
+            .rename_all
+            .map(|rename_all| rename_all.as_rename_rule()));
+        let name = super::rename::<FieldRename>(name, rename_to, rename_all)
+            .unwrap_or(Cow::Borrowed(name));
+        let type_tree = TypeTree::from_type(&field.ty)?;
+
+        tokens.extend(quote! { utoipa::openapi::path::ParameterBuilder::new()
+            .name(#name)
+        });
+        tokens.extend(
+            if let Some(ref parameter_in) = &container_attributes.parameter_in {
+                parameter_in.to_token_stream()
+            } else {
+                quote! {
+                    .parameter_in(parameter_in_provider().unwrap_or_default())
+                }
+            },
+        );
+
+        if let Some(deprecated) = super::get_deprecated(&field.attrs) {
+            tokens.extend(quote! { .deprecated(Some(#deprecated)) });
+        }
+
+        let schema_with = pop_feature!(param_features => Feature::SchemaWith(_));
+        if let Some(schema_with) = schema_with {
+            let schema_with = crate::as_tokens_or_diagnostics!(&schema_with);
+            tokens.extend(quote! { .schema(Some(#schema_with)).build() });
+        } else {
+            let description =
+                CommentAttributes::from_attributes(&field.attrs).as_formatted_string();
+            if !description.is_empty() {
+                tokens.extend(quote! { .description(Some(#description))})
+            }
+
+            let value_type = pop_feature!(param_features => Feature::ValueType(_) as Option<features::attributes::ValueType>);
+            let component = value_type
+                .as_ref()
+                .map_try(|value_type| value_type.as_type_tree())?
+                .unwrap_or(type_tree);
+
+            let required: Option<features::attributes::Required> =
+                pop_feature!(param_features => Feature::Required(_)).into_inner();
+            let component_required =
+                !component.is_option() && super::is_required(field_serde_params, serde_container);
+
+            let required = match (required, component_required) {
+                (Some(required_feature), _) => Into::<Required>::into(required_feature.is_true()),
+                (None, component_required) => Into::<Required>::into(component_required),
+            };
+
+            tokens.extend(quote! {
+                .required(#required)
+            });
+            tokens.extend(param_features.to_token_stream()?);
+
+            let schema = ComponentSchema::new(component::ComponentSchemaProps {
+                type_tree: &component,
+                features: schema_features,
+                description: None,
+                container: &Container { generics },
+            })?;
+            let schema_tokens = schema.to_token_stream();
+
+            tokens.extend(quote! { .schema(Some(#schema_tokens)).build() });
+        }
+
+        Ok(Self { tokens })
+    }
+
     /// Resolve [`Param`] features and split features into two [`Vec`]s. Features are split by
     /// whether they should be rendered in [`Param`] itself or in [`Param`]s schema.
     ///
     /// Method returns a tuple containing two [`Vec`]s of [`Feature`].
-    fn resolve_field_features(&self) -> Result<(Vec<Feature>, Vec<Feature>), syn::Error> {
-        let mut field_features = self
-            .field
-            .attrs
-            .iter()
-            .filter(|attribute| attribute.path().is_ident("param"))
-            .map(|attribute| {
-                attribute
-                    .parse_args::<FieldFeatures>()
-                    .map(FieldFeatures::into_inner)
-            })
-            .collect::<Result<Vec<_>, syn::Error>>()?
-            .into_iter()
-            .reduce(|acc, item| acc.merge(item))
-            .unwrap_or_default();
-
-        if let Some(ref style) = self.container_attributes.style {
+    fn resolve_field_features(
+        mut field_features: Vec<Feature>,
+        container_attributes: &FieldParamContainerAttributes<'_>,
+    ) -> Result<(Vec<Feature>, Vec<Feature>), syn::Error> {
+        if let Some(ref style) = container_attributes.style {
             if !field_features
                 .iter()
                 .any(|feature| matches!(&feature, Feature::Style(_)))
@@ -370,104 +468,8 @@ impl Param<'_> {
     }
 }
 
-impl ToTokensDiagnostics for Param<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostics> {
-        let field = self.field;
-        let field_serde_params = &self.field_serde_params;
-        let ident = &field.ident;
-        let mut name = &*ident
-            .as_ref()
-            .map(|ident| ident.to_string())
-            .or_else(|| self.container_attributes.name.cloned())
-            .ok_or_else(||
-                Diagnostics::with_span(field.span(), "No name specified for unnamed field.")
-                    .help("Try adding #[into_params(names(...))] container attribute to specify the name for this field")
-            )?;
-
-        if name.starts_with("r#") {
-            name = &name[2..];
-        }
-
-        let (schema_features, mut param_features) =
-            self.resolve_field_features().map_err(Diagnostics::from)?;
-
-        let rename = pop_feature!(param_features => Feature::Rename(_) as Option<Rename>)
-            .map(|rename| rename.into_value());
-        let rename_to = field_serde_params
-            .rename
-            .as_deref()
-            .map(Cow::Borrowed)
-            .or(rename.map(Cow::Owned));
-        let rename_all = self.serde_container.rename_all.as_ref().or(self
-            .container_attributes
-            .rename_all
-            .map(|rename_all| rename_all.as_rename_rule()));
-        let name = super::rename::<FieldRename>(name, rename_to, rename_all)
-            .unwrap_or(Cow::Borrowed(name));
-        let type_tree = TypeTree::from_type(&field.ty)?;
-
-        tokens.extend(quote! { utoipa::openapi::path::ParameterBuilder::new()
-            .name(#name)
-        });
-        tokens.extend(
-            if let Some(ref parameter_in) = self.container_attributes.parameter_in {
-                parameter_in.to_token_stream()
-            } else {
-                quote! {
-                    .parameter_in(parameter_in_provider().unwrap_or_default())
-                }
-            },
-        );
-
-        if let Some(deprecated) = super::get_deprecated(&field.attrs) {
-            tokens.extend(quote! { .deprecated(Some(#deprecated)) });
-        }
-
-        let schema_with = pop_feature!(param_features => Feature::SchemaWith(_));
-        if let Some(schema_with) = schema_with {
-            let schema_with = crate::as_tokens_or_diagnostics!(&schema_with);
-            tokens.extend(quote! { .schema(Some(#schema_with)).build() });
-        } else {
-            let description =
-                CommentAttributes::from_attributes(&field.attrs).as_formatted_string();
-            if !description.is_empty() {
-                tokens.extend(quote! { .description(Some(#description))})
-            }
-
-            let value_type = pop_feature!(param_features => Feature::ValueType(_) as Option<features::attributes::ValueType>);
-            let component = value_type
-                .as_ref()
-                .map_try(|value_type| value_type.as_type_tree())?
-                .unwrap_or(type_tree);
-
-            let required: Option<features::attributes::Required> =
-                pop_feature!(param_features => Feature::Required(_)).into_inner();
-            let component_required = !component.is_option()
-                && super::is_required(field_serde_params, self.serde_container);
-
-            let required = match (required, component_required) {
-                (Some(required_feature), _) => Into::<Required>::into(required_feature.is_true()),
-                (None, component_required) => Into::<Required>::into(component_required),
-            };
-
-            tokens.extend(quote! {
-                .required(#required)
-            });
-            tokens.extend(param_features.to_token_stream()?);
-
-            let schema = ComponentSchema::new(component::ComponentSchemaProps {
-                type_tree: &component,
-                features: schema_features,
-                description: None,
-                container: &Container {
-                    generics: self.generics,
-                },
-            })?;
-            let schema_tokens = schema.to_token_stream();
-
-            tokens.extend(quote! { .schema(Some(#schema_tokens)).build() });
-        }
-
-        Ok(())
+impl ToTokens for Param {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.tokens.to_tokens(tokens)
     }
 }

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -7,8 +7,9 @@ use crate::{
     component::features::{
         attributes::{
             AdditionalProperties, As, Bound, ContentEncoding, ContentMediaType, Deprecated,
-            Description, Discriminator, Example, Examples, Format, Inline, Nullable, ReadOnly,
-            Rename, RenameAll, Required, SchemaWith, Title, ValueType, WriteOnly, XmlAttr,
+            Description, Discriminator, Example, Examples, Format, Ignore, Inline, Nullable,
+            ReadOnly, Rename, RenameAll, Required, SchemaWith, Title, ValueType, WriteOnly,
+            XmlAttr,
         },
         impl_into_inner, impl_merge, parse_features,
         validation::{
@@ -137,7 +138,8 @@ impl Parse for NamedFieldFeatures {
             Required,
             Deprecated,
             ContentEncoding,
-            ContentMediaType
+            ContentMediaType,
+            Ignore
         )))
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -187,6 +187,7 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 ///   See [`Object::content_encoding`][schema_object_encoding]
 /// * `content_media_type = ...` Can be used to define MIME type of a string for underlying schema object.
 ///   See [`Object::content_media_type`][schema_object_media_type]
+///* `ignore` Can be used to skip the field from being serialized to OpenAPI schema.
 ///
 /// #### Field nullability and required rules
 ///
@@ -2227,6 +2228,8 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///   [`HashMap`](std::collections::HashMap) and [`BTreeMap`](std::collections::BTreeMap).
 ///   Free form type enables use of arbitrary types within map values.
 ///   Supports formats _`additional_properties`_ and _`additional_properties = true`_.
+///
+/// * `ignore` Can be used to skip the field from being serialized to OpenAPI schema.
 ///
 /// #### Field nullability and required rules
 ///

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -2751,3 +2751,41 @@ fn path_derive_with_body_ref_using_as_attribute_schema() {
         })
     );
 }
+
+#[test]
+fn derive_into_params_with_ignored_field() {
+    #![allow(unused)]
+
+    #[derive(IntoParams)]
+    #[into_params(parameter_in = Query)]
+    struct Params {
+        name: String,
+        #[param(ignore)]
+        __this_is_private: String,
+    }
+
+    #[utoipa::path(get, path = "/params", params(Params))]
+    #[allow(unused)]
+    fn get_params() {}
+    let operation = test_api_fn_doc! {
+        get_params,
+        operation: get,
+        path: "/params"
+    };
+
+    let value = operation.pointer("/parameters");
+
+    assert_json_eq!(
+        value,
+        json!([
+            {
+                "in": "query",
+                "name": "name",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            }
+        ])
+    )
+}

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5681,3 +5681,29 @@ fn derive_map_with_property_names() {
         })
     )
 }
+
+#[test]
+fn derive_schema_with_ignored_field() {
+    #![allow(unused)]
+
+    let value = api_doc! {
+        struct SchemaIgnoredField {
+            value: String,
+            #[schema(ignore)]
+            __this_is_private: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "value": {
+                    "type": "string"
+                }
+            },
+            "required": [ "value" ],
+            "type": "object"
+        })
+    )
+}


### PR DESCRIPTION
Add support for `#[schema(ignore)]` for named field struct types implementing `ToSchema` trait. Add support for `param(ignore)` for named field structs implementing `IntoParams` trait. The ignored field will not get serialized to the OpenAPI schema.

```rust
 #[derive(ToSchema)]
 struct SchemaIgnoredField {
     value: String,
     #[schema(ignore)]
     __this_is_private: String,
 }

 #[derive(IntoParams)]
 #[into_params(parameter_in = Query)]
 struct Params {
     name: String,
     #[param(ignore)]
     __this_is_private: String,
 }
```

Closes #795