### PR TITLE
Exclude snapshots from published packages

### DIFF
--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -9,6 +9,14 @@ keywords = ["openapi", "codegen", "proc-macro", "documentation", "compile-time"]
 repository = "https://github.com/juhaku/utoipa"
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
 rust-version.workspace = true
+include = [
+    "README.md",
+    "src/**/*.rs",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "CHANGELOG.md",
+    "Cargo.toml",
+]
 
 [lib]
 proc-macro = true

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -18,6 +18,14 @@ repository = "https://github.com/juhaku/utoipa"
 categories = ["web-programming"]
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
 rust-version.workspace = true
+include = [
+    "README.md",
+    "src/**/*.rs",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "CHANGELOG.md",
+    "Cargo.toml",
+]
 
 [features]
 # See README.md for list and explanations of features


### PR DESCRIPTION
This commit excludes insta snapshot files from the published packages. I've chosen to go with an explicit list of included files instead of an exclude list as this also excludes other possibly files present by accident at the publish time.

Fixes #1281