### PR TITLE
Update axum to v0.8.0

### DIFF
--- a/examples/axum-multipart/Cargo.toml
+++ b/examples/axum-multipart/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { version = "0.7", features = ["multipart"] }
+axum = { version = "0.8.0", features = ["multipart"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
 utoipa = { version = "5", features = ["axum_extras"] }

--- a/examples/axum-multipart/Cargo.toml
+++ b/examples/axum-multipart/Cargo.toml
@@ -7,9 +7,9 @@ edition = "2021"
 axum = { version = "0.8.0", features = ["multipart"] }
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
-utoipa = { version = "5", features = ["axum_extras"] }
-utoipa-swagger-ui = { version = "8", features = ["axum"] }
-utoipa-axum = "0.1"
+utoipa = { path = "../../utoipa", features = ["axum_extras"] }
+utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["axum"] }
+utoipa-axum = { path = "../../utoipa-axum" }
 serde = { features = ["derive"], version = "1" }
 
 [workspace]

--- a/examples/axum-utoipa-bindings/Cargo.toml
+++ b/examples/axum-utoipa-bindings/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = "0.7"
+axum = "0.8.0"
 tokio = { version = "1", features = ["full"] }
 tower = "0.5"
 utoipa = { path = "../../utoipa", features = ["axum_extras", "debug"] }

--- a/examples/axum-utoipa-nesting-vendored/Cargo.toml
+++ b/examples/axum-utoipa-nesting-vendored/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Elli Example <example@example.com>"]
 
 
 [dependencies]
-axum = "0.7"
+axum = "0.8.0"
 hyper = { version = "1.0.1", features = ["full"] }
 tokio = { version = "1.17", features = ["full"] }
 tower = "0.5"

--- a/examples/simple-axum/Cargo.toml
+++ b/examples/simple-axum/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.7"
+axum = "0.8.0"
 tokio = { version = "1.17", features = ["full"] }
 utoipa = { path = "../../utoipa", features = ["axum_extras"] }
 

--- a/examples/todo-axum/Cargo.toml
+++ b/examples/todo-axum/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Elli Example <example@example.com>"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-axum = "0.7"
+axum = "0.8.0"
 hyper = { version = "1.0.1", features = ["full"] }
 tokio = { version = "1.17", features = ["full"] }
 tower = "0.5"

--- a/utoipa-axum/CHANGELOG.md
+++ b/utoipa-axum/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+* Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)
 * Added mutable getter for the openapi instance of a OpenApiRouter (https://github.com/juhaku/utoipa/pull/1262)
 * utoipa-axum: Add basic path params test (https://github.com/juhaku/utoipa/pull/1268)
 

--- a/utoipa-axum/Cargo.toml
+++ b/utoipa-axum/Cargo.toml
@@ -15,7 +15,7 @@ rust-version.workspace = true
 debug = []
 
 [dependencies]
-axum = { version = "0.7", default-features = false }
+axum = { version = "0.8.0", default-features = false }
 utoipa = { version = "5.0.0", path = "../utoipa", default-features = false, features = [
     "macros",
 ] }
@@ -25,7 +25,7 @@ paste = "1.0"
 
 [dev-dependencies]
 utoipa = { path = "../utoipa", features = ["debug"] }
-axum = { version = "0.7", default-features = false, features = ["json"] }
+axum = { version = "0.8.0", default-features = false, features = ["json"] }
 http = "1.2"
 insta = { version = "1.41", features = ["json"] }
 serde = "1"

--- a/utoipa-axum/src/router.rs
+++ b/utoipa-axum/src/router.rs
@@ -11,14 +11,6 @@ use tower_layer::Layer;
 use tower_service::Service;
 
 #[inline]
-fn colonized_params<S: AsRef<str>>(path: S) -> String
-where
-    String: From<S>,
-{
-    String::from(path).replace('}', "").replace('{', ":")
-}
-
-#[inline]
 fn path_template<S: AsRef<str>>(path: S) -> String {
     path.as_ref()
         .split('/')
@@ -245,11 +237,11 @@ where
             };
             let path = if path.is_empty() { "/" } else { path };
 
-            self.0.route(&colonized_params(path), method_router)
+            self.0.route(path, method_router)
         } else {
             paths.paths.iter().fold(self.0, |this, (path, _)| {
                 let path = if path.is_empty() { "/" } else { path };
-                this.route(&colonized_params(path), method_router.clone())
+                this.route(path, method_router.clone())
             })
         };
 
@@ -273,7 +265,7 @@ where
 
     /// Pass through method for [`axum::Router<S>::route`].
     pub fn route(self, path: &str, method_router: MethodRouter<S>) -> Self {
-        Self(self.0.route(&colonized_params(path), method_router), self.1)
+        Self(self.0.route(path, method_router), self.1)
     }
 
     /// Pass through method for [`axum::Router::route_layer`].
@@ -340,7 +332,7 @@ where
             router.1,
             path_for_nested_route,
         );
