### PR TITLE
Fix description on `inline` field

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+* Fix description on `inline` field (https://github.com/juhaku/utoipa/pull/1102)
 * Fix `title` on unnamed struct and references (https://github.com/juhaku/utoipa/pull/1101)
 * Fix generic references (https://github.com/juhaku/utoipa/pull/1097)
 * Fix non generic root generic references (https://github.com/juhaku/utoipa/pull/1095)

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1113,13 +1113,19 @@ impl ComponentSchema {
                         object_schema_reference.tokens = items_tokens.clone();
                         object_schema_reference.references = quote! { <#type_path as utoipa::__dev::SchemaReferences>::schemas(schemas) };
 
-                        let schema = if default.is_some() || nullable || title.is_some() {
+                        let description_tokens = description_stream.to_token_stream();
+                        let schema = if default.is_some()
+                            || nullable
+                            || title.is_some()
+                            || !description_tokens.is_empty()
+                        {
                             quote_spanned! {type_path.span()=>
                                 utoipa::openapi::schema::AllOfBuilder::new()
                                     #nullable_item
                                     .item(#items_tokens)
                                 #title_tokens
                                 #default_tokens
+                                #description_stream
                             }
                         } else {
                             items_tokens

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5751,3 +5751,63 @@ fn derive_schema_unnamed_title() {
         })
     )
 }
+
+#[test]
+fn derive_struct_inline_with_description() {
+    #[derive(utoipa::ToSchema)]
+    #[allow(unused)]
+    struct Foo {
+        name: &'static str,
+    }
+
+    let value = api_doc! {
+        struct FooInlined {
+            /// This is description
+            #[schema(inline)]
+            with_description: Foo,
+
+            #[schema(inline)]
+            no_description_inline: Foo,
+        }
+    };
+
+    assert_json_eq!(
+        &value,
+        json!({
+            "properties": {
+                "no_description_inline": {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        },
+                    },
+                    "required": [
+                        "name"
+                    ],
+                    "type": "object"
+                },
+                "with_description": {
+                    "description": "This is description",
+                    "allOf": [
+                        {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                },
+                            },
+                            "required": [
+                                "name"
+                            ],
+                            "type": "object"
+                        }
+                    ]
+                },
+            },
+            "required": [
+                "with_description",
+                "no_description_inline",
+            ],
+            "type": "object"
+        })
+    );
+}


### PR DESCRIPTION
This commit fixes the missing description on inlined field items by making field `allOf` with `description` in presence of description.

Fixes #797