### PR TITLE
Change Option<T> compose to OneOfBuilder

### DIFF
--- a/utoipa-gen/tests/testdata/schema_generic_enum_variant_with_generic_type
+++ b/utoipa-gen/tests/testdata/schema_generic_enum_variant_with_generic_type
@@ -14,7 +14,7 @@
         ],
         "properties": {
           "foo": {
-            "allOf": [
+            "oneOf": [
               {
                 "type": "null"
               },
@@ -75,7 +75,7 @@
                 ],
                 "properties": {
                   "foo": {
-                    "allOf": [
+                    "oneOf": [
                       {
                         "type": "null"
                       },

--- a/utoipa-gen/tests/testdata/uuid_type_generic_argument
+++ b/utoipa-gen/tests/testdata/uuid_type_generic_argument
@@ -17,7 +17,7 @@
         ],
         "properties": {
           "high": {
-            "allOf": [
+            "oneOf": [
               {
                 "type": "null"
               },

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -11,6 +11,10 @@ to look into changes introduced to **`utoipa-gen`**.
 * Implement schema traits for indexset (https://github.com/juhaku/utoipa/pull/1129)
 * Add `ToSchema` implementation for serde_json::Value (https://github.com/juhaku/utoipa/pull/1132)
 
+### Changed
+
+* Change Option<T> compose to OneOfBuilder (https://github.com/juhaku/utoipa/pull/1141)
+
 ## 5.0.0 - Oct 14 2024
 
 ### Added

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1360,7 +1360,7 @@ pub mod __dev {
         fn compose(
             schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-            utoipa::openapi::schema::AllOfBuilder::new()
+            utoipa::openapi::schema::OneOfBuilder::new()
                 .item(
                     utoipa::openapi::schema::ObjectBuilder::new()
                         .schema_type(utoipa::openapi::schema::Type::Null),


### PR DESCRIPTION
This commit change the `Option<T>` compose implementation from `AllOfBuilder` to `OneOfBuilder`. This comes as follow up for #1135 which changed the `utoipa-gen` side nullable types from `allOf` to `oneOf`.

Closes #1050 Closes #1135