-        let router = self.0.nest(&colonized_params(path), router.0);
+        let router = self.0.nest(path, router.0);
 
         Self(router, api)
     }

--- a/utoipa-axum/src/router.rs
+++ b/utoipa-axum/src/router.rs
@@ -10,21 +10,6 @@ use axum::Router;
 use tower_layer::Layer;
 use tower_service::Service;
 
-#[inline]
-fn path_template<S: AsRef<str>>(path: S) -> String {
-    path.as_ref()
-        .split('/')
-        .map(|segment| {
-            if !segment.is_empty() && segment[0..1] == *":" {
-                Cow::Owned(format!("{{{}}}", &segment[1..]))
-            } else {
-                Cow::Borrowed(segment)
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("/")
-}
-
 /// Wrapper type for [`utoipa::openapi::path::Paths`] and [`axum::routing::MethodRouter`].
 ///
 /// This is used with [`OpenApiRouter::routes`] method to register current _`paths`_ to the
@@ -328,7 +313,7 @@ where
         }
 
         let api = self.1.nest_with_path_composer(
-            path_for_nested_route(&path_template(path), "/"),
+            path_for_nested_route(path, "/"),
             router.1,
             path_for_nested_route,
         );

--- a/utoipa-axum/src/router.rs
+++ b/utoipa-axum/src/router.rs
@@ -63,8 +63,8 @@ where
     /// routes.
     fn layer<L, NewError>(self, layer: L) -> UtoipaMethodRouter<S, NewError>
     where
-        L: Layer<Route<E>> + Clone + Send + 'static,
-        L::Service: Service<Request> + Clone + Send + 'static,
+        L: Layer<Route<E>> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request>>::Error: Into<NewError> + 'static,
         <L::Service as Service<Request>>::Future: Send + 'static,
@@ -103,8 +103,8 @@ where
 {
     fn layer<L, NewError>(self, layer: L) -> UtoipaMethodRouter<S, NewError>
     where
-        L: Layer<Route<E>> + Clone + Send + 'static,
-        L::Service: Service<Request> + Clone + Send + 'static,
+        L: Layer<Route<E>> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request>>::Error: Into<NewError> + 'static,
         <L::Service as Service<Request>>::Future: Send + 'static,
@@ -211,7 +211,7 @@ where
     /// Pass through method for [`axum::Router::fallback_service`].
     pub fn fallback_service<T>(self, service: T) -> Self
     where
-        T: Service<Request, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
@@ -221,8 +221,8 @@ where
     /// Pass through method for [`axum::Router::layer`].
     pub fn layer<L>(self, layer: L) -> Self
     where
-        L: Layer<Route> + Clone + Send + 'static,
-        L::Service: Service<Request> + Clone + Send + 'static,
+        L: Layer<Route> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request>>::Future: Send + 'static,
@@ -279,8 +279,8 @@ where
     /// Pass through method for [`axum::Router::route_layer`].
     pub fn route_layer<L>(self, layer: L) -> Self
     where
-        L: Layer<Route> + Clone + Send + 'static,
-        L::Service: Service<Request> + Clone + Send + 'static,
+        L: Layer<Route> + Clone + Send + Sync + 'static,
+        L::Service: Service<Request> + Clone + Send + Sync + 'static,
         <L::Service as Service<Request>>::Response: IntoResponse + 'static,
         <L::Service as Service<Request>>::Error: Into<Infallible> + 'static,
         <L::Service as Service<Request>>::Future: Send + 'static,
@@ -291,7 +291,7 @@ where
     /// Pass through method for [`axum::Router<S>::route_service`].
     pub fn route_service<T>(self, path: &str, service: T) -> Self
     where
-        T: Service<Request, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {
@@ -348,7 +348,7 @@ where
     /// Pass through method for [`axum::Router::nest_service`]. _**This does nothing for OpenApi paths.**_
     pub fn nest_service<T>(self, path: &str, service: T) -> Self
     where
-        T: Service<Request, Error = Infallible> + Clone + Send + 'static,
+        T: Service<Request, Error = Infallible> + Clone + Send + Sync + 'static,
         T::Response: IntoResponse,
         T::Future: Send + 'static,
     {

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+* Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)
 * Replace `assert-json-diff` with snapshot testing via `insta` (https://github.com/juhaku/utoipa/pull/1253)
 * scripts/test.sh: Fix `auto_into_responses` feature declaration (https://github.com/juhaku/utoipa/pull/1252)
 

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -33,7 +33,7 @@ utoipa = { path = "../utoipa", features = [
 serde_json = "1"
 serde = "1"
 actix-web = { version = "4", features = ["macros"], default-features = false }
-axum = { version = "0.7", default-features = false, features = [
+axum = { version = "0.8.0", default-features = false, features = [
     "json",
     "query",
 ] }

--- a/utoipa-rapidoc/CHANGELOG.md
+++ b/utoipa-rapidoc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-rapidoc
 
+## Unreleased
+
+### Changed
+
+* Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)
+
 ## 5.0.0 - Oct 14 2024
 
 ### Added

--- a/utoipa-rapidoc/Cargo.toml
+++ b/utoipa-rapidoc/Cargo.toml
@@ -23,7 +23,7 @@ utoipa = { version = "5.0.0", path = "../utoipa", default-features = false, feat
 ] }
 actix-web = { version = "4", optional = true, default-features = false }
 rocket = { version = "0.5", features = ["json"], optional = true }
-axum = { version = "0.7", default-features = false, features = [
+axum = { version = "0.8.0", default-features = false, features = [
     "json",
 ], optional = true }
 

--- a/utoipa-redoc/CHANGELOG.md
+++ b/utoipa-redoc/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-redoc
 
+## Unreleased
+
+### Changed
+
+* Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)
+
 ## 5.0.0 - Oct 14 2024
 
 ### Added

--- a/utoipa-redoc/Cargo.toml
+++ b/utoipa-redoc/Cargo.toml
@@ -23,7 +23,7 @@ utoipa = { version = "5.0.0", path = "../utoipa", default-features = false, feat
 ] }
 actix-web = { version = "4", optional = true }
 rocket = { version = "0.5", features = ["json"], optional = true }
-axum = { version = "0.7", default-features = false, optional = true }
+axum = { version = "0.8.0", default-features = false, optional = true }
 
 [dev-dependencies]
 utoipa-redoc = { path = ".", features = ["actix-web", "axum", "rocket"] }

--- a/utoipa-scalar/CHANAGELOG.md
+++ b/utoipa-scalar/CHANAGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-scalar
 
+## Unreleased
+
+### Changed
+
+* Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)
+
 ## 0.2.0 - Oct 14 2024
 
 ### Added

--- a/utoipa-scalar/Cargo.toml
+++ b/utoipa-scalar/Cargo.toml
@@ -23,7 +23,7 @@ utoipa = { version = "5.0.0", path = "../utoipa", default-features = false, feat
 ] }
 actix-web = { version = "4", optional = true, default-features = false }
 rocket = { version = "0.5", features = ["json"], optional = true }
-axum = { version = "0.7", default-features = false, optional = true }
+axum = { version = "0.8.0", default-features = false, optional = true }
 
 [dev-dependencies]
 utoipa-scalar = { path = ".", features = ["actix-web", "axum", "rocket"] }

--- a/utoipa-swagger-ui/CHANGELOG.md
+++ b/utoipa-swagger-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-swagger-ui
 
+## Unreleased
+
+### Changed
+
+* Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)
+
 ## 8.1.0 - Dec 19 2024
 
 ### Added

--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -26,7 +26,7 @@ rust-embed = { version = "8" }
 mime_guess = { version = "2.0" }
 actix-web = { version = "4", optional = true, default-features = false, features = ["macros"] }
 rocket = { version = "0.5", features = ["json"], optional = true }
-axum = { version = "0.7", default-features = false, features = [
+axum = { version = "0.8.0", default-features = false, features = [
     "json",
 ], optional = true }
 utoipa = { version = "5.0.0", path = "../utoipa", default-features = false, features = [

--- a/utoipa-swagger-ui/src/axum.rs
+++ b/utoipa-swagger-ui/src/axum.rs
@@ -54,7 +54,7 @@ where
         let mut router = if path == "/" {
             router
                 .route(path, handler.clone())
-                .route(&format!("{}*rest", path), handler)
+                .route(&format!("{}{{*rest}}", path), handler)
         } else {
             let path = if path.ends_with('/') {
                 &path[..path.len() - 1]
@@ -70,7 +70,7 @@ where
                     routing::get(|| async move { axum::response::Redirect::to(&slash_path) }),
                 )
                 .route(&format!("{}/", path), handler.clone())
-                .route(&format!("{}/*rest", path), handler)
+                .route(&format!("{}/{{*rest}}", path), handler)
         };
 
         if let Some(BasicAuth { username, password }) = config.basic_auth {

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -7,6 +7,7 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Changed
 
+* Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)
 * Replace `assert-json-diff` with snapshot testing via `insta` (https://github.com/juhaku/utoipa/pull/1254)
 
 ## 5.3.0 - Dec 19 2024


### PR DESCRIPTION
This PR updates our `axum` dependencies to v0.8.0 and adjusts to the breaking changes in this release.

Specifically, it removes the `colonized_params()` fn from the router in `utoipa-axum`, since axum 0.8 now uses the same path syntax as the OpenAPI spec. It also adds a couple of `Sync` constraints.

Until `axum-test` has been updated to support the new version we won't be able to update this yet, which is why I'm opening this PR in draft mode. This PR currently also includes https://github.com/juhaku/utoipa/pull/1268 to prevent merge conflicts.