### PR TITLE
Add support for `#[schema(pattern = "...")]` on new type structs

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 * `Info::from_env()` sets `License::identifier` (https://github.com/juhaku/utoipa/pull/1233)
 
+### Added
+
+* Add support for `#[schema(pattern = "...")]` on new type structs (https://github.com/juhaku/utoipa/pull/{PR_NUMBER})
+
 ## 5.2.0 - Nov 2024
 
 ### Fixed

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Added
 
-* Add support for `#[schema(pattern = "...")]` on new type structs (https://github.com/juhaku/utoipa/pull/{PR_NUMBER})
+* Add support for `#[schema(pattern = "...")]` on new type structs (https://github.com/juhaku/utoipa/pull/1241)
 
 ## 5.2.0 - Nov 2024
 

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -9,7 +9,10 @@ use syn::{
 
 use crate::{
     as_tokens_or_diagnostics,
-    component::features::attributes::{Rename, Title, ValueType},
+    component::features::{
+        attributes::{Rename, Title, ValueType},
+        validation::Pattern,
+    },
     doc_comment::CommentAttributes,
     parse_utils::LitBoolOrExprPath,
     Array, AttributesExt, Diagnostics, OptionExt, ToTokensDiagnostics,
@@ -741,6 +744,20 @@ impl UnnamedStructSchema {
                     ));
                 }
             }
+            let pattern = if let Some(pattern) =
+                pop_feature!(features => Feature::Pattern(_) as Option<Pattern>)
+            {
+                // Pattern Attribute is only allowed for unnamed structs with single field
+                if fields_len > 1 {
+                    return Err(Diagnostics::with_span(
+                        root.ident.span(),
+                        "Pattern attribute is not allowed for unnamed structs with multiple fields",
+                    ));
+                }
+                Some(pattern.to_token_stream())
+            } else {
+                None
+            };
 
             let comments = CommentAttributes::from_attributes(root.attributes);
             let description = description
@@ -763,6 +780,11 @@ impl UnnamedStructSchema {
             })?;
 
             tokens.extend(schema.to_token_stream());
+            if let Some(pattern) = pattern {
+                tokens.extend(quote! {
+                    .pattern(Some(#pattern))
+                });
+            }
             schema_references = std::mem::take(&mut schema.schema_references);
         } else {
             // Struct that has multiple unnamed fields is serialized to array by default with serde.

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -750,7 +750,7 @@ impl UnnamedStructSchema {
                 // Pattern Attribute is only allowed for unnamed structs with single field
                 if fields_len > 1 {
                     return Err(Diagnostics::with_span(
-                        root.ident.span(),
+                        pattern.span(),
                         "Pattern attribute is not allowed for unnamed structs with multiple fields",
                     ));
                 }

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -64,7 +64,8 @@ impl Parse for UnnamedFieldStructFeatures {
             ContentEncoding,
             ContentMediaType,
             Bound,
-            NoRecursion
+            NoRecursion,
+            Pattern
         )))
     }
 }

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -6127,3 +6127,23 @@ fn test_named_and_enum_container_recursion_compiles() {
         .expect("OpenApi is JSON serializable");
     println!("{json}")
 }
+
+#[test]
+fn test_new_type_struct_pattern() {
+    #![allow(unused)]
+    #[derive(ToSchema)]
+    #[schema(pattern = r#"^([a-zA-Z0-9_\-]{3,32}$)"#)]
+    struct Username(String);
+
+    use utoipa::PartialSchema;
+    let schema = <Username as PartialSchema>::schema();
+    let value = serde_json::to_value(schema).expect("schema is JSON serializable");
+
+    assert_json_eq! {
+        value,
+        json!({
+            "pattern": r#"^([a-zA-Z0-9_\-]{3,32}$)"#,
+            "type": "string"
+        })
+    }
+}


### PR DESCRIPTION
This adds pattern for new type structs

Forgot about this issue I had a busy semester.
Closes #1150
