### PR TITLE
Add `identifier` for `Info`

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Add `identifier` for `Info` (https://github.com/juhaku/utoipa/pull/1140)
 * Add `no_recursion` feature for `ToSchema` (https://github.com/juhaku/utoipa/pull/1137)
 
 ### Fixed

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -252,6 +252,26 @@ fn derive_openapi_with_servers() {
 }
 
 #[test]
+fn derive_openapi_with_licence() {
+    #[derive(OpenApi)]
+    #[openapi(info(license(name = "licence_name", identifier = "MIT"), version = "1.0.0",))]
+    struct ApiDoc;
+
+    let value = serde_json::to_value(ApiDoc::openapi()).unwrap();
+    let info = value.pointer("/info/license");
+    dbg!(&info);
+
+    assert_json_include!(
+        actual: info,
+        expected:
+            json!({
+                "name": "licence_name",
+                "identifier": "MIT",
+            })
+    )
+}
+
+#[test]
 fn derive_openapi_with_custom_info() {
     #[derive(OpenApi)]
     #[openapi(info(

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -7,6 +7,7 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Added
 
+* Add `identifier` for `Info` (https://github.com/juhaku/utoipa/pull/1140)
 * Implement schema traits for indexset (https://github.com/juhaku/utoipa/pull/1129)
 * Add `ToSchema` implementation for serde_json::Value (https://github.com/juhaku/utoipa/pull/1132)
 

--- a/utoipa/src/openapi/info.rs
+++ b/utoipa/src/openapi/info.rs
@@ -212,6 +212,13 @@ builder! {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub url: Option<String>,
 
+        /// An [SPDX-Licenses][spdx_licence] expression for the API. The _`identifier`_ field
+        /// is mutually exclusive of the _`url`_ field. E.g. Apache-2.0
+        ///
+        /// [spdx_licence]: <https://spdx.org/licenses/>
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub identifier: Option<String>,
+
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
         pub extensions: Option<Extensions>,
@@ -244,6 +251,14 @@ impl LicenseBuilder {
     /// Add openapi extensions (x-something) of the API.
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Set identifier of the licence as [SPDX-Licenses][spdx_licence] expression for the API.
+    /// The _`identifier`_ field is mutually exclusive of the _`url`_ field. E.g. Apache-2.0
+    ///
+    /// [spdx_licence]: <https://spdx.org/licenses/>
+    pub fn identifier<S: Into<String>>(mut self, identifier: Option<S>) -> Self {
+        set_value!(self identifier identifier.map(|identifier| identifier.into()))
     }
 }
 


### PR DESCRIPTION
This commit adds `identifier` field to `Info` what was missing since upgrading to OpenAPI 3.1.

Fixes #1139