### PR TITLE
[swagger-ui] add basic authentication for internal use

### DIFF
--- a/utoipa-swagger-ui/CHANGELOG.md
+++ b/utoipa-swagger-ui/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ### Added
 
-* Allow disabling syntax highlighting (https://github.com/juhaku/utoipa/pull/1188)
 * Add basic auth support for actix, rocket, axum (https://github.com/juhaku/utoipa/pull/1221)
+* Allow disabling syntax highlighting (https://github.com/juhaku/utoipa/pull/1188)
 
 ## 8.0.3 - Oct 23 2024
 

--- a/utoipa-swagger-ui/CHANGELOG.md
+++ b/utoipa-swagger-ui/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Allow disabling syntax highlighting (https://github.com/juhaku/utoipa/pull/1188)
+* Add basic auth support for actix, rocket, axum (https://github.com/juhaku/utoipa/pull/1221)
 
 ## 8.0.3 - Oct 23 2024
 

--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -22,7 +22,7 @@ vendored = ["dep:utoipa-swagger-ui-vendored"]
 [dependencies]
 rust-embed = { version = "8" }
 mime_guess = { version = "2.0" }
-actix-web = { version = "4", optional = true, default-features = false }
+actix-web = { version = "4", optional = true, default-features = false, features = ["macros"] }
 rocket = { version = "0.5", features = ["json"], optional = true }
 axum = { version = "0.7", default-features = false, features = [
     "json",

--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -32,6 +32,7 @@ utoipa = { version = "5.0.0", path = "../utoipa", default-features = false, feat
 ] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
+base64 = { version = "0.22.1" }
 
 [dev-dependencies]
 axum-test = "16.2.0"

--- a/utoipa-swagger-ui/src/actix.rs
+++ b/utoipa-swagger-ui/src/actix.rs
@@ -1,11 +1,13 @@
 #![cfg(feature = "actix-web")]
 
-use actix_web::{
-    dev::HttpServiceFactory, guard::Get, web, web::Data, HttpResponse, Resource,
-    Responder as ActixResponder,
-};
+use std::future;
 
-use crate::{ApiDoc, Config, SwaggerUi};
+use actix_web::{
+    web, dev::{HttpServiceFactory, Service, ServiceResponse}, guard::Get, web::Data, HttpResponse, Resource, Responder as ActixResponder
+};
+use base64::Engine;
+
+use crate::{ApiDoc, BasicAuth, Config, SwaggerUi};
 
 impl HttpServiceFactory for SwaggerUi {
     fn register(self, config: &mut actix_web::dev::AppService) {
@@ -23,18 +25,34 @@ impl HttpServiceFactory for SwaggerUi {
         });
         urls.extend(external_api_docs);
 
+
         let swagger_resource = Resource::new(self.path.as_ref())
-            .guard(Get())
-            .app_data(Data::new(if let Some(config) = self.config {
-                if config.url.is_some() || !config.urls.is_empty() {
-                    config
-                } else {
-                    config.configure_defaults(urls)
-                }
+        .guard(Get())
+        .app_data(Data::new(if let Some(config) = self.config.clone() {
+            if config.url.is_some() || !config.urls.is_empty() {
+                config
             } else {
-                Config::new(urls)
-            }))
-            .to(serve_swagger_ui);
+                config.configure_defaults(urls)
+            }
+        } else {
+            Config::new(urls)
+        }))
+        .wrap_fn(move |req, srv| {
+            if let Some(BasicAuth { username, password }) = self.config.as_ref().and_then(|config| config.basic_auth.clone()) {
+                let encoded_credentials = format!("Basic {}", base64::prelude::BASE64_STANDARD.encode(format!("{username}:{password}")));
+                if let Some(auth_header) = req.headers().get("Authorization") {
+                    if auth_header.to_str().unwrap() == encoded_credentials {
+                        return srv.call(req);
+                    }
+                }
+                return Box::pin(future::ready(Ok(ServiceResponse::new(
+                    req.request().clone(),
+                    HttpResponse::Unauthorized().finish(),
+                ))))
+            }
+            srv.call(req)
+        })
+        .to(serve_swagger_ui);
 
         HttpServiceFactory::register(swagger_resource, config);
     }
@@ -62,5 +80,38 @@ async fn serve_swagger_ui(path: web::Path<String>, data: web::Data<Config<'_>>) 
             })
             .unwrap_or_else(|| HttpResponse::NotFound().finish()),
         Err(error) => HttpResponse::InternalServerError().body(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use actix_web::{http::StatusCode, test, App};
+    use base64::prelude::BASE64_STANDARD;
+
+    use super::*;
+    #[actix_web::test]
+    async fn mount_onto_path_with_slash() {
+        let swagger_ui = SwaggerUi::new("/swagger-ui/{_:.*}");
+
+        let app = test::init_service(App::new().service(swagger_ui)).await;
+        let req = test::TestRequest::get().uri("/swagger-ui/").to_request();
+        let resp = test::call_service(&app, req).await;
+
+        assert!(resp.status().is_success());
+    }
+    
+    #[actix_web::test]
+    async fn basic_auth() {
+        let swagger_ui = SwaggerUi::new("/swagger-ui/{_:.*}")
+            .config(Config::default().basic_auth(BasicAuth { username: "admin".to_string(), password: "password".to_string() }));
+
+        let app = test::init_service(App::new().service(swagger_ui)).await;
+        let req = test::TestRequest::get().uri("/swagger-ui/").to_request();
+        let resp = test::call_service(&app, req).await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let encoded_credentials = BASE64_STANDARD.encode("admin:password");
+        let req = test::TestRequest::get().uri("/swagger-ui/").insert_header(("Authorization", format!("Basic {}", encoded_credentials))).to_request();
+        let resp = test::call_service(&app, req).await;
+        assert!(resp.status().is_success());
     }
 }

--- a/utoipa-swagger-ui/src/actix.rs
+++ b/utoipa-swagger-ui/src/actix.rs
@@ -57,7 +57,9 @@ impl HttpServiceFactory for SwaggerUi {
                     }
                     return Box::pin(future::ready(Ok(ServiceResponse::new(
                         req.request().clone(),
-                        HttpResponse::Unauthorized().finish(),
+                        HttpResponse::Unauthorized()
+                            .insert_header(("WWW-Authenticate", "Basic realm=\":\""))
+                            .finish(),
                     ))));
                 }
                 srv.call(req)

--- a/utoipa-swagger-ui/src/axum.rs
+++ b/utoipa-swagger-ui/src/axum.rs
@@ -3,10 +3,11 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::Path, http::StatusCode, response::IntoResponse, routing, Extension, Json, Router,
+    body::Body, extract::Path, http::{HeaderMap, Request, Response, StatusCode}, middleware::{self, Next}, response::IntoResponse, routing, Extension, Json, Router
 };
+use base64::{prelude::BASE64_STANDARD, Engine};
 
-use crate::{ApiDoc, Config, SwaggerUi, Url};
+use crate::{ApiDoc, BasicAuth, Config, SwaggerUi, Url};
 
 impl<S> From<SwaggerUi> for Router<S>
 where
@@ -42,10 +43,10 @@ where
             Config::new(urls)
         };
 
-        let handler = routing::get(serve_swagger_ui).layer(Extension(Arc::new(config)));
+        let handler = routing::get(serve_swagger_ui).layer(Extension(Arc::new(config.clone())));
         let path: &str = swagger_ui.path.as_ref();
 
-        if path == "/" {
+        let mut router = if path == "/" {
             router
                 .route(path, handler.clone())
                 .route(&format!("{}*rest", path), handler)
@@ -65,7 +66,30 @@ where
                 )
                 .route(&format!("{}/", path), handler.clone())
                 .route(&format!("{}/*rest", path), handler)
+        };
+
+        if let Some(BasicAuth {username, password}) = config.basic_auth {
+            let username = Arc::new(username);
+            let password = Arc::new(password);
+            let basic_auth_middleware = move |headers: HeaderMap, req: Request<Body>, next: Next| {
+                let username = username.clone();
+                let password = password.clone();
+                async move {
+                    if let Some(header) = headers.get("Authorization") {
+                        if let Ok(header_str) = header.to_str() {
+                            let base64_encoded_credentials = BASE64_STANDARD.encode(format!("{}:{}", &username, &password));
+                            if header_str == format!("Basic {}", base64_encoded_credentials) {
+                                return Ok::<Response<Body>, StatusCode>(next.run(req).await);
+                            }
+                        }
+                    }
+                    Ok::<Response<Body>, StatusCode>((StatusCode::UNAUTHORIZED, [("WWW-Authenticate", "Basic realm=\":\"")]).into_response())
+                }
+            };
+            router = router.layer(middleware::from_fn(basic_auth_middleware));
         }
+
+        router
     }
 }
 
@@ -150,6 +174,23 @@ mod tests {
         let response = server.get("/swagger-ui/").await;
         response.assert_status_ok();
         let response = server.get("/swagger-ui/swagger-ui.css").await;
+        response.assert_status_ok();
+    }
+
+    #[tokio::test]
+    async fn basic_auth() {
+        let swagger_ui = SwaggerUi::new("/swagger-ui")
+            .config(Config::default().basic_auth(BasicAuth { username: "admin".to_string(), password: "password".to_string() }));
+        let app = Router::<()>::from(swagger_ui);
+        let server = TestServer::new(app).unwrap();
+        let response = server.get("/swagger-ui").await;
+        response.assert_status_unauthorized();
+        let encoded_credentials = BASE64_STANDARD.encode("admin:password");
+        let response = server.get("/swagger-ui").authorization(format!("Basic {}", encoded_credentials)).await;
+        response.assert_status_see_other();
+        let response = server.get("/swagger-ui/").authorization(format!("Basic {}", encoded_credentials)).await;
+        response.assert_status_ok();
+        let response = server.get("/swagger-ui/swagger-ui.css").authorization(format!("Basic {}", encoded_credentials)).await;
         response.assert_status_ok();
     }
 }

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -1345,6 +1345,7 @@ impl From<String> for Config<'_> {
 /// Swagger UI can be restricted behind given basic authentication. 
 #[derive(Serialize, Clone)]
 pub struct BasicAuth {
+    /// Username for the `BasicAuth`
     pub username: String,
     pub password: String,
 }

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -1347,6 +1347,7 @@ impl From<String> for Config<'_> {
 pub struct BasicAuth {
     /// Username for the `BasicAuth`
     pub username: String,
+    /// Password of the _`username`_ for the `BasicAuth`
     pub password: String,
 }
 

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -1341,6 +1341,8 @@ impl From<String> for Config<'_> {
     }
 }
 
