### PR TITLE
Fix bug in generic schemas on OpenApi derive macro

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+* Fix bug in generic schemas on OpenApi derive macro (https://github.com/juhaku/utoipa/pull/1277)
+
 ### Changed
 
 * Update axum to v0.8 (https://github.com/juhaku/utoipa/pull/1269)

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -633,7 +633,7 @@ impl Parse for Components {
     }
 }
 
-impl crate::ToTokensDiagnostics for Components {
+impl ToTokensDiagnostics for Components {
     fn to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostics> {
         if self.schemas.is_empty() && self.responses.is_empty() {
             return Ok(());
@@ -659,7 +659,10 @@ impl crate::ToTokensDiagnostics for Components {
                         <#type_path as utoipa::ToSchema>::schemas(&mut schemas);
                         schemas
                     } )});
-                    components.extend(quote! { .schema(#name, #schema) });
+                    components.extend(quote! { .schema(#name, {
+                        let mut generics = Vec::<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>::new();
+                        #schema
+                    }) });
 
                     components
                 },

--- a/utoipa-gen/tests/snapshots/openapi_derive__derive_generic_openapi_component_schemas.snap
+++ b/utoipa-gen/tests/snapshots/openapi_derive__derive_generic_openapi_component_schemas.snap
@@ -1,0 +1,41 @@
+---
+source: utoipa-gen/tests/openapi_derive.rs
+expression: schemas
+snapshot_kind: text
+---
+{
+  "schemas": {
+    "dto.page.Response_dto.get.unit.Response": {
+      "properties": {
+        "list": {
+          "items": {
+            "$ref": "#/components/schemas/dto.get.unit.Response"
+          },
+          "type": "array"
+        },
+        "num": {
+          "format": "int64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "size": {
+          "format": "int64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "total": {
+          "format": "int64",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "list",
+        "num",
+        "size",
+        "total"
+      ],
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
This commit fixes bug caused by changes introduced here #1184 by adding necessary changes to how schema is added to an OpenApi when it is added via `components(schemas(...))` attribute of the OpenApi derive macro.

Fixes #1265