### PR TITLE
fix: diverging axum route and openapi spec

### DIFF
--- a/utoipa-axum/CHANGELOG.md
+++ b/utoipa-axum/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-axum
 
+## Unreleased
+
+### Fixed
+
+* Fix diverging axum route and openapi spec (https://github.com/juhaku/utoipa/pull/1199)
+
 ## 0.1.2 - Oct 29 2024
 
 ### Changed

--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -313,7 +313,7 @@ mod tests {
         let paths = router.to_openapi().paths;
         let expected_paths = utoipa::openapi::path::PathsBuilder::new()
             .path(
-                "/api/customer/",
+                "/api/customer",
                 utoipa::openapi::PathItem::new(
                     utoipa::openapi::path::HttpMethod::Get,
                     utoipa::openapi::path::OperationBuilder::new()

--- a/utoipa-axum/src/router.rs
+++ b/utoipa-axum/src/router.rs
@@ -320,8 +320,26 @@ where
     ///     .nest("/api", search_router);
     /// ```
     pub fn nest(self, path: &str, router: OpenApiRouter<S>) -> Self {
-        let api = self.1.nest(path_template(path), router.1);
-        let path = if path.is_empty() { "/" } else { path };
+        // from axum::routing::path_router::path_for_nested_route
+        // method is private, so we need to replicate it here
+        fn path_for_nested_route<'a>(prefix: &'a str, path: &'a str) -> String {
+            debug_assert!(prefix.starts_with('/'));
+            debug_assert!(path.starts_with('/'));
+
+            if prefix.ends_with('/') {
+                format!("{prefix}{}", path.trim_start_matches('/')).into()
+            } else if path == "/" {
+                prefix.into()
+            } else {
+                format!("{prefix}{path}").into()
+            }
+        }
+
+        let api = self.1.nest_with_path_composer(
+            path_for_nested_route(path, "/"),
+            router.1,
+            |a: &str, b: &str| path_for_nested_route(a, b),
+        );
         let router = self.0.nest(&colonized_params(path), router.0);
 
         Self(router, api)

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -3,6 +3,12 @@
 **`utoipa`** is in direct correlation with **`utoipa-gen`** ([CHANGELOG.md](../utoipa-gen/CHANGELOG.md)). You might want
 to look into changes introduced to **`utoipa-gen`**.
 
+## Unreleased
+
+### Fixed
+
+* Fix diverging axum route and openapi spec (https://github.com/juhaku/utoipa/pull/1199)
+
 ## 5.2.0 - Nov 2024
 
 ### Changed


### PR DESCRIPTION
Currently there is the possibility that the swagger-ui does not work with `utoipa_axum` in certain conditions.
The reason for this is, that the path resolution in the `.nest(router)` function is different in axum and utoipa.

This pull request fixes it by applying the same logic for the OpenAPI spec generation, that is used in axum.

## How to reproduce this issue
With the following minimal reproducible example, open the swagger ui on `localhost:3000/docs`.
The only endpoint is `/a/`, but when you perform the request, it returns `404 Not Found`.

```rust
use std::io;
use utoipa::OpenApi;
use utoipa_axum::{router::OpenApiRouter, routes};
use utoipa_swagger_ui::SwaggerUi;

#[derive(OpenApi)]
#[openapi()]
struct ApiDoc;

#[tokio::main]
async fn main() -> Result<(), io::Error> {
    #[utoipa::path(get, path = "/")]
    async fn nested_get_all() -> String {
        String::from("nested get all")
    }

    let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
        .nest("/a", OpenApiRouter::new().routes(routes!(nested_get_all)))
        .split_for_parts();

    let router = router.merge(SwaggerUi::new("/docs").url("/apidoc/openapi.json", api));

    let listener = tokio::net::TcpListener::bind(("0.0.0.0", 3000)).await?;
    axum::serve(listener, router).await
}
```

## Cause of the issue
In Axum the `.nest` logic joins the prefix and nested path in a different way than utopia. E.g. for nested routes the trailing `/` is stripped away and other logic to prevent double `//` in the joined path.