### PR TITLE
Adds support for `prefixItems` on `Array`

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -74,6 +74,7 @@
 
 ### Breaking
 
+* Adds support for `prefixItems` on `Array` (https://github.com/juhaku/utoipa/pull/1103)
 * Auto collect tuple responses schema references (https://github.com/juhaku/utoipa/pull/1071)
 * Implement automatic schema collection for requests (https://github.com/juhaku/utoipa/pull/1066)
 * Refactor enums processing (https://github.com/juhaku/utoipa/pull/1059)

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -4920,28 +4920,34 @@ fn derive_tuple_named_struct_field() {
             info: (String, i64, bool, Person)
         }
     };
+
     assert_json_eq!(
         value,
         json!({
             "properties": {
                 "info": {
-                    "items": {
-                        "allOf": [
-                            {
-                                "type": "string"
+                    "prefixItems": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer",
+                            "format": "int64",
+                        },
+                        {
+                            "type": "boolean",
+                        },
+                        {
+                            "properties": {
+                                "name": {
+                                    "type": "string"
+                                }
                             },
-                            {
-                                "type": "integer",
-                                "format": "int64",
-                            },
-                            {
-                                "type": "boolean",
-                            },
-                            {
-                                "$ref": "#/components/schemas/Person"
-                            }
-                        ]
-                    },
+                            "required": ["name"],
+                            "type": "object"
+                        }
+                    ],
+                    "items": false,
                     "type": "array"
                 }
             },
@@ -4966,17 +4972,16 @@ fn derive_nullable_tuple() {
         json!({
             "properties": {
                 "info": {
-                    "items": {
-                        "allOf": [
-                            {
-                                "type": "string"
-                            },
-                            {
-                                "type": "integer",
-                                "format": "int64",
-                            },
-                        ]
-                    },
+                    "prefixItems": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "integer",
+                            "format": "int64",
+                        },
+                    ],
+                    "items": false,
                     "type": ["array", "null"],
                     "deprecated": true,
                     "description": "This is description",

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -54,6 +54,7 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Breaking
 
+* Adds support for `prefixItems` on `Array` (https://github.com/juhaku/utoipa/pull/1103)
 * Implement automatic schema collection for requests (https://github.com/juhaku/utoipa/pull/1066)
 * Refactor enums processing (https://github.com/juhaku/utoipa/pull/1059)
 * Feature openapi 31 (https://github.com/juhaku/utoipa/pull/981)


### PR DESCRIPTION
This PR adds support for `prefixItems` as defined in JSON schema specification https://json-schema.org/understanding-json-schema/reference/array#tupleValidation. The `prefixItems` are used to correctly represent Rust tuples as tuple values in OpenAPI. This will remove the old `allOf` behavior known from OpenAPI 3.0 which fails to correctly represent a tuple. Prefix items are conforming OpenAPI 3.1 and is coming from JSON Schema.

Add new type `ArrayItems` what represent [`Array::items`] supported values.

 ### Breaking

 This commit removes `allOf` tuple behavior, replacing with with all new
 `prefixItems` while setting `items` to false.

Closes #901