### PR TITLE
Chore filter const generics

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Fixed
 
+* Chore filter const generics (https://github.com/juhaku/utoipa/pull/1118)
 * Fix impl `ToSchema` for container types (https://github.com/juhaku/utoipa/pull/1107)
 * Fix description on `inline` field (https://github.com/juhaku/utoipa/pull/1102)
 * Fix `title` on unnamed struct and references (https://github.com/juhaku/utoipa/pull/1101)

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5854,3 +5854,35 @@ fn schema_manual_impl() {
         })
     )
 }
+
+#[test]
+fn const_generic_test() {
+    #![allow(unused)]
+
+    #[derive(ToSchema)]
+    pub struct ArrayResponse<T: ToSchema, const N: usize> {
+        array: [T; N],
+    }
+
+    #[derive(ToSchema)]
+    struct CombinedResponse<T: ToSchema, const N: usize> {
+        pub array_response: ArrayResponse<T, N>,
+    }
+
+    use utoipa::PartialSchema;
+    let schema = <CombinedResponse<String, 1> as PartialSchema>::schema();
+    let value = serde_json::to_value(schema).expect("schema is JSON serializable");
+
+    assert_json_eq! {
+        value,
+        json!({
+            "properties": {
+                "array_response": {
+                    "$ref": "#/components/schemas/ArrayResponse_String"
+                }
+            },
+            "required": ["array_response"],
+            "type": "object"
+        })
+    }
+}


### PR DESCRIPTION
This commit will filter out const generics from being added to the schema composing because the value is not used in anyway.

Perhaps in some future release the real support of const generics could be experimented.

Fixes #1115