### PR TITLE
Fix generic references

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+* Fix generic references (https://github.com/juhaku/utoipa/pull/1097)
 * Fix non generic root generic references (https://github.com/juhaku/utoipa/pull/1095)
 * Fix option wrapped tailing query parameters (https://github.com/juhaku/utoipa/pull/1089)
 * Fix doc comment trimming to keep relative indentation. (https://github.com/juhaku/utoipa/pull/1082)

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1131,8 +1131,14 @@ impl ComponentSchema {
                         let index = container.generics.get_generic_type_param_index(type_tree);
                         // only set schema references for concrete non generic types
                         if index.is_none() {
-                            object_schema_reference.tokens =
-                                quote! {<#type_path as utoipa::PartialSchema>::schema() };
+                            let reference_tokens = if let Some(children) = &type_tree.children {
+                                let composed_generics =
+                                    Self::compose_generics(children).collect::<Array<_>>();
+                                quote! { <#type_path as utoipa::__dev::ComposeSchema>::compose(#composed_generics.to_vec()) }
+                            } else {
+                                quote! { <#type_path as utoipa::PartialSchema>::schema() }
+                            };
+                            object_schema_reference.tokens = reference_tokens;
                             object_schema_reference.references = quote! { <#type_path as utoipa::__dev::SchemaReferences>::schemas(schemas) };
                         }
                         let composed_or_ref = |item_tokens: TokenStream| -> TokenStream {

--- a/utoipa-gen/tests/testdata/openapi_schemas_resolve_inner_schema_references
+++ b/utoipa-gen/tests/testdata/openapi_schemas_resolve_inner_schema_references
@@ -57,7 +57,33 @@
         {
           "properties": {
             "One": {
-              "$ref": "#/components/schemas/Yeah"
+              "properties": {
+                "accounts": {
+                  "items": {
+                    "allOf": [
+                      {
+                        "type": "null"
+                      },
+                      {
+                        "$ref": "#/components/schemas/Account"
+                      }
+                    ]
+                  },
+                  "type": "array"
+                },
+                "foo_bar": {
+                  "$ref": "#/components/schemas/Foobar"
+                },
+                "name": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "foo_bar",
+                "accounts"
+              ],
+              "type": "object"
             }
           },
           "required": [
@@ -69,7 +95,7 @@
           "properties": {
             "Many": {
               "items": {
-                "$ref": "#/components/schemas/Yeah"
+                "type": "object"
               },
               "type": "array"
             }

--- a/utoipa-gen/tests/testdata/schema_non_generic_root_generic_references
+++ b/utoipa-gen/tests/testdata/schema_non_generic_root_generic_references
@@ -14,7 +14,7 @@
         ],
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/String"
+            "type": "string"
           }
         }
       },
@@ -25,7 +25,8 @@
         ],
         "properties": {
           "value": {
-            "$ref": "#/components/schemas/i32"
+            "type": "integer",
+            "format": "int32"
           }
         }
       },


### PR DESCRIPTION
This PR is follow up for #1095 which fixed the generic references name resolving. This commit will fix the generic references inner type resolving. Prior this commit the generic reference always set everything as `$ref` even in case of primitive type. Nonetheless now the correct type will be used instead.

Fixes #1092