### PR TITLE
Add debug implementation for SwaggerUi

### DIFF
--- a/utoipa-swagger-ui/CHANGELOG.md
+++ b/utoipa-swagger-ui/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)
 
+### Fixed
+
+* Add debug implementation for SwaggerUi (https://github.com/juhaku/utoipa/pull/1276)
+
 ## 8.1.0 - Dec 19 2024
 
 ### Added

--- a/utoipa-swagger-ui/README.md
+++ b/utoipa-swagger-ui/README.md
@@ -35,6 +35,7 @@ more details at [serve](https://docs.rs/utoipa-swagger-ui/latest/utoipa_swagger_
 * **`url`** Enabled by default for parsing and encoding the download URL.
 * **`vendored`** Enables vendored Swagger UI via `utoipa-swagger-ui-vendored` crate.
 - **`cache`** Enables caching of the Swagger UI download in `utoipa-swagger-ui` during the build process.
+- **`debug`**: Implement debug trait for SwaggerUi and other types.
 
 ## Install
 

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -1344,6 +1344,7 @@ impl From<String> for Config<'_> {
 /// Basic auth options for Swagger UI. By providing `BasicAuth` to `Config::basic_auth` the access to the
 /// Swagger UI can be restricted behind given basic authentication.
 #[derive(Serialize, Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
 pub struct BasicAuth {
     /// Username for the `BasicAuth`
     pub username: String,
@@ -1354,6 +1355,7 @@ pub struct BasicAuth {
 /// Represents settings related to syntax highlighting of payloads and
 /// cURL commands.
 #[derive(Serialize, Clone)]
+#[cfg_attr(feature = "debug", derive(Debug))]
 #[non_exhaustive]
 pub struct SyntaxHighlight {
     /// Boolean telling whether syntax highlighting should be


### PR DESCRIPTION
Add missing `debug` feature implementation for `SwaggerUi` and other types with `#[cfg_attr(feature = "debug", ...)]`.

Fixes #1274