### PR TITLE
Do not inline non-primitive type parameters by default

### DIFF
--- a/utoipa-gen/tests/testdata/openapi_schemas_resolve_inner_schema_references
+++ b/utoipa-gen/tests/testdata/openapi_schemas_resolve_inner_schema_references
@@ -40,7 +40,7 @@
           "properties": {
             "Many": {
               "items": {
-                "type": "object"
+                "type": "string"
               },
               "type": "array"
             }
@@ -95,6 +95,32 @@
           "properties": {
             "Many": {
               "items": {
+                "properties": {
+                  "accounts": {
+                    "items": {
+                      "oneOf": [
+                        {
+                          "type": "null"
+                        },
+                        {
+                          "$ref": "#/components/schemas/Account"
+                        }
+                      ]
+                    },
+                    "type": "array"
+                  },
+                  "foo_bar": {
+                    "$ref": "#/components/schemas/Foobar"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "name",
+                  "foo_bar",
+                  "accounts"
+                ],
                 "type": "object"
               },
               "type": "array"

--- a/utoipa-gen/tests/testdata/schema_generics_openapi
+++ b/utoipa-gen/tests/testdata/schema_generics_openapi
@@ -193,7 +193,7 @@
               "Many": {
                 "type": "array",
                 "items": {
-                  "type": "object"
+                  "type": "string"
                 }
               }
             }


### PR DESCRIPTION
Fixes https://github.com/juhaku/utoipa/issues/1182

- [x] Implement a more comprehensive inlining strategy for generic type parameters
- [x] Fix the tests
- [x] Update the CHANGELOG