### PR TITLE
Chore explicit FromIterator for edition 2018

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-gen
 
+## Unreleased
+
+### Fixed
+
+* Chore explicit FromIterator for edition 2018 (https://github.com/juhaku/utoipa/pull/1131)
+
 ## 5.0.0 - Oct 14 2024
 
 ### Added

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -889,9 +889,12 @@ impl ComponentSchema {
         if let Some(nullable) = nullable {
             let nullable_schema_type = nullable.into_schema_type_token_stream();
             let schema_type = if nullable.value() && !nullable_schema_type.is_empty() {
-                Some(
-                    quote! { utoipa::openapi::schema::SchemaType::from_iter([#schema_type_inner, #nullable_schema_type]) },
-                )
+                Some(quote! {
+                    {
+                        use std::iter::FromIterator;
+                        utoipa::openapi::schema::SchemaType::from_iter([#schema_type_inner, #nullable_schema_type])
+                    }
+                })
             } else {
                 None
             };

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -236,10 +236,15 @@ impl ToTokensDiagnostics for SchemaType<'_> {
             nullable: bool,
         ) {
             if nullable {
-                tokens.extend(quote! { utoipa::openapi::schema::SchemaType::from_iter([
-                    #schema_type,
-                    utoipa::openapi::schema::Type::Null
-                ])})
+                tokens.extend(quote! {
+                    {
+                        use std::iter::FromIterator;
+                        utoipa::openapi::schema::SchemaType::from_iter([
+                            #schema_type,
+                            utoipa::openapi::schema::Type::Null
+                        ])
+                    }
+                })
             } else {
                 tokens.extend(quote! { utoipa::openapi::schema::SchemaType::new(#schema_type)});
             }


### PR DESCRIPTION
This commit adds explicit import for `FromIterator` to better support Rust `2018` edition. In `2021` edition the import can be implicit.

Fixes  #1127