### PR TITLE
Added a passthrough for scoped middleware in actix-web

### DIFF
--- a/utoipa-actix-web/CHANGELOG.md
+++ b/utoipa-actix-web/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-actix-web
 
+## 0.1.2 - Nov 8 2024
+
+### Added
+
+* Add passthrough for `Scope::wrap` (https://github.com/juhaku/utoipa/pull/1196)
+
 ## 0.1.1 - Oct 30 2024
 
 ### Changed

--- a/utoipa-actix-web/Cargo.toml
+++ b/utoipa-actix-web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utoipa-actix-web"
 description = "Utoipa's actix-web bindings for seamless integration of the two"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/utoipa-actix-web/src/scope.rs
+++ b/utoipa-actix-web/src/scope.rs
@@ -98,9 +98,26 @@ where
     }
 
     /// Passthrough implementation for [`actix_web::Scope::wrap`].
-    pub fn wrap<M, B>(self, middleware: M) -> Scope<impl ServiceFactory<ServiceRequest, Config = (), Response = ServiceResponse<B>, Error = Error, InitError = ()>>
+    pub fn wrap<M, B>(
+        self,
+        middleware: M,
+    ) -> Scope<
+        impl ServiceFactory<
+            ServiceRequest,
+            Config = (),
+            Response = ServiceResponse<B>,
+            Error = Error,
+            InitError = (),
+        >,
+    >
     where
-        M: Transform<T::Service, ServiceRequest, Response = ServiceResponse<B>, Error = Error, InitError = ()> + 'static,
+        M: Transform<
+                T::Service,
+                ServiceRequest,
+                Response = ServiceResponse<B>,
+                Error = Error,
+                InitError = (),
+            > + 'static,
         B: MessageBody,
     {
         let scope = self.0.wrap(middleware);

--- a/utoipa-actix-web/src/scope.rs
+++ b/utoipa-actix-web/src/scope.rs
@@ -5,7 +5,7 @@
 use core::fmt;
 use std::cell::{Cell, RefCell};
 
-use actix_service::{IntoServiceFactory, ServiceFactory};
+use actix_service::{IntoServiceFactory, ServiceFactory, Transform};
 use actix_web::body::MessageBody;
 use actix_web::dev::{AppService, HttpServiceFactory, ServiceRequest, ServiceResponse};
 use actix_web::guard::Guard;
@@ -95,6 +95,16 @@ where
     /// Passthrough implementation for [`actix_web::Scope::app_data`].
     pub fn app_data<U: 'static>(self, data: U) -> Self {
         Self(self.0.app_data(data), self.1, self.2)
+    }
+
+    /// Passthrough implementation for [`actix_web::Scope::wrap`].
+    pub fn wrap<M, B>(self, middleware: M) -> Scope<impl ServiceFactory<ServiceRequest, Config = (), Response = ServiceResponse<B>, Error = Error, InitError = ()>>
+    where
+        M: Transform<T::Service, ServiceRequest, Response = ServiceResponse<B>, Error = Error, InitError = ()> + 'static,
+        B: MessageBody,
+    {
+        let scope = self.0.wrap(middleware);
+        Scope(scope, self.1, self.2)
     }
 
     /// Synonymous for [`UtoipaApp::configure`][utoipa_app_configure]


### PR DESCRIPTION
This PR adds the ability to register middlewares at a specific `Scope` using a fluent API, similar to the one of [actix-web's `Scope` struct](https://docs.rs/actix-web/latest/actix_web/struct.Scope.html#method.wrap).

Before:
```rust
utoipa_actix_web::scope(
    actix_web::web::scope("/admin")
        .wrap(Authenticated::new("/admin"))
    )
    .service(admin_dashboard)
```
After:
```rust
utoipa_actix_web::scope("/admin")
    .wrap(Authenticated::new("/admin"))
    .service(admin_dashboard)
```