### PR TITLE
Remove `axum-test` dependency

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -37,9 +37,10 @@ serde_json = { version = "1.0" }
 base64 = { version = "0.22.1" }
 
 [dev-dependencies]
-axum-test = "16.2.0"
+http = "1.2"
 similar = "2.5"
 tokio = { version = "1", features = ["macros"] }
+tower = "0.5"
 utoipa-swagger-ui = { path = ".", features = ["actix-web", "axum", "rocket"] }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
The `axum-test` crate has not yet been updated to work with axum v0.8 and is blocking us from releasing support for it ourselves. Since we use very little functionality from it, we can just replace it with direct calls to the `ServiceExt` trait of `tower`.

This should unblock https://github.com/juhaku/utoipa/pull/1269