### PR TITLE
Add missing `extensions` for OpenAPI types

### DIFF
--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -7,6 +7,7 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Added
 
+* Add missing `extensions` for OpenAPI types (https://github.com/juhaku/utoipa/pull/1104)
 * Add a default impl of ToSchema::name() (https://github.com/juhaku/utoipa/pull/1096)
 * Add support for `property_names` for object (https://github.com/juhaku/utoipa/pull/1084)
 * Add changelogs for crates (https://github.com/juhaku/utoipa/pull/1075)

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -89,7 +89,6 @@ builder! {
         /// Available paths and operations for the API.
         ///
         /// See more details at <https://spec.openapis.org/oas/latest.html#paths-object>.
-        #[serde(flatten)]
         pub paths: Paths,
 
         /// Holds various reusable schemas for the OpenAPI document.
@@ -208,6 +207,11 @@ impl OpenApi {
                 }
             }
             self.paths.paths.extend(other.paths.paths);
+
+            if let Some(other_paths_extensions) = other.paths.extensions {
+                let paths_extensions = self.paths.extensions.get_or_insert(Extensions::default());
+                paths_extensions.merge(other_paths_extensions);
+            }
         };
 
         if let Some(other_components) = &mut other.components {
@@ -852,6 +856,7 @@ mod tests {
                             .response("200", Response::new("Get user success 1")),
                     ),
                 )
+                .extensions(Some(Extensions::from_iter([("x-v1-api", true)])))
                 .build(),
         );
 
@@ -891,6 +896,7 @@ mod tests {
                                 .response("200", Response::new("Post user success 2")),
                         ),
                     )
+                    .extensions(Some(Extensions::from_iter([("x-random", "Value")])))
                     .build(),
             )
             .components(Some(
@@ -950,7 +956,9 @@ mod tests {
                           }
                         }
                       }
