### PR TITLE
Chore enhance generic schema collection

### DIFF
--- a/utoipa-config/CHANGELOG.md
+++ b/utoipa-config/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+* Chore enhance generic schema collection (https://github.com/juhaku/utoipa/pull/1116)
 * Add test for aliases on enum variant values
 * Fixed broken tests at `utoipa-config`
 * Remove commit commit id from changelogs (https://github.com/juhaku/utoipa/pull/1077)

--- a/utoipa-config/README.md
+++ b/utoipa-config/README.md
@@ -5,7 +5,14 @@
 [![docs.rs](https://img.shields.io/static/v1?label=docs.rs&message=utoipa-config&color=blue&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K)](https://docs.rs/utoipa-config/latest/)
 ![rustc](https://img.shields.io/static/v1?label=rustc&message=1.75&color=orange&logo=rust)
 
-This crate provides global configuration capabilities for `utoipa`. Currently only supports providing Rust type aliases.
+This crate provides global configuration capabilities for `utoipa`.
+
+## Config options
+
+* Define rust type aliases for `utoipa` with `.alias_for(...)` method.
+* Define schema collect mode for `utoipa` with `.schema_collect(...)` method.
+  * `SchemaCollect:All` will collect all schemas from usages including inlined with `inline(T)`
+  * `SchemaCollect::NonInlined` will only collect non inlined schemas from usages.
 
 ## Install
 
@@ -15,9 +22,6 @@ Add dependency declaration to `Cargo.toml`.
 [build-dependencies]
 utoipa_config = "0.1"
 ```
-
-> [!NOTE]
-> Not released yet.
 
 ## Examples
 
@@ -34,7 +38,7 @@ fn main() {
 }
 ```
 
-See full [example for utoipa-config](../examples/config-test-crate/).
+See full [example for utoipa-config](../examples/utoipa-config-test/).
 
 ## License
 

--- a/utoipa-config/config-test-crate/tests/config.rs
+++ b/utoipa-config/config-test-crate/tests/config.rs
@@ -1,15 +1,14 @@
 use std::borrow::Cow;
 
 use utoipa::{OpenApi, ToSchema};
-use utoipa_config::Config;
+use utoipa_config::{Config, SchemaCollect};
 
 #[test]
 fn test_create_config_with_aliases() {
-    Config::new()
-        .alias_for("i32", "Option<String>")
-        .write_to_file();
+    let config: Config<'_> = Config::new().alias_for("i32", "Option<String>");
+    let json = serde_json::to_string(&config).expect("config is json serializable");
 
-    let config = Config::read_from_file();
+    let config: Config = serde_json::from_str(&json).expect("config is json deserializable");
 
     assert!(!config.aliases.is_empty());
     assert!(config.aliases.contains_key("i32"));
@@ -17,6 +16,16 @@ fn test_create_config_with_aliases() {
         config.aliases.get("i32"),
         Some(&Cow::Borrowed("Option<String>"))
     );
+}
+
+#[test]
+fn test_config_with_collect_all() {
+    let config: Config<'_> = Config::new().schema_collect(utoipa_config::SchemaCollect::All);
+    let json = serde_json::to_string(&config).expect("config is json serializable");
+
+    let config: Config = serde_json::from_str(&json).expect("config is json deserializable");
+
+    assert!(matches!(config.schema_collect, SchemaCollect::All));
 }
 
 #[test]

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### Changed
 
+* Chore enhance generic schema collection (https://github.com/juhaku/utoipa/pull/1116)
 * Enhance file uploads (https://github.com/juhaku/utoipa/pull/1113)
 * Move `schemas` into `ToSchema` for schemas (https://github.com/juhaku/utoipa/pull/1112)
 * Refactor `KnownFormat`

--- a/utoipa-gen/src/path/media_type.rs
+++ b/utoipa-gen/src/path/media_type.rs
@@ -202,6 +202,16 @@ impl Schema<'_> {
             Self::Ext(ext) => ext.get_component_schema(),
         }
     }
+
+    pub fn is_inline(&self) -> bool {
+        match self {
+            Self::Default(def) => match def {
+                DefaultSchema::TypePath(parsed) => parsed.is_inline,
+                _ => false,
+            },
+            Self::Ext(_) => false,
+        }
+    }
 }
 
 impl ToTokensDiagnostics for Schema<'_> {

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -89,11 +89,18 @@ impl<'r> RequestBodyAttr<'r> {
 
     pub fn get_component_schemas(
         &self,
-    ) -> Result<impl Iterator<Item = ComponentSchema>, Diagnostics> {
+    ) -> Result<impl Iterator<Item = (bool, ComponentSchema)>, Diagnostics> {
         Ok(self
             .content
             .iter()
-            .map(|media_type| media_type.schema.get_component_schema())
+            .map(
+                |media_type| match media_type.schema.get_component_schema() {
+                    Ok(component_schema) => {
+                        Ok(Some(media_type.schema.is_inline()).zip(component_schema))
+                    }
+                    Err(error) => Err(error),
+                },
+            )
             .collect::<Result<Vec<_>, Diagnostics>>()?
             .into_iter()
             .flatten())

--- a/utoipa-gen/tests/testdata/schema_generic_collect_non_inlined_schema
+++ b/utoipa-gen/tests/testdata/schema_generic_collect_non_inlined_schema
@@ -1,0 +1,253 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "title",
+    "version": "version"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Account": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "FooStruct_BTreeMap_String_Person_Value": {
+        "type": "object",
+        "required": [
+          "foo"
+        ],
+        "properties": {
+          "foo": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "required": [
+                "name",
+                "account",
+                "t"
+              ],
+              "properties": {
+                "account": {
+                  "$ref": "#/components/schemas/Account"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "t": {
+                  "type": "string"
+                }
+              }
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "FooStruct_BTreeMap_Ty_Ky_Person_Value": {
+        "type": "object",
+        "required": [
+          "foo"
+        ],
+        "properties": {
+          "foo": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "required": [
+                "name",
+                "account",
+                "t"
+              ],
+              "properties": {
+                "account": {
+                  "$ref": "#/components/schemas/Account"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "t": {
+                  "type": "object",
+                  "required": [
+                    "t"
+                  ],
+                  "properties": {
+                    "t": {
+                      "type": "string",
+                      "enum": [
+                        "One",
+                        "Two"
+                      ]
+                    }
+                  }
+                }
+              }
+            },
+            "propertyNames": {
+              "type": "object",
+              "required": [
+                "t"
+              ],
+              "properties": {
+                "t": {
+                  "type": "object",
+                  "required": [
+                    "t"
+                  ],
+                  "properties": {
+                    "t": {
+                      "type": "string",
+                      "enum": [
+                        "One",
+                        "Two"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "FooStruct_HashMap_i32_Person_i64": {
+        "type": "object",
+        "required": [
+          "foo"
+        ],
+        "properties": {
+          "foo": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "required": [
+                "name",
+                "account",
+                "t"
+              ],
+              "properties": {
+                "account": {
+                  "$ref": "#/components/schemas/Account"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "t": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "propertyNames": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "FooStruct_HashSet_i32": {
+        "type": "object",
+        "required": [
+          "foo"
+        ],
+        "properties": {
+          "foo": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "uniqueItems": true
+          }
+        }
+      },
+      "FoosEnum": {
+        "oneOf": [
+          {
+            "type": "object",
+            "required": [
+              "LinkedList"
+            ],
+            "properties": {
+              "LinkedList": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Person_Value"
+                }
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "BTreeMap"
+            ],
+            "properties": {
+              "BTreeMap": {
+                "$ref": "#/components/schemas/FooStruct_BTreeMap_String_Person_Value"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "HashMap"
+            ],
+            "properties": {
+              "HashMap": {
+                "$ref": "#/components/schemas/FooStruct_HashMap_i32_Person_i64"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "HashSet"
+            ],
+            "properties": {
+              "HashSet": {
+                "$ref": "#/components/schemas/FooStruct_HashSet_i32"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
+              "Btre"
+            ],
+            "properties": {
+              "Btre": {
+                "$ref": "#/components/schemas/FooStruct_BTreeMap_Ty_Ky_Person_Value"
+              }
+            }
+          }
+        ]
+      },
+      "Person_Value": {
+        "type": "object",
+        "required": [
+          "name",
+          "account",
+          "t"
+        ],
+        "properties": {
+          "account": {
+            "$ref": "#/components/schemas/Account"
+          },
+          "name": {
+            "type": "string"
+          },
+          "t": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/utoipa-gen/tests/testdata/schema_generic_enum_variant_with_generic_type
+++ b/utoipa-gen/tests/testdata/schema_generic_enum_variant_with_generic_type
@@ -7,110 +7,6 @@
   "paths": {},
   "components": {
     "schemas": {
-      "FooStruct_BTreeMap_String_String": {
-        "type": "object",
-        "required": [
-          "foo"
-        ],
-        "properties": {
-          "foo": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "propertyNames": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "FooStruct_BTreeSet_i32": {
-        "type": "object",
-        "required": [
-          "foo"
-        ],
-        "properties": {
-          "foo": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "uniqueItems": true
-          }
-        }
-      },
-      "FooStruct_HashMap_i32_String": {
-        "type": "object",
-        "required": [
-          "foo"
-        ],
-        "properties": {
-          "foo": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "string"
-            },
-            "propertyNames": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        }
-      },
-      "FooStruct_HashSet_i32": {
-        "type": "object",
-        "required": [
-          "foo"
-        ],
-        "properties": {
-          "foo": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int32"
-            },
-            "uniqueItems": true
-          }
-        }
-      },
-      "FooStruct_LinkedList_i32": {
-        "type": "object",
-        "required": [
-          "foo"
-        ],
-        "properties": {
-          "foo": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int32"
-            }
-          }
-        }
-      },
-      "FooStruct_Option_Vec_i32": {
-        "type": "object",
-        "required": [
-          "foo"
-        ],
-        "properties": {
-          "foo": {
-            "allOf": [
-              {
-                "type": "null"
-              },
-              {
-                "type": "array",
-                "items": {
-                  "type": "integer",
-                  "format": "int32"
-                }
-              }
-            ]
-          }
-        }
-      },
       "FooStruct_Option_i32": {
         "type": "object",
         "required": [
@@ -127,21 +23,6 @@
                 "format": "int32"
               }
             ]
-          }
-        }
-      },
-      "FooStruct_Vec_i32": {
-        "type": "object",
-        "required": [
-          "foo"
-        ],
-        "properties": {
-          "foo": {
-            "type": "array",
-            "items": {
-              "type": "integer",
-              "format": "int32"
-            }
           }
         }
       },

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -40,6 +40,7 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Changed
 
+* Chore enhance generic schema collection (https://github.com/juhaku/utoipa/pull/1116)
 * Enhance file uploads (https://github.com/juhaku/utoipa/pull/1113)
 * Move `schemas` into `ToSchema` for schemas (https://github.com/juhaku/utoipa/pull/1112)
 * List only `utoipa` related changes in `utoipa` CHANGELOG

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -520,30 +520,6 @@ impl ToSchema for TupleUnit {
     }
 }
 
-macro_rules! impl_partial_schema {
-    ( $ty:path ) => {
-        impl_partial_schema!( @impl_schema $ty );
-    };
-    ( & $ty:path ) => {
-        impl_partial_schema!( @impl_schema &$ty );
-    };
-    ( @impl_schema $( $tt:tt )* ) => {
-        #[cfg(feature = "macros")]
-        #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-        impl PartialSchema for $($tt)* {
-            fn schema() -> openapi::RefOr<openapi::schema::Schema> {
-                schema!( $($tt)* ).into()
-            }
-        }
-    };
-}
-
-macro_rules! impl_partial_schema_primitive {
-    ( $( $tt:path  ),* ) => {
-        $( impl_partial_schema!( $tt ); )*
-    };
-}
-
 macro_rules! impl_to_schema {
     ( $( $ty:ident ),* ) => {
         $(
@@ -561,90 +537,270 @@ impl_to_schema!(
     i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char
 );
 
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<T: ToSchema> ToSchema for Option<T> where Option<T>: PartialSchema {}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<T: ToSchema> ToSchema for Vec<T> where Vec<T>: PartialSchema {}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<T: ToSchema> ToSchema for std::collections::LinkedList<T> where
-    std::collections::LinkedList<T>: PartialSchema
-{
+impl ToSchema for &str {
+    fn name() -> Cow<'static, str> {
+        str::name()
+    }
 }
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<T: ToSchema> ToSchema for [T] where [T]: PartialSchema {}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'t, T: ToSchema> ToSchema for &'t [T] where &'t [T]: PartialSchema {}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'t, T: ToSchema> ToSchema for &'t mut [T] where &'t mut [T]: PartialSchema {}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<K: PartialSchema, T: ToSchema> ToSchema for std::collections::HashMap<K, T> where
-    std::collections::HashMap<K, T>: PartialSchema
+impl<T: ToSchema> ToSchema for Option<T>
+where
+    Option<T>: PartialSchema,
 {
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
 }
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<K: PartialSchema, T: ToSchema> ToSchema for std::collections::BTreeMap<K, T> where
-    std::collections::BTreeMap<K, T>: PartialSchema
+impl<T: ToSchema> ToSchema for Vec<T>
+where
+    Vec<T>: PartialSchema,
 {
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
 }
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<K: PartialSchema> ToSchema for std::collections::HashSet<K> where
-    std::collections::HashSet<K>: PartialSchema
+impl<T: ToSchema> ToSchema for std::collections::LinkedList<T>
+where
+    std::collections::LinkedList<T>: PartialSchema,
 {
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
 }
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<K: PartialSchema> ToSchema for std::collections::BTreeSet<K> where
-    std::collections::BTreeSet<K>: PartialSchema
+impl<T: ToSchema> ToSchema for [T]
+where
+    [T]: PartialSchema,
 {
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
+}
+
+#[cfg(feature = "macros")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+impl<'t, T: ToSchema> ToSchema for &'t [T]
+where
+    &'t [T]: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
+}
+
+#[cfg(feature = "macros")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+impl<'t, T: ToSchema> ToSchema for &'t mut [T]
+where
+    &'t mut [T]: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
+}
+
+#[cfg(feature = "macros")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+impl<K: ToSchema, T: ToSchema> ToSchema for std::collections::HashMap<K, T>
+where
+    std::collections::HashMap<K, T>: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        K::schemas(schemas);
+        T::schemas(schemas);
+    }
+}
+
+#[cfg(feature = "macros")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+impl<K: ToSchema, T: ToSchema> ToSchema for std::collections::BTreeMap<K, T>
+where
+    std::collections::BTreeMap<K, T>: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        K::schemas(schemas);
+        T::schemas(schemas);
+    }
+}
+
+#[cfg(feature = "macros")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+impl<K: ToSchema> ToSchema for std::collections::HashSet<K>
+where
+    std::collections::HashSet<K>: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        K::schemas(schemas);
+    }
+}
+
+#[cfg(feature = "macros")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+impl<K: ToSchema> ToSchema for std::collections::BTreeSet<K>
+where
+    std::collections::BTreeSet<K>: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        K::schemas(schemas);
+    }
 }
 
 #[cfg(all(feature = "macros", feature = "indexmap"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros", feature = "indexmap")))]
-impl<K: PartialSchema, T: ToSchema> ToSchema for indexmap::IndexMap<K, T> where
-    indexmap::IndexMap<K, T>: PartialSchema
+impl<K: ToSchema, T: ToSchema> ToSchema for indexmap::IndexMap<K, T>
+where
+    indexmap::IndexMap<K, T>: PartialSchema,
 {
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        K::schemas(schemas);
+        T::schemas(schemas);
+    }
 }
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<T: PartialSchema> ToSchema for std::boxed::Box<T> where std::boxed::Box<T>: PartialSchema {}
-
-#[cfg(feature = "macros")]
-#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<'a, T: PartialSchema + Clone> ToSchema for std::borrow::Cow<'a, T> where
-    std::borrow::Cow<'a, T>: PartialSchema
+impl<T: ToSchema> ToSchema for std::boxed::Box<T>
+where
+    std::boxed::Box<T>: PartialSchema,
 {
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
 }
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<T: PartialSchema> ToSchema for std::cell::RefCell<T> where std::cell::RefCell<T>: PartialSchema {}
+impl<'a, T: ToSchema + Clone> ToSchema for std::borrow::Cow<'a, T>
+where
+    std::borrow::Cow<'a, T>: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
+}
+
+#[cfg(feature = "macros")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+impl<T: ToSchema> ToSchema for std::cell::RefCell<T>
+where
+    std::cell::RefCell<T>: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
+}
 
 #[cfg(all(feature = "macros", feature = "rc_schema"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros", feature = "rc_schema")))]
-impl<T: PartialSchema> ToSchema for std::rc::Rc<T> where std::rc::Rc<T>: PartialSchema {}
+impl<T: ToSchema> ToSchema for std::rc::Rc<T>
+where
+    std::rc::Rc<T>: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
+}
 
 #[cfg(all(feature = "macros", feature = "rc_schema"))]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros", feature = "rc_schema")))]
-impl<T: PartialSchema> ToSchema for std::sync::Arc<T> where std::sync::Arc<T>: PartialSchema {}
+impl<T: ToSchema> ToSchema for std::sync::Arc<T>
+where
+    std::sync::Arc<T>: PartialSchema,
+{
+    fn schemas(
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        T::schemas(schemas);
+    }
+}
 
 // Create `utoipa` module so we can use `utoipa-gen` directly from `utoipa` crate.
 // ONLY for internal use!
@@ -724,19 +880,6 @@ pub trait PartialSchema {
     /// construct combined schemas.
     fn schema() -> openapi::RefOr<openapi::schema::Schema>;
 }
-
-#[rustfmt::skip]
-impl_partial_schema_primitive!(
-    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char
-);
-
-impl<'a> ToSchema for &'a str {
-    fn name() -> Cow<'static, str> {
-        std::borrow::Cow::Borrowed("str")
-    }
-}
-
-impl_partial_schema!(&str);
 
 /// Trait for implementing OpenAPI PathItem object with path.
 ///
@@ -1124,7 +1267,7 @@ impl_from_for_number!(
 pub mod __dev {
     use utoipa_gen::schema;
 
-    use crate::{utoipa, OpenApi, PartialSchema, ToSchema};
+    use crate::{utoipa, OpenApi, PartialSchema};
 
     pub trait PathConfig {
         fn path() -> String;
@@ -1196,191 +1339,198 @@ pub mod __dev {
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>;
     }
 
-    // Default implementation
-    impl<T: utoipa::__dev::ComposeSchema> utoipa::PartialSchema for T {
+    macro_rules! impl_compose_schema {
+        ( $( $ty:ident ),* ) => {
+            $(
+            impl ComposeSchema for $ty {
+                fn compose(_: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                    schema!( $ty ).into()
+                }
+            }
+            )*
+        };
+    }
+
+    #[rustfmt::skip]
+    impl_compose_schema!(
+        i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char
+    );
+
+    impl ComposeSchema for &str {
+        fn compose(
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+        ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+            str::compose(schemas)
+        }
+    }
+
+    impl<T: ComposeSchema + ?Sized> PartialSchema for T {
         fn schema() -> crate::openapi::RefOr<crate::openapi::schema::Schema> {
             T::compose(Vec::new())
         }
     }
-
-    impl<T: utoipa::PartialSchema> ComposeSchema for Option<T> {
+    impl<T: ComposeSchema> ComposeSchema for Option<T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(#[inline] Option<T>).into()
+            utoipa::openapi::schema::AllOfBuilder::new()
+                .item(
+                    utoipa::openapi::schema::ObjectBuilder::new()
+                        .schema_type(utoipa::openapi::schema::Type::Null),
+                )
+                .item(T::compose(schemas))
+                .into()
         }
     }
 
-    impl<T: ToSchema> ComposeSchema for Vec<T> {
+    impl<T: ComposeSchema> ComposeSchema for Vec<T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(#[inline] Vec<T>).into()
+            utoipa::openapi::schema::ArrayBuilder::new()
+                .items(T::compose(schemas))
+                .into()
         }
     }
 
-    impl<T: ToSchema> ComposeSchema for std::collections::LinkedList<T> {
+    impl<T: ComposeSchema> ComposeSchema for std::collections::LinkedList<T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(#[inline] LinkedList<T>).into()
+            utoipa::openapi::schema::ArrayBuilder::new()
+                .items(T::compose(schemas))
+                .into()
         }
     }
 
-    impl<T: ToSchema> ComposeSchema for [T] {
+    impl<T: ComposeSchema> ComposeSchema for [T] {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                [T]
-            )
-            .into()
+            utoipa::openapi::schema::ArrayBuilder::new()
+                .items(T::compose(schemas))
+                .into()
         }
     }
 
-    impl<T: ToSchema> ComposeSchema for &[T] {
+    impl<T: ComposeSchema> ComposeSchema for &[T] {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                [T]
-            )
-            .into()
+            utoipa::openapi::schema::ArrayBuilder::new()
+                .items(T::compose(schemas))
+                .into()
         }
     }
 
-    impl<T: ToSchema> ComposeSchema for &mut [T] {
+    impl<T: ComposeSchema> ComposeSchema for &mut [T] {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                [T]
-            )
-            .into()
+            utoipa::openapi::schema::ArrayBuilder::new()
+                .items(T::compose(schemas))
+                .into()
         }
     }
 
-    impl<K: PartialSchema, T: ToSchema> ComposeSchema for std::collections::HashMap<K, T> {
+    impl<K: ComposeSchema, T: ComposeSchema> ComposeSchema for std::collections::HashMap<K, T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                HashMap<K, T>
-            )
-            .into()
+            utoipa::openapi::ObjectBuilder::new()
+                .property_names(Some(K::compose(schemas.clone())))
+                .additional_properties(Some(T::compose(schemas)))
+                .into()
         }
     }
 
-    impl<K: PartialSchema, T: ToSchema> ComposeSchema for std::collections::BTreeMap<K, T> {
+    impl<K: ComposeSchema, T: ComposeSchema> ComposeSchema for std::collections::BTreeMap<K, T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                BTreeMap<K, T>
-            )
-            .into()
+            utoipa::openapi::ObjectBuilder::new()
+                .property_names(Some(K::compose(schemas.clone())))
+                .additional_properties(Some(T::compose(schemas)))
+                .into()
         }
     }
 
-    impl<K: PartialSchema> ComposeSchema for std::collections::HashSet<K> {
+    impl<K: ComposeSchema> ComposeSchema for std::collections::HashSet<K> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                HashSet<K>
-            )
-            .into()
+            utoipa::openapi::schema::ArrayBuilder::new()
+                .items(K::compose(schemas))
+                .unique_items(true)
+                .into()
         }
     }
 
-    impl<K: PartialSchema> ComposeSchema for std::collections::BTreeSet<K> {
+    impl<K: ComposeSchema> ComposeSchema for std::collections::BTreeSet<K> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                BTreeSet<K>
-            )
-            .into()
+            utoipa::openapi::schema::ArrayBuilder::new()
+                .items(K::compose(schemas))
+                .unique_items(true)
+                .into()
         }
     }
 
     #[cfg(feature = "indexmap")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "macros", feature = "indexmap")))]
-    impl<K: PartialSchema, T: ToSchema> ComposeSchema for indexmap::IndexMap<K, T> {
+    impl<K: ComposeSchema, T: ComposeSchema> ComposeSchema for indexmap::IndexMap<K, T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                IndexMap<K, T>
-            )
-            .into()
+            utoipa::openapi::ObjectBuilder::new()
+                .property_names(Some(K::compose(schemas.clone())))
+                .additional_properties(Some(T::compose(schemas)))
+                .into()
         }
     }
 
