### PR TITLE
Enhance no_recursion rule to apply also containers

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-gen
 
+## Unreleased
+
+### Changed
+
+*  Enhance no_recursion rule to apply also containers (https://github.com/juhaku/utoipa/pull/1144)
+
 ## 5.1.0 - Oct 16 2024
 
 ### Added

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1188,10 +1188,12 @@ impl ComponentSchema {
                     let type_path = &**type_tree.path.as_ref().unwrap();
                     let rewritten_path = type_path.rewrite_path()?;
                     let nullable_item = nullable_one_of_item(nullable);
-                    let mut object_schema_reference = SchemaReference::default();
-                    object_schema_reference.no_recursion = features
-                        .iter()
-                        .any(|feature| matches!(feature, Feature::NoRecursion(_)));
+                    let mut object_schema_reference = SchemaReference {
+                        no_recursion: features
+                            .iter()
+                            .any(|feature| matches!(feature, Feature::NoRecursion(_))),
+                        ..SchemaReference::default()
+                    };
 
                     if let Some(children) = &type_tree.children {
                         let children_name = Self::compose_name(

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -38,7 +38,8 @@ impl Parse for NamedFieldStructFeatures {
             crate::component::features::attributes::Default,
             Deprecated,
             Description,
-            Bound
+            Bound,
+            NoRecursion
         )))
     }
 }
@@ -103,7 +104,8 @@ impl Parse for MixedEnumFeatures {
             As,
             Deprecated,
             Description,
-            Discriminator
+            Discriminator,
+            NoRecursion
         )))
     }
 }
@@ -164,7 +166,8 @@ impl Parse for EnumNamedFieldVariantFeatures {
             RenameAll,
             Deprecated,
             MaxProperties,
-            MinProperties
+            MinProperties,
+            NoRecursion
         )))
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -134,6 +134,10 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 ///   contain. Value must be a number.
 /// * `min_properties = ...` Can be used to define minimum number of properties this struct can
 ///   contain. Value must be a number.
+///* `no_recursion` Is used to break from recursion in case of looping schema tree e.g. `Pet` ->
+///  `Owner` -> `Pet`. _`no_recursion`_ attribute must be used within `Ower` type not to allow
+///  recurring into `Pet`. Failing to do so will cause infinite loop and runtime **panic**. On
+///  struct level the _`no_recursion`_ rule will be applied to all of its fields.
 ///
 /// ## Named Fields Optional Configuration Options for `#[schema(...)]`
 ///
@@ -325,6 +329,10 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 /// * `discriminator = ...` or `discriminator(...)` Can be used to define OpenAPI discriminator
 ///   field for enums with single unnamed _`ToSchema`_ reference field. See the [discriminator
 ///   syntax][derive@ToSchema#schemadiscriminator-syntax].
+///* `no_recursion` Is used to break from recursion in case of looping schema tree e.g. `Pet` ->
+///  `Owner` -> `Pet`. _`no_recursion`_ attribute must be used within `Ower` type not to allow
+///  recurring into `Pet`. Failing to do so will cause infinite loop and runtime **panic**. On
+///  enum level the _`no_recursion`_ rule will be applied to all of its variants.
 ///
 ///  ### `#[schema(discriminator)]` syntax
 ///  
@@ -336,7 +344,7 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 ///
 ///  Can be literal string or expression e.g. [_`const`_][const] reference. It can be defined as
 ///  _`discriminator = "value"`_ where the assigned value is the
-/// discriminator field that must exists in each variant referencing schema.
+///  discriminator field that must exists in each variant referencing schema.
 ///
 /// **Complex form `discriminator(...)`**
 ///
@@ -377,6 +385,10 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 ///   contain. Value must be a number.
 /// * `min_properties = ...` Can be used to define minimum number of properties this struct can
 ///   contain. Value must be a number.
+///* `no_recursion` Is used to break from recursion in case of looping schema tree e.g. `Pet` ->
+///  `Owner` -> `Pet`. _`no_recursion`_ attribute must be used within `Ower` type not to allow
+///  recurring into `Pet`. Failing to do so will cause infinite loop and runtime **panic**. On
+///  named field variant level the _`no_recursion`_ rule will be applied to all of its fields.
 ///
 /// ## Mixed Enum Unnamed Field Variant Optional Configuration Options for `#[serde(schema)]`
 ///

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5960,3 +5960,44 @@ fn test_recursion_compiles() {
         .expect("OpenApi is JSON serializable");
     println!("{json}")
 }
+
+#[test]
+fn test_named_and_enum_container_recursion_compiles() {
+    #![allow(unused)]
+
+    #[derive(ToSchema)]
+    #[schema(no_recursion)]
+    pub struct Tree {
+        left: Box<Tree>,
+        right: Box<Tree>,
+    }
+
+    #[derive(ToSchema)]
+    #[schema(no_recursion)]
+    pub enum TreeRecursion {
+        Named { left: Box<TreeRecursion> },
+        Unnamed(Box<TreeRecursion>),
+        NoValue,
+    }
+
+    #[derive(ToSchema)]
+    pub enum Recursion {
+        #[schema(no_recursion)]
+        Named {
+            left: Box<Recursion>,
+            right: Box<Recursion>,
+        },
+        #[schema(no_recursion)]
+        Unnamed(Box<Recursion>),
+        NoValue,
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(components(schemas(Recursion, Tree, TreeRecursion)))]
+    pub struct ApiDoc {}
+
+    let json = ApiDoc::openapi()
+        .to_pretty_json()
+        .expect("OpenApi is JSON serializable");
+    println!("{json}")
+}


### PR DESCRIPTION
This commit further enhances the `no_recursion` rule to also apply on named structs, enums and named field enum variants. When provided on these aforementioned levels it will apply to its fields / variants.

Example of the enhanced syntax.
```rust
 #[derive(ToSchema)]
 #[schema(no_recursion)]
 pub struct Tree {
     left: Box<Tree>,
     right: Box<Tree>,
 }

 #[derive(ToSchema)]
 #[schema(no_recursion)]
 pub enum TreeRecursion {
     Named { left: Box<TreeRecursion> },
     Unnamed(Box<TreeRecursion>),
     NoValue,
 }

 #[derive(ToSchema)]
 pub enum Recursion {
     #[schema(no_recursion)]
     Named {
         left: Box<Recursion>,
         right: Box<Recursion>,
     },
     #[schema(no_recursion)]
     Unnamed(Box<Recursion>),
     NoValue,
 }
```

Closes #1137