### PR TITLE
Fixed dependency name in doc comment

### DIFF
--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! utoipa_axum = "0.1"
+//! utoipa-axum = "0.1"
 //! ```
 //!
 //! ## Examples


### PR DESCRIPTION
Doc comment showed wrong dependency name ("_" instead of "-")