-                    }
+                    },
+                    "x-random": "Value",
+                    "x-v1-api": true,
                   },
                   "components": {
                     "schemas": {

--- a/utoipa/src/openapi/content.rs
+++ b/utoipa/src/openapi/content.rs
@@ -7,6 +7,7 @@ use serde_json::Value;
 
 use super::builder;
 use super::example::Example;
+use super::extensions::Extensions;
 use super::{encoding::Encoding, set_value, RefOr, Schema};
 
 builder! {
@@ -14,6 +15,10 @@ builder! {
 
 
     /// Content holds request body content or response content.
+    ///
+    /// [`Content`] implements OpenAPI spec [Media Type Object][media_type]
+    ///
+    /// [media_type]: <https://spec.openapis.org/oas/latest.html#media-type-object>
     #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     #[non_exhaustive]
@@ -43,6 +48,10 @@ builder! {
         /// multipart or `application/x-www-form-urlencoded`.
         #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
         pub encoding: BTreeMap<String, Encoding>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -106,5 +115,10 @@ impl ContentBuilder {
     ) -> Self {
         self.encoding.insert(property_name.into(), encoding.into());
         self
+    }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
     }
 }

--- a/utoipa/src/openapi/encoding.rs
+++ b/utoipa/src/openapi/encoding.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use super::extensions::Extensions;
 use super::{builder, path::ParameterStyle, set_value, Header};
 
 builder! {
@@ -51,6 +52,10 @@ builder! {
         /// `application/x-www-form-urlencoded`.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub allow_reserved: Option<bool>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -80,5 +85,10 @@ impl EncodingBuilder {
     /// Set the allow reserved. See [`Encoding::allow_reserved`].
     pub fn allow_reserved(mut self, allow_reserved: Option<bool>) -> Self {
         set_value!(self allow_reserved allow_reserved)
+    }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
     }
 }

--- a/utoipa/src/openapi/extensions.rs
+++ b/utoipa/src/openapi/extensions.rs
@@ -26,6 +26,13 @@ builder! {
     }
 }
 
+impl Extensions {
+    /// Merge other [`Extensions`] into _`self`_.
+    pub fn merge(&mut self, other: Extensions) {
+        self.extensions.extend(other.extensions);
+    }
+}
+
 impl Deref for Extensions {
     type Target = HashMap<String, serde_json::Value>;
 

--- a/utoipa/src/openapi/external_docs.rs
+++ b/utoipa/src/openapi/external_docs.rs
@@ -3,6 +3,7 @@
 //! [external_docs]: https://spec.openapis.org/oas/latest.html#xml-object
 use serde::{Deserialize, Serialize};
 
+use super::extensions::Extensions;
 use super::{builder, set_value};
 
 builder! {
@@ -18,6 +19,10 @@ builder! {
         pub url: String,
         /// Additional description supporting markdown syntax of the external documentation.
         pub description: Option<String>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -49,5 +54,10 @@ impl ExternalDocsBuilder {
     /// Add additional description of external documentation.
     pub fn description<S: Into<String>>(mut self, description: Option<S>) -> Self {
         set_value!(self description description.map(|description| description.into()))
+    }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
     }
 }

--- a/utoipa/src/openapi/info.rs
+++ b/utoipa/src/openapi/info.rs
@@ -158,6 +158,10 @@ builder! {
         /// Email of the contact person or the organization of the API.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub email: Option<String>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -183,6 +187,11 @@ impl ContactBuilder {
     pub fn email<S: Into<String>>(mut self, email: Option<S>) -> Self {
         set_value!(self email email.map(|email| email.into()))
     }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
+    }
 }
 
 builder! {
@@ -202,6 +211,10 @@ builder! {
         /// Optional url pointing to the license.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub url: Option<String>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -226,6 +239,11 @@ impl LicenseBuilder {
     /// Add url pointing to the license used in API.
     pub fn url<S: Into<String>>(mut self, url: Option<S>) -> Self {
         set_value!(self url url.map(|url| url.into()))
+    }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
     }
 }
 

--- a/utoipa/src/openapi/link.rs
+++ b/utoipa/src/openapi/link.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use super::extensions::Extensions;
 use super::{builder, Server};
 
 builder! {
@@ -67,6 +68,10 @@ builder! {
         /// [server]: ../server/struct.Server.html
         #[serde(skip_serializing_if = "Option::is_none")]
         pub server: Option<Server>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -125,6 +130,13 @@ impl LinkBuilder {
     /// [server]: ../server/struct.Server.html
     pub fn server<S: Into<Server>>(mut self, server: Option<S>) -> Self {
         self.server = server.map(|server| server.into());
+
+        self
+    }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        self.extensions = extensions;
 
         self
     }

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -34,6 +34,7 @@ builder! {
     pub struct Paths {
         /// Map of relative paths with [`PathItem`]s holding [`Operation`]s matching
         /// api endpoints.
+        #[serde(flatten)]
         pub paths: PathsMap<String, PathItem>,
 
         /// Optional extensions "x-something".

--- a/utoipa/src/openapi/request_body.rs
+++ b/utoipa/src/openapi/request_body.rs
@@ -5,6 +5,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+use super::extensions::Extensions;
 use super::{builder, set_value, Content, Required};
 
 builder! {
@@ -28,6 +29,10 @@ builder! {
         /// Determines whether request body is required in the request or not.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub required: Option<Required>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -54,6 +59,11 @@ impl RequestBodyBuilder {
         self.content.insert(content_type.into(), content);
 
         self
+    }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
     }
 }
 

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -29,6 +29,10 @@ builder! {
         /// Map containing status code as a key with represented response as a value.
         #[serde(flatten)]
         pub responses: BTreeMap<String, RefOr<Response>>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -72,6 +76,11 @@ impl ResponsesBuilder {
         self.responses.extend(I::responses());
         self
     }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
+    }
 }
 
 impl From<Responses> for BTreeMap<String, RefOr<Response>> {
@@ -91,6 +100,7 @@ where
                 iter.into_iter()
                     .map(|(code, response)| (code.into(), response.into())),
             ),
+            ..Default::default()
         }
     }
 }

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -78,6 +78,10 @@ builder! {
         /// [security_scheme]: https://spec.openapis.org/oas/latest.html#security-scheme-object
         #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
         pub security_schemes: BTreeMap<String, SecurityScheme>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -254,6 +258,11 @@ impl ComponentsBuilder {
 
         self
     }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
+    }
 }
 
 /// Is super type for [OpenAPI Schema Object][schemas]. Schema is reusable resource what can be
@@ -312,6 +321,10 @@ pub struct Discriminator {
     /// validation.
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub mapping: BTreeMap<String, String>,
+
+    /// Optional extensions "x-something".
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub extensions: Option<Extensions>,
 }
 
 impl Discriminator {
@@ -328,6 +341,7 @@ impl Discriminator {
         Self {
             property_name: property_name.into(),
             mapping: BTreeMap::new(),
+            ..Default::default()
         }
     }
 
@@ -363,6 +377,7 @@ impl Discriminator {
                     .into_iter()
                     .map(|(key, val)| (key.into(), val.into())),
             ),
+            ..Default::default()
         }
     }
 }
