### PR TITLE
Fix non generic root generic references

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+* Fix non generic root generic references (https://github.com/juhaku/utoipa/pull/1095)
 * Fix option wrapped tailing query parameters (https://github.com/juhaku/utoipa/pull/1089)
 * Fix doc comment trimming to keep relative indentation. (https://github.com/juhaku/utoipa/pull/1082)
 * Fix generic aliases (https://github.com/juhaku/utoipa/pull/1083)

--- a/utoipa-gen/tests/schema_generics.rs
+++ b/utoipa-gen/tests/schema_generics.rs
@@ -97,6 +97,39 @@ fn generic_schema_full_api() {
 }
 
 #[test]
+fn schema_with_non_generic_root() {
+    #![allow(unused)]
+
+    #[derive(ToSchema)]
+    struct Foo<T> {
+        bar: Bar<T>,
+    }
+
+    #[derive(ToSchema)]
+    struct Bar<T> {
+        value: T,
+    }
+
+    #[derive(ToSchema)]
+    struct Top {
+        foo1: Foo<String>,
+        foo2: Foo<i32>,
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(components(schemas(Top)))]
+    struct ApiDoc;
+    let mut api = ApiDoc::openapi();
+    api.info = Info::new("title", "version");
+
+    let actual = api.to_pretty_json().expect("schema is JSON serializable");
+    println!("{actual}");
+    let expected = include_str!("./testdata/schema_non_generic_root_generic_references");
+
+    assert_eq!(actual.trim(), expected.trim())
+}
+
+#[test]
 #[ignore = "For debugging only"]
 fn schema_macro_run() {
     #![allow(unused)]

--- a/utoipa-gen/tests/testdata/schema_generics_openapi
+++ b/utoipa-gen/tests/testdata/schema_generics_openapi
@@ -125,7 +125,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/path.to.PageList_Person_String_Type_i32"
+                  "$ref": "#/components/schemas/path.to.PageList_Person_String_path.MyType_i32"
                 }
               }
             }
@@ -136,7 +136,7 @@
   },
   "components": {
     "schemas": {
-      "Person_String_Type_i32": {
+      "Person_String_path.MyType_i32": {
         "type": "object",
         "required": [
           "id",
@@ -200,7 +200,7 @@
           }
         ]
       },
-      "path.to.PageList_Person_String_Type_i32": {
+      "path.to.PageList_Person_String_path.MyType_i32": {
         "type": "object",
         "required": [
           "total",

--- a/utoipa-gen/tests/testdata/schema_non_generic_root_generic_references
+++ b/utoipa-gen/tests/testdata/schema_non_generic_root_generic_references
@@ -1,0 +1,71 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "title",
+    "version": "version"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Bar_String": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/String"
+          }
+        }
+      },
+      "Bar_i32": {
+        "type": "object",
+        "required": [
+          "value"
+        ],
+        "properties": {
+          "value": {
+            "$ref": "#/components/schemas/i32"
+          }
+        }
+      },
+      "Foo_String": {
+        "type": "object",
+        "required": [
+          "bar"
+        ],
+        "properties": {
+          "bar": {
+            "$ref": "#/components/schemas/Bar_String"
+          }
+        }
+      },
+      "Foo_i32": {
+        "type": "object",
+        "required": [
+          "bar"
+        ],
+        "properties": {
+          "bar": {
+            "$ref": "#/components/schemas/Bar_i32"
+          }
+        }
+      },
+      "Top": {
+        "type": "object",
+        "required": [
+          "foo1",
+          "foo2"
+        ],
+        "properties": {
+          "foo1": {
+            "$ref": "#/components/schemas/Foo_String"
+          },
+          "foo2": {
+            "$ref": "#/components/schemas/Foo_i32"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Prior to this commit the type having generic reference resulted incorrect schema due to wrong reference names of generic references. This commit will fix this by correctly resolving names for generic schema references. This is done by relying on `ToSchema::name` implementation instead of directly Ident of the type when composing children name.

Following example now works where the deeply nested generic references will all get correct name resulting correct OpenAPI schema.
```rust
 #[derive(ToSchema)]
 struct Foo<T> {
     bar: Bar<T>,
 }

 #[derive(ToSchema)]
 struct Bar<T> {
     value: T,
 }

 #[derive(ToSchema)]
 struct Top {
     foo1: Foo<String>,
     foo2: Foo<i32>,
 }

 #[derive(OpenApi)]
 #[openapi(components(schemas(Top)))]
 struct ApiDoc;
```

Fixes #1092