### PR TITLE
utopia-gen: Adjust params code to not set `nullable` on `Option` for `Query` params

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 
+* Adjust params code to not set `nullable` on `Option` for `Query` params (https://github.com/juhaku/utoipa/pull/1248)
 * Use `insta` for snapshot testing (https://github.com/juhaku/utoipa/pull/1247)
 * Make `parse_named_attributes` a method of `MediaTypeAttr` (https://github.com/juhaku/utoipa/pull/1236)
 * Use a re-exported `serde_json` dependency in macros instead of implicitly requiring it as dependency in end projects (https://github.com/juhaku/utoipa/pull/1243)

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -694,6 +694,18 @@ pub struct ComponentSchemaProps<'c> {
     pub description: Option<&'c ComponentDescription<'c>>,
 }
 
+impl ComponentSchemaProps<'_> {
+    fn set_nullable(&mut self) {
+        if !self
+            .features
+            .iter()
+            .any(|feature| matches!(feature, Feature::Nullable(_)))
+        {
+            self.features.push(Nullable::new().into());
+        }
+    }
+}
+
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub enum ComponentDescription<'c> {
     CommentAttributes(&'c CommentAttributes),

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -762,11 +762,33 @@ pub struct ComponentSchema {
 }
 
 impl ComponentSchema {
-    pub fn new(
+    pub fn for_params(
+        mut schema_props: ComponentSchemaProps,
+        option_is_nullable: bool,
+    ) -> Result<Self, Diagnostics> {
+        // Add nullable feature if not already exists.
+        // Option is always nullable, except when used in query parameters.
+        if schema_props.type_tree.is_option() && option_is_nullable {
+            schema_props.set_nullable()
+        }
+
+        Self::new_inner(schema_props)
+    }
+
+    pub fn new(mut schema_props: ComponentSchemaProps) -> Result<Self, Diagnostics> {
+        // Add nullable feature if not already exists. Option is always nullable
+        if schema_props.type_tree.is_option() {
+            schema_props.set_nullable();
+        }
+
+        Self::new_inner(schema_props)
+    }
+
+    fn new_inner(
         ComponentSchemaProps {
             container,
             type_tree,
-            mut features,
+            features,
             description,
         }: ComponentSchemaProps,
     ) -> Result<Self, Diagnostics> {
@@ -803,13 +825,6 @@ impl ComponentSchema {
                 description,
             )?,
             Some(GenericType::Option) => {
-                // Add nullable feature if not already exists. Option is always nullable
-                if !features
-                    .iter()
-                    .any(|feature| matches!(feature, Feature::Nullable(_)))
-                {
-                    features.push(Nullable::new().into());
-                }
                 let child = type_tree
                     .children
                     .as_ref()

--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -414,6 +414,12 @@ impl_feature! {
     pub struct ParameterIn(parameter::ParameterIn);
 }
 
+impl ParameterIn {
+    pub fn is_query(&self) -> bool {
+        matches!(self.0, parameter::ParameterIn::Query)
+    }
+}
+
 impl Parse for ParameterIn {
     fn parse(input: syn::parse::ParseStream, _: Ident) -> syn::Result<Self> {
         parse_utils::parse_next(input, || input.parse::<parameter::ParameterIn>().map(Self))

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -407,12 +407,18 @@ impl Param {
             });
             tokens.extend(param_features.to_token_stream()?);
 
-            let schema = ComponentSchema::new(component::ComponentSchemaProps {
-                type_tree: component,
-                features: schema_features,
-                description: None,
-                container: &Container { generics },
-            })?;
+            let is_query = matches!(container_attributes.parameter_in, Some(Feature::ParameterIn(p)) if p.is_query());
+            let option_is_nullable = !is_query;
+
+            let schema = ComponentSchema::for_params(
+                component::ComponentSchemaProps {
+                    type_tree: component,
+                    features: schema_features,
+                    description: None,
+                    container: &Container { generics },
+                },
+                option_is_nullable,
+            )?;
             let schema_tokens = schema.to_token_stream();
 
             tokens.extend(quote! { .schema(Some(#schema_tokens)).build() });

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -249,9 +249,7 @@ fn derive_path_with_extra_attributes_without_nested_module() {
         "parameters.[1].in" = r#""query""#, "Parameter 1 in"
         "parameters.[1].name" = r#""since""#, "Parameter 1 name"
         "parameters.[1].required" = r#"false"#, "Parameter 1 required"
-        "parameters.[1].schema.allOf.[0].format" = r#"null"#, "Parameter 1 schema format"
-        "parameters.[1].schema.allOf.[0].type" = r#"null"#, "Parameter 1 schema type"
-        "parameters.[1].schema.allOf.nullable" = r#"null"#, "Parameter 1 schema type"
+        "parameters.[1].schema.type" = r#""string""#, "Parameter 1 schema type"
     }
 }
 
@@ -477,14 +475,7 @@ fn derive_path_with_parameter_schema() {
                 "name": "since",
                 "required": false,
                 "schema": {
-                    "oneOf": [
-                        {
-                            "type": "null"
-                        },
-                        {
-                            "$ref": "#/components/schemas/Since"
-                        }
-                    ],
+                    "$ref": "#/components/schemas/Since"
                 }
             }
         ])
@@ -549,28 +540,21 @@ fn derive_path_with_parameter_inline_schema() {
                 "name": "since",
                 "required": false,
                 "schema": {
-                    "oneOf": [
-                        {
-                            "type": "null"
+                    "properties": {
+                        "date": {
+                            "description": "Some date",
+                            "type": "string"
                         },
-                        {
-                            "properties": {
-                                "date": {
-                                    "description": "Some date",
-                                    "type": "string"
-                                },
-                                "time": {
-                                    "description": "Some time",
-                                    "type": "string"
-                                }
-                            },
-                            "required": [
-                                "date",
-                                "time"
-                            ],
-                            "type": "object"
+                        "time": {
+                            "description": "Some time",
+                            "type": "string"
                         }
+                    },
+                    "required": [
+                        "date",
+                        "time"
                     ],
+                    "type": "object"
                 }
             }
         ])
@@ -831,7 +815,7 @@ fn derive_required_path_params() {
                 "name": "vec_default",
                 "required": false,
                 "schema": {
-                    "type": ["array", "null"],
+                    "type": "array",
                     "items": {
                         "type": "string"
                     }
@@ -842,7 +826,7 @@ fn derive_required_path_params() {
                 "name": "string_default",
                 "required": false,
                 "schema": {
-                    "type": ["string", "null"]
+                    "type": "string"
                 }
             },
             {
@@ -872,7 +856,7 @@ fn derive_required_path_params() {
                     "items": {
                         "type": "string"
                     },
-                    "type": ["array", "null"],
+                    "type": "array",
                 },
             },
             {
@@ -880,7 +864,7 @@ fn derive_required_path_params() {
                 "name": "string_option",
                 "required": false,
                 "schema": {
-                    "type": ["string", "null"]
+                    "type": "string"
                 }
             },
             {
@@ -938,7 +922,7 @@ fn derive_path_params_with_serde_and_custom_rename() {
                 "name": "vecDefault",
                 "required": false,
                 "schema": {
-                    "type": ["array", "null"],
+                    "type": "array",
                     "items": {
                         "type": "string"
                     }
@@ -949,7 +933,7 @@ fn derive_path_params_with_serde_and_custom_rename() {
                 "name": "STRING",
                 "required": false,
                 "schema": {
-                    "type": ["string", "null"]
+                    "type": "string"
                 }
             },
             {
@@ -1001,7 +985,7 @@ fn derive_path_params_custom_rename_all() {
                 "name": "vecDefault",
                 "required": false,
                 "schema": {
-                    "type": ["array", "null"],
+                    "type": "array",
                     "items": {
                         "type": "string"
                     }
@@ -1030,7 +1014,7 @@ fn derive_path_params_custom_rename_all_serde_will_override() {
                 "name": "VEC_DEFAULT",
                 "required": false,
                 "schema": {
-                    "type": ["array", "null"],
+                    "type": "array",
                     "items": {
                         "type": "string"
                     }
@@ -1163,7 +1147,7 @@ fn derive_path_params_intoparams() {
                 "name": "since",
                 "required": false,
                 "schema": {
-                    "type": ["string", "null"]
+                    "type": "string"
                 },
                 "style": "form"
             },
@@ -1196,17 +1180,10 @@ fn derive_path_params_intoparams() {
                 "name": "foo_inline_option",
                 "required": false,
                 "schema": {
-                    "oneOf": [
-                        {
-                            "type": "null",
-                        },
-                        {
-                            "default": "foo1",
-                            "example": "foo1",
-                            "enum": ["foo1", "foo2"],
-                            "type": "string",
-                        }
-                    ],
+                    "default": "foo1",
+                    "example": "foo1",
+                    "enum": ["foo1", "foo2"],
+                    "type": "string",
                 },
                 "style": "form"
             },
@@ -1343,7 +1320,7 @@ fn derive_path_params_into_params_with_value_type() {
             "name": "value3",
             "required": false,
             "schema": {
-                "type": ["string", "null"]
+                "type": "string"
             }
         },
         {
@@ -1351,7 +1328,7 @@ fn derive_path_params_into_params_with_value_type() {
             "name": "value4",
             "required": false,
             "schema": {
-                "type": ["object", "null"]
+                "type": "object"
             }
         },
         {
@@ -1776,7 +1753,7 @@ fn derive_into_params_required() {
               "name": "name2",
               "required": false,
               "schema": {
-                  "type": ["string", "null"],
+                  "type": "string",
               },
           },
           {
@@ -1784,7 +1761,7 @@ fn derive_into_params_required() {
               "name": "name3",
               "required": true,
               "schema": {
-                  "type": ["string", "null"],
+                  "type": "string",
               },
           },
         ])
@@ -1830,7 +1807,7 @@ fn derive_into_params_with_serde_skip() {
               "name": "name2",
               "required": false,
               "schema": {
-                  "type": ["string", "null"],
+                  "type": "string",
               },
           },
         ])
@@ -1878,7 +1855,7 @@ fn derive_into_params_with_serde_skip_deserializing() {
               "name": "name2",
               "required": false,
               "schema": {
-                  "type": ["string", "null"],
+                  "type": "string",
               },
           },
         ])
@@ -1924,7 +1901,7 @@ fn derive_into_params_with_serde_skip_serializing() {
               "name": "name2",
               "required": false,
               "schema": {
-                  "type": ["string", "null"],
+                  "type": "string",
               },
           },
         ])

--- a/utoipa-gen/tests/path_derive_axum_test.rs
+++ b/utoipa-gen/tests/path_derive_axum_test.rs
@@ -729,7 +729,7 @@ fn derive_path_with_validation_attributes_axum() {
             },
             {
                 "schema": {
-                    "type": ["string", "null"],
+                    "type": "string",
                     "minLength": 3,
                 },
                 "required": false,

--- a/utoipa-gen/tests/path_derive_rocket.rs
+++ b/utoipa-gen/tests/path_derive_rocket.rs
@@ -137,7 +137,7 @@ fn resolve_get_with_optional_query_args() {
                     "items": {
                         "type": "string",
                     },
-                    "type": ["array", "null"],
+                    "type": "array",
                 }
             }
         ])

--- a/utoipa-gen/tests/path_parameter_derive_test.rs
+++ b/utoipa-gen/tests/path_parameter_derive_test.rs
@@ -194,7 +194,7 @@ fn derive_parameters_with_all_types() {
         "[2].description" = r#""Foo numbers list""#, "Parameter description"
         "[2].required" = r#"false"#, "Parameter required"
         "[2].deprecated" = r#"null"#, "Parameter deprecated"
-        "[2].schema.type" = r#"["array","null"]"#, "Parameter schema type"
+        "[2].schema.type" = r#""array""#, "Parameter schema type"
         "[2].schema.format" = r#"null"#, "Parameter schema format"
         "[2].schema.items.type" = r#""integer""#, "Parameter schema items type"
         "[2].schema.items.format" = r#""int64""#, "Parameter schema items format"
@@ -286,7 +286,7 @@ fn derive_params_with_params_ext() {
         "[0].description" = r#""Foo value description""#, "Parameter description"
         "[0].required" = r#"false"#, "Parameter required"
         "[0].deprecated" = r#"true"#, "Parameter deprecated"
-        "[0].schema.type" = r#"["array","null"]"#, "Parameter schema type"
+        "[0].schema.type" = r#""array""#, "Parameter schema type"
         "[0].schema.items.type" = r#""string""#, "Parameter schema items type"
         "[0].style" = r#""form""#, "Parameter style"
         "[0].allowReserved" = r#"true"#, "Parameter allowReserved"
@@ -330,7 +330,7 @@ fn derive_path_params_with_parameter_type_args() {
                   "deprecated": true,
                   "description": "Foo value description",
                   "schema": {
-                      "type": ["array", "null"],
+                      "type": "array",
                       "items": {
                           "maxLength": 20,
                           "pattern": r"\w",
@@ -424,10 +424,7 @@ fn derive_into_params_required_custom_query_parameter_required() {
                 "schema": {
                     "format": "int32",
                     "minimum": 0,
-                    "type": [
-                        "integer",
-                        "null"
-                    ]
+                    "type": "integer"
                 }
             },
             {
@@ -439,10 +436,7 @@ fn derive_into_params_required_custom_query_parameter_required() {
                 "schema": {
                     "format": "int32",
                     "minimum": 0,
-                    "type": [
-                        "integer",
-                        "null"
-                    ]
+                    "type": "integer"
                 }
             }
         ])


### PR DESCRIPTION
This PR resolves https://github.com/juhaku/utoipa/issues/1215 by ensuring that `Option<_>` usage in `Query` params is not transformed into a nullable feature.

https://swagger.io/docs/specification/v3_0/describing-parameters/#default-parameter-values gives an example on how `required: false` query parameters are described and there is no `nullable: true` or `schema.type: null` in there, which indicates that `required: false` should be sufficient to describe an `Option<_>` type for query parameters.

(Potentially) Related:

- https://github.com/juhaku/utoipa/issues/1215
- https://github.com/juhaku/utoipa/pull/530
- https://github.com/juhaku/utoipa/issues/609
- https://github.com/juhaku/utoipa/issues/1058
- https://github.com/juhaku/utoipa/issues/622