@@ -2373,7 +2388,13 @@ mod tests {
                 "200",
                 ResponseBuilder::new().description("Okay").build(),
             )])
-            .security_scheme("TLS", SecurityScheme::MutualTls { description: None })
+            .security_scheme(
+                "TLS",
+                SecurityScheme::MutualTls {
+                    description: None,
+                    extensions: None,
+                },
+            )
             .build();
 
         let serialized_components = serde_json::to_string(&components).unwrap();

--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -185,6 +185,9 @@ pub enum SecurityScheme {
         #[allow(missing_docs)]
         #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        extensions: Option<Extensions>,
     },
 }
 
@@ -212,6 +215,10 @@ pub struct ApiKeyValue {
     /// Description of the the [`ApiKey`] [`SecurityScheme`]. Supports markdown syntax.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Optional extensions "x-something".
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub extensions: Option<Extensions>,
 }
 
 impl ApiKeyValue {
@@ -228,6 +235,7 @@ impl ApiKeyValue {
         Self {
             name: name.into(),
             description: None,
+            extensions: Default::default(),
         }
     }
 
@@ -244,6 +252,7 @@ impl ApiKeyValue {
         Self {
             name: name.into(),
             description: Some(description.into()),
+            extensions: Default::default(),
         }
     }
 }
@@ -269,6 +278,10 @@ builder! {
         /// Optional description of [`Http`] [`SecurityScheme`] supporting markdown syntax.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub description: Option<String>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -289,6 +302,7 @@ impl Http {
             scheme,
             bearer_format: None,
             description: None,
+            extensions: Default::default(),
         }
     }
 }
@@ -375,6 +389,10 @@ pub struct OpenIdConnect {
     /// Description of [`OpenIdConnect`] [`SecurityScheme`] supporting markdown syntax.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+
+    /// Optional extensions "x-something".
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub extensions: Option<Extensions>,
 }
 
 impl OpenIdConnect {
@@ -390,6 +408,7 @@ impl OpenIdConnect {
         Self {
             open_id_connect_url: open_id_connect_url.into(),
             description: None,
+            extensions: Default::default(),
         }
     }
 
@@ -406,6 +425,7 @@ impl OpenIdConnect {
         Self {
             open_id_connect_url: open_id_connect_url.into(),
             description: Some(description.into()),
+            extensions: Default::default(),
         }
     }
 }
@@ -559,6 +579,10 @@ pub struct Implicit {
     /// Scopes required by the flow.
     #[serde(flatten)]
     pub scopes: Scopes,
+
+    /// Optional extensions "x-something".
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub extensions: Option<Extensions>,
 }
 
 impl Implicit {
@@ -594,6 +618,7 @@ impl Implicit {
             authorization_url: authorization_url.into(),
             refresh_url: None,
             scopes,
+            extensions: Default::default(),
         }
     }
 
@@ -622,6 +647,7 @@ impl Implicit {
             authorization_url: authorization_url.into(),
             refresh_url: Some(refresh_url.into()),
             scopes,
+            extensions: Default::default(),
         }
     }
 }
@@ -644,6 +670,10 @@ pub struct AuthorizationCode {
     /// Scopes required by the flow.
     #[serde(flatten)]
     pub scopes: Scopes,
+
+    /// Optional extensions "x-something".
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub extensions: Option<Extensions>,
 }
 
 impl AuthorizationCode {
@@ -686,6 +716,7 @@ impl AuthorizationCode {
             token_url: token_url.into(),
             refresh_url: None,
             scopes,
+            extensions: Default::default(),
         }
     }
 
