### PR TITLE
The `ignore` attribute now accepts an optional bool value

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 * Added missing formats for `KnownFormat` parsing (https://github.com/juhaku/utoipa/pull/1178)
+* The `#[schema(ignore)]` attribute now accepts an optional bool value/function path (https://github.com/juhaku/utoipa/pull/1177)
 
 ## 5.1.3 - Oct 27 2024
 

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -242,7 +242,7 @@ impl ToTokensDiagnostics for Feature {
                 let name = <attributes::Required as FeatureLike>::get_name();
                 quote! { .#name(#required) }
             }
-            Feature::Ignore(_) => return Err(Diagnostics::new("Feature::Ignore does not support ToTokens")),
+            Feature::Ignore(_) => return Err(Diagnostics::new("Ignore does not support `ToTokens`")),
         };
 
         tokens.extend(feature);

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -2899,6 +2899,52 @@ fn derive_into_params_with_ignored_field() {
 }
 
 #[test]
+fn derive_into_params_with_ignored_eq_false_field() {
+    #![allow(unused)]
+
+    #[derive(IntoParams)]
+    #[into_params(parameter_in = Query)]
+    struct Params {
+        name: String,
+        #[param(ignore = false)]
+        __this_is_private: String,
+    }
+
+    #[utoipa::path(get, path = "/params", params(Params))]
+    #[allow(unused)]
+    fn get_params() {}
+    let operation = test_api_fn_doc! {
+        get_params,
+        operation: get,
+        path: "/params"
+    };
+
+    let value = operation.pointer("/parameters");
+
+    assert_json_eq!(
+        value,
+        json!([
+            {
+                "in": "query",
+                "name": "name",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            },
+            {
+                "in": "query",
+                "name": "__this_is_private",
+                "required": true,
+                "schema": {
+                    "type": "string"
+                }
+            }
+        ])
+    )
+}
+
+#[test]
 fn derive_octet_stream_request_body() {
     #![allow(dead_code)]
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -5727,6 +5727,69 @@ fn derive_schema_with_ignored_field() {
 }
 
 #[test]
+fn derive_schema_with_ignore_eq_false_field() {
+    #![allow(unused)]
+    let value = api_doc! {
+        struct SchemaIgnoredField {
+            value: String,
+            #[schema(ignore = false)]
+            this_is_not_private: String,
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "this_is_not_private": {
+                    "type": "string"
+                }
+            },
+            "required": [ "value", "this_is_not_private" ],
+            "type": "object"
+        })
+    )
+}
+
+#[test]
+fn derive_schema_with_ignore_eq_call_field() {
+    #![allow(unused)]
+
+    let value = api_doc! {
+        struct SchemaIgnoredField {
+            value: String,
+            #[schema(ignore = Self::ignore)]
+            this_is_not_private: String,
+        }
+
+        impl SchemaIgnoredField {
+            fn ignore() -> bool {
+                false
+            }
+        }
+    };
+
+    assert_json_eq!(
+        value,
+        json!({
+            "properties": {
+                "value": {
+                    "type": "string"
+                },
+                "this_is_not_private": {
+                    "type": "string"
+                }
+            },
+            "required": [ "value", "this_is_not_private" ],
+            "type": "object"
+        })
+    )
+}
+
+#[test]
 fn derive_schema_unnamed_title() {
     #![allow(unused)]
 


### PR DESCRIPTION
Allow to statically ignore field using const generics:

```rust
#[derive(Debug, Serialize, ToSchema)]
pub struct SuccessResponsePayload<T: ResourceObject, const IGNORE_INCLUDED: bool = true> {
    pub data: Vec<T>,
    #[schema(ignore = IGNORE_INCLUDED)]
    pub included: Vec<T::RelationshipValue>,
    #[schema(inline)]
    pub links: LinksObject<T>,
}
```

The following syntaxes are also supported:

- `#[schema(ignore)]` (defaults to `true`)
- `#[schema(ignore = false)]`
- `#[schema(ignore = <exp>)]` with `<exp>` any expression that returns `bool`