### PR TITLE
Enhance unit struct schema

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Add support for title and description for unit struct schema (https://github.com/juhaku/utoipa/pull/1122)
 * Add support for `schema(ignore)` and `param(ignore)` (https://github.com/juhaku/utoipa/pull/1090)
 * Add support for `property_names` for object (https://github.com/juhaku/utoipa/pull/1084)
 * Add `bound` attribute for customizing generic impl bounds. (https://github.com/juhaku/utoipa/pull/1079)

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5886,3 +5886,26 @@ fn const_generic_test() {
         })
     }
 }
+
+#[test]
+fn unit_struct_schema() {
+    #![allow(unused)]
+
+    /// This is description
+    #[derive(ToSchema)]
+    #[schema(title = "Title")]
+    struct UnitType;
+
+    use utoipa::PartialSchema;
+    let schema = <UnitType as PartialSchema>::schema();
+    let value = serde_json::to_value(schema).expect("schema is JSON serializable");
+
+    assert_json_eq! {
+        value,
+        json!({
+            "description": "This is description",
+            "title": "Title",
+            "default": null,
+        })
+    }
+}


### PR DESCRIPTION
This commit adds `description` and `title` support for unit structs to enhance OpenAPI documentation.

Closes #823