### PR TITLE
Use a re-exported serde_json dependency in macros

### DIFF
--- a/examples/actix-web-multiple-api-docs-with-scopes/Cargo.toml
+++ b/examples/actix-web-multiple-api-docs-with-scopes/Cargo.toml
@@ -13,7 +13,6 @@ authors = [
 [dependencies]
 actix-web = "4"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 env_logger = "0.11.0"
 log = "0.4"
 futures = "0.3"

--- a/examples/actix-web-scopes-binding/Cargo.toml
+++ b/examples/actix-web-scopes-binding/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 actix-web = "4"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 env_logger = "0.11.0"
 log = "0.4"
 futures = "0.3"

--- a/examples/axum-multipart/Cargo.toml
+++ b/examples/axum-multipart/Cargo.toml
@@ -11,6 +11,5 @@ utoipa = { version = "5", features = ["axum_extras"] }
 utoipa-swagger-ui = { version = "8", features = ["axum"] }
 utoipa-axum = "0.1"
 serde = { features = ["derive"], version = "1" }
-serde_json = "1"
 
 [workspace]

--- a/examples/axum-utoipa-bindings/Cargo.toml
+++ b/examples/axum-utoipa-bindings/Cargo.toml
@@ -11,6 +11,5 @@ utoipa = { path = "../../utoipa", features = ["axum_extras", "debug"] }
 utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["axum"] }
 utoipa-axum = { path = "../../utoipa-axum" ,features = ["debug"] }
 serde = "1"
-serde_json = "1"
 
 [workspace]

--- a/examples/axum-utoipa-nesting-vendored/Cargo.toml
+++ b/examples/axum-utoipa-nesting-vendored/Cargo.toml
@@ -15,7 +15,6 @@ tower = "0.5"
 utoipa = { path = "../../utoipa", features = ["axum_extras"] }
 utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["axum", "vendored"], default-features = false }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 env_logger = "0.11"
 log = "0.4"
 

--- a/examples/generics-actix/Cargo.toml
+++ b/examples/generics-actix/Cargo.toml
@@ -15,7 +15,6 @@ actix-web = "4"
 env_logger = "0.10.0"
 geo-types = { version = "0.7", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 utoipa = { path = "../../utoipa", features = ["actix_extras", "non_strict_integers"] }
 utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["actix-web"] }
 

--- a/examples/todo-actix/Cargo.toml
+++ b/examples/todo-actix/Cargo.toml
@@ -11,7 +11,6 @@ authors = ["Example <example@example.com>"]
 [dependencies]
 actix-web = "4"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 env_logger = "0.11"
 log = "0.4"
 futures = "0.3"

--- a/examples/todo-axum/Cargo.toml
+++ b/examples/todo-axum/Cargo.toml
@@ -20,6 +20,5 @@ utoipa-redoc = { path = "../../utoipa-redoc", features = ["axum"] }
 utoipa-rapidoc = { path = "../../utoipa-rapidoc", features = ["axum"] }
 utoipa-scalar = { path = "../../utoipa-scalar", features = ["axum"] }
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 
 [workspace]

--- a/examples/todo-warp-rapidoc/Cargo.toml
+++ b/examples/todo-warp-rapidoc/Cargo.toml
@@ -12,7 +12,6 @@ authors = [
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 env_logger = "0.11.0"
 log = "0.4"
 futures = "0.3"

--- a/examples/todo-warp-redoc-with-file-config/Cargo.toml
+++ b/examples/todo-warp-redoc-with-file-config/Cargo.toml
@@ -12,7 +12,6 @@ authors = ["Elli Example <example@example.com>"]
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 env_logger = "0.11.0"
 log = "0.4"
 futures = "0.3"

--- a/examples/todo-warp/Cargo.toml
+++ b/examples/todo-warp/Cargo.toml
@@ -14,7 +14,6 @@ authors = [
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 env_logger = "0.11.0"
 log = "0.4"
 futures = "0.3"

--- a/examples/warp-multiple-api-docs/Cargo.toml
+++ b/examples/warp-multiple-api-docs/Cargo.toml
@@ -14,7 +14,6 @@ authors = [
 tokio = { version = "1", features = ["full"] }
 warp = "0.3"
 serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
 env_logger = "0.10.0"
 log = "0.4"
 futures = "0.3"

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -2,16 +2,14 @@
 
 ## Unreleased
 
-### Changed
-
-* Simplified `ToTokensDiagnostics` for `request_body` (https://github.com/juhaku/utoipa/pull/1235)
-
 ### Fixed
 
 * Fix tagged enum with flatten fields (https://github.com/juhaku/utoipa/pull/1208)
 
 ### Changed
 
+* Use a re-exported `serde_json` dependency in macros instead of implicitly requiring it as dependency in end projects (https://github.com/juhaku/utoipa/pull/1243)
+* Simplified `ToTokensDiagnostics` for `request_body` (https://github.com/juhaku/utoipa/pull/1235)
 * `Info::from_env()` sets `License::identifier` (https://github.com/juhaku/utoipa/pull/1233)
 
 ### Added

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -281,7 +281,7 @@ impl UnitStructVariant {
         let mut tokens = quote! {
             utoipa::openapi::Object::builder()
                 .schema_type(utoipa::openapi::schema::SchemaType::AnyValue)
-                .default(Some(serde_json::Value::Null))
+                .default(Some(utoipa::gen::serde_json::Value::Null))
         };
 
         let mut features = features::parse_schema_features_with(root.attributes, |input| {

--- a/utoipa-gen/src/component/schema/enums.rs
+++ b/utoipa-gen/src/component/schema/enums.rs
@@ -774,7 +774,7 @@ where
             tokens.extend(quote! {
                 utoipa::openapi::schema::Object::builder()
                     .schema_type(utoipa::openapi::schema::Type::Null)
-                    .default(Some(serde_json::Value::Null))
+                    .default(Some(utoipa::gen::serde_json::Value::Null))
             })
         }
 

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -3341,14 +3341,14 @@ impl ToTokens for AnyValue {
     fn to_tokens(&self, tokens: &mut TokenStream2) {
         match self {
             Self::Json(json) => tokens.extend(quote! {
-                serde_json::json!(#json)
+                utoipa::gen::serde_json::json!(#json)
             }),
             Self::String(string) => string.to_tokens(tokens),
             Self::DefaultTrait {
                 struct_ident,
                 field_ident,
             } => tokens.extend(quote! {
-                serde_json::to_value(#struct_ident::default().#field_ident).unwrap()
+                utoipa::gen::serde_json::to_value(#struct_ident::default().#field_ident).unwrap()
             }),
         }
     }

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -9,6 +9,10 @@ to look into changes introduced to **`utoipa-gen`**.
 
 * Fix diverging axum route and openapi spec (https://github.com/juhaku/utoipa/pull/1199)
 
+### Changed
+
+* Use a re-exported `serde_json` dependency in macros instead of implicitly requiring it as dependency in end projects (https://github.com/juhaku/utoipa/pull/1243)
+
 ## 5.2.0 - Nov 2024
 
 ### Changed

--- a/utoipa/src/gen.rs
+++ b/utoipa/src/gen.rs
@@ -1,0 +1,1 @@
+pub use serde_json;

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -234,6 +234,12 @@
 
 pub mod openapi;
 
+#[cfg(feature = "macros")]
+#[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
+#[doc(hidden)]
+/// Public re-exports for utoipa-gen.
+pub mod gen;
+
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::option::Option;


### PR DESCRIPTION
Hello, here is a proposal to avoid shadow-depending on `serde_json` when using derives.

Fixes #1172