### PR TITLE
Add `map` for `ServiceConfig`

### DIFF
--- a/utoipa-actix-web/CHANGELOG.md
+++ b/utoipa-actix-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-actix-web
 
+## 0.1.1 - Oct 30 2024
+
+### Changed
+
+* Add `map` support for `ServiceConfig` (https://github.com/juhaku/utoipa/pull/1174)
+
 ## 0.1.0 - Oct 23 2024
 
 ### Added

--- a/utoipa-actix-web/Cargo.toml
+++ b/utoipa-actix-web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utoipa-actix-web"
 description = "Utoipa's actix-web bindings for seamless integration of the two"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/utoipa-actix-web/src/lib.rs
+++ b/utoipa-actix-web/src/lib.rs
@@ -363,10 +363,10 @@ mod tests {
     #![allow(unused)]
 
     use actix_service::Service;
-    use actix_web::guard::Guard;
+    use actix_web::guard::{Get, Guard};
     use actix_web::http::header::{HeaderValue, CONTENT_TYPE};
-    use actix_web::web::Data;
-    use actix_web::{get, App};
+    use actix_web::web::{self, Data};
+    use actix_web::{get, App, HttpRequest, HttpResponse};
     use utoipa::ToSchema;
 
     use super::*;
@@ -441,10 +441,16 @@ mod tests {
         }
     }
 
+    #[get("/normal_service")]
+    async fn normal_service() -> &'static str {
+        "str"
+    }
+
     #[test]
     fn test_app_generate_correct_openapi() {
         fn config(cfg: &mut service_config::ServiceConfig) {
-            cfg.service(handler3);
+            cfg.service(handler3)
+                .map(|config| config.service(normal_service));
         }
 
         let (_, mut api) = App::new()

--- a/utoipa-actix-web/src/service_config.rs
+++ b/utoipa-actix-web/src/service_config.rs
@@ -94,4 +94,18 @@ impl<'s> ServiceConfig<'s> {
         self.0.external_resource(name, url);
         self
     }
+
+    /// Synonymous for [`UtoipaApp::map`][utoipa_app_map]
+    ///
+    /// [utoipa_app_map]: ../struct.UtoipaApp.html#method.map
+    pub fn map<
+        F: FnOnce(&mut actix_web::web::ServiceConfig) -> &mut actix_web::web::ServiceConfig,
+    >(
+        &mut self,
+        op: F,
+    ) -> &mut Self {
+        op(self.0);
+
+        self
+    }
 }


### PR DESCRIPTION
This commit adds `map` function for `ServiceConfig` to allow defining normal services to `actix_web::web::ServiceConfig` via `ServiceConfig` in similar fashion to `Scope` and `UtoipaApp`.

This example demonstrates the `map` functionality of `ServiceConfig` to allow direct access to underlying `actix_web::web::ServiceConfig`.
```rust
fn config(cfg: &mut service_config::ServiceConfig) {
    cfg.service(handler3)
        .map(|config| config.service(normal_service));
}
```

Closes #1173