-    impl<'a, T: PartialSchema + Clone> ComposeSchema for std::borrow::Cow<'a, T> {
+    impl<'a, T: ComposeSchema + Clone> ComposeSchema for std::borrow::Cow<'a, T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                Cow<T>
-            )
+            T::compose(schemas)
         }
     }
 
-    impl<T: PartialSchema> ComposeSchema for std::boxed::Box<T> {
+    impl<T: ComposeSchema> ComposeSchema for std::boxed::Box<T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                Box<T>
-            )
+            T::compose(schemas)
         }
     }
 
-    impl<T: PartialSchema> ComposeSchema for std::cell::RefCell<T> {
+    impl<T: ComposeSchema> ComposeSchema for std::cell::RefCell<T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                RefCell<T>
-            )
+            T::compose(schemas)
         }
     }
 
     #[cfg(feature = "rc_schema")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "macros", feature = "rc_schema")))]
-    impl<T: PartialSchema> ComposeSchema for std::rc::Rc<T> {
+    impl<T: ComposeSchema> ComposeSchema for std::rc::Rc<T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                Rc<T>
-            )
+            T::compose(schemas)
         }
     }
 
     #[cfg(feature = "rc_schema")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "macros", feature = "rc_schema")))]
-    impl<T: PartialSchema> ComposeSchema for std::sync::Arc<T> {
+    impl<T: ComposeSchema> ComposeSchema for std::sync::Arc<T> {
         fn compose(
-            _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
+            schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            schema!(
-                #[inline]
-                Arc<T>
-            )
+            T::compose(schemas)
         }
     }
 


### PR DESCRIPTION
This commit enhances generic schema collection from generic arguments for pre defined set of container types. Prior to this commit if the generic argument was one of known container types like `Vec` or `LinkedList` then types within that container type was not correctly composed. This commit addresses this allowing better compose ability.

This commit changes the auto collect of schemas to only collect non inlined schemas from their usage. This results leaner OpenAPI document by avoid polluting the OpenAPI document from unrelated schemas (which are not used by referencing). This behavior can be altered with `utoipa-config` by setting `SchemaCollect::All` mode on which will return to old behavior of collecting also inlined schemas.

Closes #1114