+/// Basic auth options for Swagger UI. By providing `BasicAuth` to `Config::basic_auth` the access to the
+/// Swagger UI can be restricted behind given basic authentication. 
 #[derive(Serialize, Clone)]
 pub struct BasicAuth {
     pub username: String,

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -669,6 +669,10 @@ pub struct Config<'a> {
 
     /// The layout of Swagger UI uses, default is `"StandaloneLayout"`.
     layout: &'a str,
+
+    /// Basic authentication configuration. If configured, the Swagger UI will prompt for basic auth credentials.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    basic_auth: Option<BasicAuth>,
 }
 
 impl<'a> Config<'a> {
@@ -1268,6 +1272,25 @@ impl<'a> Config<'a> {
 
         self
     }
+
+    /// Set basic authentication configuration.
+    /// If configured, the Swagger UI will prompt for basic auth credentials.
+    /// username and password are required. "{username}:{password}" will be base64 encoded and added to the "Authorization" header.
+    /// If not provided or wrong credentials are provided, the user will be prompted again.
+    /// # Examples
+    ///
+    /// Configure basic authentication.
+    /// ```rust
+    /// # use utoipa_swagger_ui::Config;
+    /// # use utoipa_swagger_ui::BasicAuth;
+    /// let config = Config::new(["/api-docs/openapi.json"])
+    ///     .basic_auth(BasicAuth { username: "admin".to_string(), password: "password".to_string() });
+    /// ```
+    pub fn basic_auth(mut self, basic_auth: BasicAuth) -> Self {
+        self.basic_auth = Some(basic_auth);
+
+        self
+    }
 }
 
 impl Default for Config<'_> {
@@ -1301,6 +1324,7 @@ impl Default for Config<'_> {
             oauth: Default::default(),
             syntax_highlight: Default::default(),
             layout: SWAGGER_STANDALONE_LAYOUT,
+            basic_auth: Default::default(),
         }
     }
 }
@@ -1315,6 +1339,12 @@ impl From<String> for Config<'_> {
     fn from(s: String) -> Self {
         Self::new([s])
     }
+}
+
+#[derive(Serialize, Clone)]
+pub struct BasicAuth {
+    pub username: String,
+    pub password: String,
 }
 
 /// Represents settings related to syntax highlighting of payloads and

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -1342,7 +1342,7 @@ impl From<String> for Config<'_> {
 }
 
 /// Basic auth options for Swagger UI. By providing `BasicAuth` to `Config::basic_auth` the access to the
-/// Swagger UI can be restricted behind given basic authentication. 
+/// Swagger UI can be restricted behind given basic authentication.
 #[derive(Serialize, Clone)]
 pub struct BasicAuth {
     /// Username for the `BasicAuth`


### PR DESCRIPTION
Add a basic auth config to SwaggerUI struct. In case we'd like to protect it by username and password.
 add the support for Axum, Actix and Rocket.