### PR TITLE
Added mutable getter for the openapi instance of a OpenApiRouter

### DIFF
--- a/utoipa-axum/CHANGELOG.md
+++ b/utoipa-axum/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-axum
 
+## Unreleased
+
+### Changed
+
+* Added mutable getter for the openapi instance of a OpenApiRouter (https://github.com/juhaku/utoipa/pull/1262)
+
 ## 0.1.3 - Dec 19 2024
 
 ### Changed

--- a/utoipa-axum/src/router.rs
+++ b/utoipa-axum/src/router.rs
@@ -403,6 +403,11 @@ where
         &self.1
     }
 
+    /// Get mutable reference to the [`utoipa::openapi::OpenApi`] instance of the router.
+    pub fn get_openapi_mut(&mut self) -> &mut utoipa::openapi::OpenApi {
+        &mut self.1
+    }
+
     /// Split the content of the [`OpenApiRouter`] to parts. Method will return a tuple of
     /// inner [`axum::Router`] and [`utoipa::openapi::OpenApi`].
     pub fn split_for_parts(self) -> (axum::Router<S>, utoipa::openapi::OpenApi) {


### PR DESCRIPTION
There is currently no way of changing the `OpenApi` without breaking the router apart and recomposing it.

This enables modification of the API while mounting the routes.

I encountered this limitation while trying to build a router, and add a common security before nesting the router inside another. This will enable code like this:
```Rust
let mut router = OpenApiRouter::default()
    .routes(routes!(handler1))
    .routes(routes!(handler2));

RequireUserToken.modify(router.get_openapi_mut());

let outer_router = OpenApiRouter::default()
    .nest("/inner", router)
```