@@ -717,6 +748,7 @@ impl AuthorizationCode {
             token_url: token_url.into(),
             refresh_url: Some(refresh_url.into()),
             scopes,
+            extensions: Default::default(),
         }
     }
 }
@@ -737,6 +769,10 @@ pub struct Password {
     /// Scopes required by the flow.
     #[serde(flatten)]
     pub scopes: Scopes,
+
+    /// Optional extensions "x-something".
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub extensions: Option<Extensions>,
 }
 
 impl Password {
@@ -772,6 +808,7 @@ impl Password {
             token_url: token_url.into(),
             refresh_url: None,
             scopes,
+            extensions: Default::default(),
         }
     }
 
@@ -799,6 +836,7 @@ impl Password {
             token_url: token_url.into(),
             refresh_url: Some(refresh_url.into()),
             scopes,
+            extensions: Default::default(),
         }
     }
 }
@@ -819,6 +857,10 @@ pub struct ClientCredentials {
     /// Scopes required by the flow.
     #[serde(flatten)]
     pub scopes: Scopes,
+
+    /// Optional extensions "x-something".
+    #[serde(skip_serializing_if = "Option::is_none", flatten)]
+    pub extensions: Option<Extensions>,
 }
 
 impl ClientCredentials {
@@ -854,6 +896,7 @@ impl ClientCredentials {
             token_url: token_url.into(),
             refresh_url: None,
             scopes,
+            extensions: Default::default(),
         }
     }
 
@@ -881,6 +924,7 @@ impl ClientCredentials {
             token_url: token_url.into(),
             refresh_url: Some(refresh_url.into()),
             scopes,
+            extensions: Default::default(),
         }
     }
 }
@@ -1266,7 +1310,8 @@ mod tests {
     test_fn! {
         security_schema_correct_mutual_tls:
         SecurityScheme::MutualTls {
-            description: Some(String::from("authorization is performed with client side certificate"))
+            description: Some(String::from("authorization is performed with client side certificate")),
+            extensions: None,
         };
         r###"{
   "type": "mutualTLS",

--- a/utoipa/src/openapi/server.rs
+++ b/utoipa/src/openapi/server.rs
@@ -45,6 +45,7 @@ use std::{collections::BTreeMap, iter};
 
 use serde::{Deserialize, Serialize};
 
+use super::extensions::Extensions;
 use super::{builder, set_value};
 
 builder! {
@@ -75,6 +76,10 @@ builder! {
         /// Optional map of variable name and its substitution value used in [`Server::url`].
         #[serde(skip_serializing_if = "Option::is_none")]
         pub variables: Option<BTreeMap<String, ServerVariable>>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -144,6 +149,11 @@ impl ServerBuilder {
 
         self
     }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
+    }
 }
 
 builder! {
@@ -158,16 +168,20 @@ builder! {
     pub struct ServerVariable {
         /// Default value used to substitute parameter if no other value is being provided.
         #[serde(rename = "default")]
-        default_value: String,
+        pub default_value: String,
 
         /// Optional description describing the variable of substitution. Markdown syntax is supported.
         #[serde(skip_serializing_if = "Option::is_none")]
-        description: Option<String>,
+        pub description: Option<String>,
 
         /// Enum values can be used to limit possible options for substitution. If enum values is used
         /// the [`ServerVariable::default_value`] must contain one of the enum values.
         #[serde(rename = "enum", skip_serializing_if = "Option::is_none")]
-        enum_values: Option<Vec<String>>,
+        pub enum_values: Option<Vec<String>>,
+
+        /// Optional extensions "x-something".
+        #[serde(skip_serializing_if = "Option::is_none", flatten)]
+        pub extensions: Option<Extensions>,
     }
 }
 
@@ -189,6 +203,11 @@ impl ServerVariableBuilder {
     ) -> Self {
         set_value!(self enum_values enum_values
             .map(|enum_values| enum_values.into_iter().map(|value| value.into()).collect()))
+    }
+
+    /// Add openapi extensions (x-something) of the API.
+    pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
+        set_value!(self extensions extensions)
     }
 }
 


### PR DESCRIPTION
This commit adds `extensions` field for OpenAPI types currently missing the field. This allows defining the `x-*` extension attributes on types supporting it.

Closes #643