### PR TITLE
utoipa-axum: Add basic path params test

### DIFF
--- a/utoipa-axum/Cargo.toml
+++ b/utoipa-axum/Cargo.toml
@@ -26,7 +26,11 @@ paste = "1.0"
 [dev-dependencies]
 utoipa = { path = "../utoipa", features = ["debug"] }
 axum = { version = "0.7", default-features = false, features = ["json"] }
+http = "1.2"
+insta = { version = "1.41", features = ["json"] }
 serde = "1"
+tokio = { version = "1.42", features = ["macros", "rt"]}
+tower = "0.5"
 
 [package.metadata.docs.rs]
 features = []

--- a/utoipa-axum/src/snapshots/utoipa_axum__tests__axum_router.snap
+++ b/utoipa-axum/src/snapshots/utoipa_axum__tests__axum_router.snap
@@ -1,0 +1,34 @@
+---
+source: utoipa-axum/src/lib.rs
+expression: openapi
+snapshot_kind: text
+---
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "",
+    "version": ""
+  },
+  "paths": {
+    "/pet/{pet_id}": {
+      "get": {
+        "operationId": "get_pet_by_id",
+        "parameters": [
+          {
+            "name": "pet_id",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {}
+      }
+    }
+  },
+  "components": {}
+}


### PR DESCRIPTION
This ensures that `/pet/{petId}` is correctly turned into a path that `axum` understands.

Note that in axum 0.8 the path syntax will change to the same syntax that OpenAPI uses, so, once we update, this test will catch the issue. I have a work-in-progress branch for the update already.