### PR TITLE
Fix `title` on unnamed struct and references

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+* Fix `title` on unnamed struct and references (https://github.com/juhaku/utoipa/pull/1101)
 * Fix generic references (https://github.com/juhaku/utoipa/pull/1097)
 * Fix non generic root generic references (https://github.com/juhaku/utoipa/pull/1095)
 * Fix option wrapped tailing query parameters (https://github.com/juhaku/utoipa/pull/1089)

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5707,3 +5707,47 @@ fn derive_schema_with_ignored_field() {
         })
     )
 }
+
+#[test]
+fn derive_schema_unnamed_title() {
+    #![allow(unused)]
+
+    let value = api_doc! {
+        #[schema(title = "This is vec title")]
+        struct SchemaIgnoredField (Vec<String>);
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "title": "This is vec title",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        })
+    );
+
+    #[derive(ToSchema)]
+    enum UnnamedEnum {
+        One,
+        Two,
+    }
+
+    let enum_value = api_doc! {
+        #[schema(title = "This is enum ref title")]
+        struct SchemaIgnoredField (UnnamedEnum);
+    };
+
+    assert_json_eq!(
+        enum_value,
+        json!({
+            "title": "This is enum ref title",
+            "allOf": [
+                {
+                    "$ref": "#/components/schemas/UnnamedEnum"
+                }
+            ],
+        })
+    )
+}


### PR DESCRIPTION
This commit fixes `title` attribute on unnamed structs having `Vec<T>` content and fields having `$ref` type.

Fields with `$ref` type to another having `title` attribute will result `allOf` type containing the `$ref` as item and `title` will be added to the `allOf`.

Fixes #850