### PR TITLE
utopia-gen: Use `insta` for snapshot testing

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 
+* Use `insta` for snapshot testing (https://github.com/juhaku/utoipa/pull/1247)
 * Make `parse_named_attributes` a method of `MediaTypeAttr` (https://github.com/juhaku/utoipa/pull/1236)
 * Use a re-exported `serde_json` dependency in macros instead of implicitly requiring it as dependency in end projects (https://github.com/juhaku/utoipa/pull/1243)
 * Simplified `ToTokensDiagnostics` for `request_body` (https://github.com/juhaku/utoipa/pull/1235)

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -45,6 +45,7 @@ chrono = { version = "0.4", features = ["serde"] }
 assert-json-diff = "2"
 time = { version = "0.3", features = ["serde-human-readable"] }
 serde_with = "3.0"
+insta = { version = "1.41", features = ["json"] }
 
 [features]
 # See README.md for list and explanations of features

--- a/utoipa-gen/tests/openapi_derive.rs
+++ b/utoipa-gen/tests/openapi_derive.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, marker::PhantomData};
 
 use assert_json_diff::{assert_json_eq, assert_json_include};
+use insta::assert_json_snapshot;
 use serde::Serialize;
 use serde_json::{json, Value};
 use utoipa::{
@@ -686,12 +687,8 @@ fn openapi_schemas_resolve_schema_references() {
 
     let value = serde_json::to_value(&doc).expect("OpenAPI is JSON serializable");
     let schemas = value.pointer("/components").unwrap();
-    let json = serde_json::to_string_pretty(&schemas).expect("OpenAPI is json serializable");
-    println!("{json}");
 
-    let expected =
-        include_str!("./testdata/openapi_schemas_resolve_inner_schema_references").trim();
-    assert_eq!(expected, json.trim());
+    assert_json_snapshot!(schemas);
 }
 
 #[test]

--- a/utoipa-gen/tests/schema_generics.rs
+++ b/utoipa-gen/tests/schema_generics.rs
@@ -1,9 +1,8 @@
 use std::borrow::Cow;
 use std::marker::PhantomData;
 
-use assert_json_diff::assert_json_eq;
+use insta::assert_json_snapshot;
 use serde::Serialize;
-use serde_json::json;
 use utoipa::openapi::{Info, RefOr, Schema};
 use utoipa::{schema, OpenApi, PartialSchema, ToSchema};
 
@@ -66,89 +65,7 @@ fn generic_request_body_schema() {
     let mut doc = ApiDoc::openapi();
     doc.info = Info::new("title", "version");
 
-    let actual = serde_json::to_value(&doc).expect("operation is JSON serializable");
-    let json = serde_json::to_string_pretty(&actual).unwrap();
-
-    println!("{json}");
-
-    assert_json_eq!(
-        actual,
-        json!({
-            "openapi": "3.1.0",
-            "info": {
-                "title": "title",
-                "version": "version"
-            },
-            "paths": {
-                "/handler": {
-                    "get": {
-                        "tags": [],
-                        "operationId": "handler",
-                        "requestBody": {
-                            "content": {
-                                "application/json": {
-                                    "schema": {
-                                        "type": "object",
-                                        "required": [
-                                            "field",
-                                            "t"
-                                        ],
-                                        "properties": {
-                                            "field": {
-                                                "type": "string"
-                                            },
-                                            "t": {
-                                                "type": "object",
-                                                "required": [
-                                                    "t"
-                                                ],
-                                                "properties": {
-                                                    "t": {
-                                                        "type": "integer",
-                                                        "format": "int32"
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "required": true
-                        },
-                        "responses": {}
-                    }
-                }
-            },
-            "components": {
-                "schemas": {
-                    "Person_String_path.MyType_i32": {
-                        "type": "object",
-                        "required": [
-                            "field",
-                            "t"
-                        ],
-                        "properties": {
-                            "field": {
-                                "type": "string"
-                            },
-                            "t": {
-                                "type": "object",
-                                "required": [
-                                    "t"
-                                ],
-                                "properties": {
-                                    "t": {
-                                        "type": "integer",
-                                        "format": "int32"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        })
-    );
+    assert_json_snapshot!(doc);
 }
 
 #[test]
@@ -217,11 +134,7 @@ fn generic_schema_full_api() {
     let mut doc = ApiDoc::openapi();
     doc.info = Info::new("title", "version");
 
-    let actual = doc.to_pretty_json().expect("OpenApi is JSON serializable");
-    println!("{actual}");
-    let expected = include_str!("./testdata/schema_generics_openapi");
-
-    assert_eq!(expected.trim(), actual.trim());
+    assert_json_snapshot!(doc);
 }
 
 #[test]
@@ -251,11 +164,7 @@ fn schema_with_non_generic_root() {
     let mut api = ApiDoc::openapi();
     api.info = Info::new("title", "version");
 
-    let actual = api.to_pretty_json().expect("schema is JSON serializable");
-    println!("{actual}");
-    let expected = include_str!("./testdata/schema_non_generic_root_generic_references");
-
-    assert_eq!(actual.trim(), expected.trim())
+    assert_json_snapshot!(api);
 }
 
 #[test]
@@ -289,10 +198,8 @@ fn derive_generic_schema_enum_variants() {
 
     let mut api = Api::openapi();
     api.info = Info::new("title", "version");
-    let api_json = api.to_pretty_json().expect("OpenAPI is JSON serializable");
-    println!("{api_json}");
-    let expected = include_str!("./testdata/schema_generic_enum_variant_with_generic_type");
-    assert_eq!(expected.trim(), api_json.trim());
+
+    assert_json_snapshot!(api);
 }
 
 #[test]
@@ -348,10 +255,8 @@ fn derive_generic_schema_collect_recursive_schema_not_inlined() {
 
     let mut api = Api::openapi();
     api.info = Info::new("title", "version");
-    let api_json = api.to_pretty_json().expect("OpenAPI is JSON serializable");
-    println!("{api_json}");
-    let expected = include_str!("./testdata/schema_generic_collect_non_inlined_schema");
-    assert_eq!(expected.trim(), api_json.trim());
+
+    assert_json_snapshot!(api);
 }
 
 #[test]
@@ -381,10 +286,8 @@ fn high_order_types() {
 
     let mut api = Api::openapi();
     api.info = Info::new("title", "version");
-    let api_json = api.to_pretty_json().expect("OpenAPI is JSON serializable");
-    println!("{api_json}");
-    let expected = include_str!("./testdata/schema_high_order_types");
-    assert_eq!(expected.trim(), api_json.trim());
+
+    assert_json_snapshot!(api);
 }
 
 #[test]
@@ -409,11 +312,8 @@ fn rc_schema_high_order_types() {
 
     let mut api = Api::openapi();
     api.info = Info::new("title", "version");
-    let api_json = api.to_pretty_json().expect("OpenAPI is JSON serializable");
-    println!("{api_json}");
 
-    let expected = include_str!("./testdata/rc_schema_high_order_types");
-    assert_eq!(expected.trim(), api_json.trim());
+    assert_json_snapshot!(api);
 }
 
 #[test]
@@ -435,11 +335,8 @@ fn uuid_type_generic_argument() {
 
     let mut api = Api::openapi();
     api.info = Info::new("title", "version");
-    let api_json = api.to_pretty_json().expect("OpenAPI is JSON serializable");
-    println!("{api_json}");
 
-    let expected = include_str!("./testdata/uuid_type_generic_argument");
-    assert_eq!(expected.trim(), api_json.trim());
+    assert_json_snapshot!(api);
 }
 
 #[test]

--- a/utoipa-gen/tests/snapshots/openapi_derive__openapi_schemas_resolve_schema_references.snap
+++ b/utoipa-gen/tests/snapshots/openapi_derive__openapi_schemas_resolve_schema_references.snap
@@ -1,3 +1,8 @@
+---
+source: utoipa-gen/tests/openapi_derive.rs
+expression: schemas
+snapshot_kind: text
+---
 {
   "schemas": {
     "Account": {

--- a/utoipa-gen/tests/snapshots/schema_generics__derive_generic_schema_collect_recursive_schema_not_inlined.snap
+++ b/utoipa-gen/tests/snapshots/schema_generics__derive_generic_schema_collect_recursive_schema_not_inlined.snap
@@ -1,3 +1,8 @@
+---
+source: utoipa-gen/tests/schema_generics.rs
+expression: api
+snapshot_kind: text
+---
 {
   "openapi": "3.1.0",
   "info": {

--- a/utoipa-gen/tests/snapshots/schema_generics__derive_generic_schema_enum_variants.snap
+++ b/utoipa-gen/tests/snapshots/schema_generics__derive_generic_schema_enum_variants.snap
@@ -1,3 +1,8 @@
+---
+source: utoipa-gen/tests/schema_generics.rs
+expression: api
+snapshot_kind: text
+---
 {
   "openapi": "3.1.0",
   "info": {

--- a/utoipa-gen/tests/snapshots/schema_generics__generic_request_body_schema.snap
+++ b/utoipa-gen/tests/snapshots/schema_generics__generic_request_body_schema.snap
@@ -1,0 +1,80 @@
+---
+source: utoipa-gen/tests/schema_generics.rs
+expression: doc
+snapshot_kind: text
+---
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "title",
+    "version": "version"
+  },
+  "paths": {
+    "/handler": {
+      "get": {
+        "tags": [],
+        "operationId": "handler",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "field",
+                  "t"
+                ],
+                "properties": {
+                  "field": {
+                    "type": "string"
+                  },
+                  "t": {
+                    "type": "object",
+                    "required": [
+                      "t"
+                    ],
+                    "properties": {
+                      "t": {
+                        "type": "integer",
+                        "format": "int32"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {}
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Person_String_path.MyType_i32": {
+        "type": "object",
+        "required": [
+          "field",
+          "t"
+        ],
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "t": {
+            "type": "object",
+            "required": [
+              "t"
+            ],
+            "properties": {
+              "t": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/utoipa-gen/tests/snapshots/schema_generics__generic_schema_full_api.snap
+++ b/utoipa-gen/tests/snapshots/schema_generics__generic_schema_full_api.snap
@@ -1,3 +1,8 @@
+---
+source: utoipa-gen/tests/schema_generics.rs
+expression: doc
+snapshot_kind: text
+---
 {
   "openapi": "3.1.0",
   "info": {

--- a/utoipa-gen/tests/snapshots/schema_generics__high_order_types.snap
+++ b/utoipa-gen/tests/snapshots/schema_generics__high_order_types.snap
@@ -1,3 +1,8 @@
+---
+source: utoipa-gen/tests/schema_generics.rs
+expression: api
+snapshot_kind: text
+---
 {
   "openapi": "3.1.0",
   "info": {

--- a/utoipa-gen/tests/snapshots/schema_generics__rc_schema_high_order_types.snap
+++ b/utoipa-gen/tests/snapshots/schema_generics__rc_schema_high_order_types.snap
@@ -1,3 +1,8 @@
+---
+source: utoipa-gen/tests/schema_generics.rs
+expression: api
+snapshot_kind: text
+---
 {
   "openapi": "3.1.0",
   "info": {

--- a/utoipa-gen/tests/snapshots/schema_generics__schema_with_non_generic_root.snap
+++ b/utoipa-gen/tests/snapshots/schema_generics__schema_with_non_generic_root.snap
@@ -1,3 +1,8 @@
+---
+source: utoipa-gen/tests/schema_generics.rs
+expression: api
+snapshot_kind: text
+---
 {
   "openapi": "3.1.0",
   "info": {

--- a/utoipa-gen/tests/snapshots/schema_generics__uuid_type_generic_argument.snap
+++ b/utoipa-gen/tests/snapshots/schema_generics__uuid_type_generic_argument.snap
@@ -1,3 +1,8 @@
+---
+source: utoipa-gen/tests/schema_generics.rs
+expression: api
+snapshot_kind: text
+---
 {
   "openapi": "3.1.0",
   "info": {


### PR DESCRIPTION
I saw in https://github.com/juhaku/utoipa/discussions/145 that snapshot testing had been considered in the past, but then `assert-json-diff` was used instead. This PR migrates a couple of the `utoipa-gen` tests to use `insta` instead of performing a basic string comparison.

`insta` produces diffs like below, which makes it much easier to see at first glance what changed. The `cargo-insta` extension also makes it very fast to update snapshots in case of any desired changes.

```
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
Snapshot file: utoipa-gen/tests/snapshots/schema_generics__generic_schema_full_api.snap
Snapshot: generic_schema_full_api
Source: utoipa-gen/tests/schema_generics.rs:221
────────────────────────────────────────────────────────────────────────────────
Expression: doc
────────────────────────────────────────────────────────────────────────────────
-old snapshot
+new results
────────────┬───────────────────────────────────────────────────────────────────
   64    64 │                     "items"
   65    65 │                   ],
   66    66 │                   "properties": {
   67    67 │                     "items": {
   68       │-                      "type": "object",
         68 │+                      "type": "array",
   69    69 │                       "items": {
   70    70 │                         "type": "object",
   71    71 │                         "required": [
   72    72 │                           "id",
────────────┴───────────────────────────────────────────────────────────────────
To update snapshots run `cargo insta review`
```

If this is considered useful we could potentially also migrate the other tests to use snapshots instead of `assert-json-diff`.