### PR TITLE
Add `no_recursion` feature for `ToSchema`

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+* Add `no_recursion` feature for `ToSchema` (https://github.com/juhaku/utoipa/pull/1137)
+
 ### Fixed
 
 * Chore explicit FromIterator for edition 2018 (https://github.com/juhaku/utoipa/pull/1131)

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -731,6 +731,7 @@ pub struct SchemaReference {
     pub tokens: TokenStream,
     pub references: TokenStream,
     pub is_inline: bool,
+    pub no_recursion: bool,
 }
 
 impl SchemaReference {
@@ -1188,6 +1189,9 @@ impl ComponentSchema {
                     let rewritten_path = type_path.rewrite_path()?;
                     let nullable_item = nullable_one_of_item(nullable);
                     let mut object_schema_reference = SchemaReference::default();
+                    object_schema_reference.no_recursion = features
+                        .iter()
+                        .any(|feature| matches!(feature, Feature::NoRecursion(_)));
 
                     if let Some(children) = &type_tree.children {
                         let children_name = Self::compose_name(
@@ -1468,6 +1472,7 @@ impl ComponentSchema {
                     tokens: quote! { <#rewritten_path as utoipa::PartialSchema>::schema() },
                     references: quote !{ <#rewritten_path as utoipa::ToSchema>::schemas(schemas) },
                     is_inline: false,
+                    no_recursion: false,
                 }))
                 )
             } else {

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -103,6 +103,7 @@ pub enum Feature {
     Discriminator(attributes::Discriminator),
     Bound(attributes::Bound),
     Ignore(attributes::Ignore),
+    NoRecursion(attributes::NoRecursion),
     MultipleOf(validation::MultipleOf),
     Maximum(validation::Maximum),
     Minimum(validation::Minimum),
@@ -229,6 +230,7 @@ impl ToTokensDiagnostics for Feature {
                 // inline feature is ignored by `ToTokens`
                 TokenStream::new()
             }
+            Feature::NoRecursion(_) => return Err(Diagnostics::new("NoRecurse does not support `ToTokens`")),
             Feature::IntoParamsNames(_) => {
                 return Err(Diagnostics::new("Names feature does not support `ToTokens`")
                     .help("Names is only used with IntoParams to artificially give names for unnamed struct type `IntoParams`."))
@@ -303,6 +305,7 @@ impl Display for Feature {
             Feature::Discriminator(discriminator) => discriminator.fmt(f),
             Feature::Bound(bound) => bound.fmt(f),
             Feature::Ignore(ignore) => ignore.fmt(f),
+            Feature::NoRecursion(no_recursion) => no_recursion.fmt(f),
         }
     }
 }
@@ -353,6 +356,7 @@ impl Validatable for Feature {
             Feature::Discriminator(discriminator) => discriminator.is_validatable(),
             Feature::Bound(bound) => bound.is_validatable(),
             Feature::Ignore(ignore) => ignore.is_validatable(),
+            Feature::NoRecursion(no_recursion) => no_recursion.is_validatable(),
         }
     }
 }
@@ -401,6 +405,7 @@ is_validatable! {
     attributes::Discriminator,
     attributes::Bound,
     attributes::Ignore,
+    attributes::NoRecursion,
     validation::MultipleOf = true,
     validation::Maximum = true,
     validation::Minimum = true,
@@ -630,6 +635,7 @@ impl_feature_into_inner! {
     attributes::Discriminator,
     attributes::Bound,
     attributes::Ignore,
+    attributes::NoRecursion,
     validation::MultipleOf,
     validation::Maximum,
     validation::Minimum,

--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -1004,3 +1004,26 @@ impl From<Ignore> for Feature {
         Self::Ignore(value)
     }
 }
+
+// Nothing to parse, it is considered to be set when attribute itself is parsed via
+// `parse_features!`.
+impl_feature! {
+    #[derive(Clone)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct NoRecursion;
+}
+
+impl Parse for NoRecursion {
+    fn parse(_: ParseStream, _: Ident) -> syn::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(Self)
+    }
+}
+
+impl From<NoRecursion> for Feature {
+    fn from(value: NoRecursion) -> Self {
+        Self::NoRecursion(value)
+    }
+}

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -80,6 +80,7 @@ impl ToTokensDiagnostics for Schema<'_> {
         let variant = SchemaVariant::new(self.data, &root)?;
         let (generic_references, schema_references): (Vec<_>, Vec<_>) = variant
             .get_schema_references()
+            .filter(|schema_reference| !schema_reference.no_recursion)
             .partition(|schema_reference| schema_reference.is_partial());
 
         struct SchemaRef<'a>(&'a TokenStream, &'a TokenStream, &'a TokenStream, bool);

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -7,9 +7,9 @@ use crate::{
     component::features::{
         attributes::{
             AdditionalProperties, As, Bound, ContentEncoding, ContentMediaType, Deprecated,
-            Description, Discriminator, Example, Examples, Format, Ignore, Inline, Nullable,
-            ReadOnly, Rename, RenameAll, Required, SchemaWith, Title, ValueType, WriteOnly,
-            XmlAttr,
+            Description, Discriminator, Example, Examples, Format, Ignore, Inline, NoRecursion,
+            Nullable, ReadOnly, Rename, RenameAll, Required, SchemaWith, Title, ValueType,
+            WriteOnly, XmlAttr,
         },
         impl_into_inner, impl_merge, parse_features,
         validation::{
@@ -62,7 +62,8 @@ impl Parse for UnnamedFieldStructFeatures {
             Description,
             ContentEncoding,
             ContentMediaType,
-            Bound
+            Bound,
+            NoRecursion
         )))
     }
 }
@@ -141,7 +142,8 @@ impl Parse for NamedFieldFeatures {
             Deprecated,
             ContentEncoding,
             ContentMediaType,
-            Ignore
+            Ignore,
+            NoRecursion
         )))
     }
 }
@@ -181,7 +183,8 @@ impl Parse for EnumUnnamedFieldVariantFeatures {
             Format,
             ValueType,
             Rename,
-            Deprecated
+            Deprecated,
+            NoRecursion
         )))
     }
 }


### PR DESCRIPTION
This commit adds a new `no_recursion` feature for `ToSchema` which is used to break out from recurring into infinite loop when collecting schema references. In case of looping schema tree this is mandatory to break the recursion. Failing to do so will be runtime panic.

Fixes #1134