### PR TITLE
utoipa-axum: Allow trailing comma in `routes!()` macro

### DIFF
--- a/utoipa-axum/CHANGELOG.md
+++ b/utoipa-axum/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+* Allow trailing comma in `routes!()` macro (https://github.com/juhaku/utoipa/pull/1238)
+
 ### Fixed
 
 * Fix axum path nesting (https://github.com/juhaku/utoipa/pull/1231)

--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -123,7 +123,7 @@ pub use paste::paste;
 /// ```
 #[macro_export]
 macro_rules! routes {
-    ( $handler:path $(, $tail:path)* ) => {
+    ( $handler:path $(, $tail:path)* $(,)? ) => {
         {
             use $crate::PathItemExt;
             let mut paths = utoipa::openapi::path::Paths::new();
@@ -250,6 +250,12 @@ mod tests {
             .route("/", axum::routing::get(root));
 
         let _ = router.get_openapi();
+    }
+
+    #[test]
+    fn routes_with_trailing_comma_compiles() {
+        let _: OpenApiRouter =
+            OpenApiRouter::new().routes(routes!(get_user, post_user, delete_user,));
     }
 
     #[test]


### PR DESCRIPTION
Once the `routes!()` invocation contains more than a couple of routes, it is likely that each route will be on its own line. Currently, the macro does not support trailing commas, which causes the git diff when adding a new route to be unnecessarily large. With this change trailing commas are supported, which shrinks the diff down to a single-line change.