### PR TITLE
Fix `no_recursion` support on maps

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-gen
 
+## Unreleased
+
+### Fixed
+
+* Fix `no_recursion` support on maps (https://github.com/juhaku/utoipa/pull/1167)
+
 ## 5.1.2 - Oct 16 2024
 
 ### Added

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1149,6 +1149,7 @@ impl ComponentSchema {
                 for feature in features.iter().filter(|feature| feature.is_validatable()) {
                     feature.validate(&schema_type, type_tree);
                 }
+                let _ = pop_feature!(features => Feature::NoRecursion(_)); // primitive types are not recursive
                 tokens.extend(features.to_token_stream()?);
             }
             ValueType::Value => {

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5970,6 +5970,7 @@ fn test_named_and_enum_container_recursion_compiles() {
     pub struct Tree {
         left: Box<Tree>,
         right: Box<Tree>,
+        map: HashMap<String, Tree>,
     }
 
     #[derive(ToSchema)]
@@ -5988,7 +5989,7 @@ fn test_named_and_enum_container_recursion_compiles() {
             right: Box<Recursion>,
         },
         #[schema(no_recursion)]
-        Unnamed(Box<Recursion>),
+        Unnamed(HashMap<String, Recursion>),
         NoValue,
     }
 


### PR DESCRIPTION
This commit fixes `no_recursion` attribute on map types like `HashMap<K, T>`.

Fixes #1166