### PR TITLE
Support servers in path macro

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 * Add support for jiff v0.2 `Timestamp` (https://github.com/juahku/utoipa/pull/1416)
+* Support servers in path macro (https://github.com/juahku/utoipa/pull/1293)
 
 ## 5.4.0 - Jun 16 2025
 

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -53,6 +53,7 @@ mod openapi;
 mod path;
 mod schema_type;
 mod security_requirement;
+mod server;
 
 use crate::path::{Path, PathAttr};
 

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -7,7 +7,7 @@ use syn::{
     punctuated::Punctuated,
     spanned::Spanned,
     token::{And, Comma},
-    Attribute, Error, ExprPath, LitStr, Token, TypePath,
+    Attribute, Error, ExprPath, Token, TypePath,
 };
 
 use proc_macro2::TokenStream;
@@ -17,6 +17,7 @@ use crate::{
     component::{features::Feature, ComponentSchema, Container, TypeTree},
     parse_utils,
     security_requirement::SecurityRequirementsAttr,
+    server::Server,
     Array, Diagnostics, ExternalDocs, ToTokensDiagnostics,
 };
 use crate::{path, OptionExt};
@@ -272,149 +273,6 @@ impl ToTokens for Tag {
         tokens.extend(quote! { .build() })
     }
 }
-
-// (url = "http:://url", description = "description", variables(...))
-#[derive(Default)]
-#[cfg_attr(feature = "debug", derive(Debug))]
-pub struct Server {
-    url: String,
-    description: Option<String>,
-    variables: Punctuated<ServerVariable, Comma>,
-}
-
-impl Parse for Server {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let server_stream;
-        parenthesized!(server_stream in input);
-        let mut server = Server::default();
-        while !server_stream.is_empty() {
-            let ident = server_stream.parse::<Ident>()?;
-            let attribute_name = &*ident.to_string();
-
-            match attribute_name {
-                "url" => {
-                    server.url = parse_utils::parse_next(&server_stream, || server_stream.parse::<LitStr>())?.value()
-                }
-                "description" => {
-                    server.description =
-                        Some(parse_utils::parse_next(&server_stream, || server_stream.parse::<LitStr>())?.value())
-                }
-                "variables" => {
-                    server.variables = parse_utils::parse_comma_separated_within_parenthesis(&server_stream)?
-                }
-                _ => {
-                    return Err(Error::new(ident.span(), format!("unexpected attribute: {attribute_name}, expected one of: url, description, variables")))
-                }
-            }
-
-            if !server_stream.is_empty() {
-                server_stream.parse::<Comma>()?;
-            }
-        }
-
-        Ok(server)
-    }
-}
-
-impl ToTokens for Server {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let url = &self.url;
-        let description = &self
-            .description
-            .as_ref()
-            .map(|description| quote! { .description(Some(#description)) });
-
-        let parameters = self
-            .variables
-            .iter()
-            .map(|variable| {
-                let name = &variable.name;
-                let default_value = &variable.default;
-                let description = &variable
-                    .description
-                    .as_ref()
-                    .map(|description| quote! { .description(Some(#description)) });
-                let enum_values = &variable.enum_values.as_ref().map(|enum_values| {
-                    let enum_values = enum_values.iter().collect::<Array<&LitStr>>();
-
-                    quote! { .enum_values(Some(#enum_values)) }
-                });
-
-                quote! {
-                    .parameter(#name, utoipa::openapi::server::ServerVariableBuilder::new()
-                        .default_value(#default_value)
-                        #description
-                        #enum_values
-                    )
-                }
-            })
-            .collect::<TokenStream>();
-
-        tokens.extend(quote! {
-            utoipa::openapi::server::ServerBuilder::new()
-                .url(#url)
-                #description
-                #parameters
-                .build()
-        })
-    }
-}
-
-// ("username" = (default = "demo", description = "This is default username for the API")),
-// ("port" = (enum_values = (8080, 5000, 4545)))
-#[derive(Default)]
-#[cfg_attr(feature = "debug", derive(Debug))]
-struct ServerVariable {
-    name: String,
-    default: String,
-    description: Option<String>,
-    enum_values: Option<Punctuated<LitStr, Comma>>,
-}
-
-impl Parse for ServerVariable {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let variable_stream;
-        parenthesized!(variable_stream in input);
-        let mut server_variable = ServerVariable {
-            name: variable_stream.parse::<LitStr>()?.value(),
-            ..ServerVariable::default()
-        };
-
-        variable_stream.parse::<Token![=]>()?;
-        let content;
-        parenthesized!(content in variable_stream);
-
-        while !content.is_empty() {
-            let ident = content.parse::<Ident>()?;
-            let attribute_name = &*ident.to_string();
-
-            match attribute_name {
-                "default" => {
-                    server_variable.default =
-                        parse_utils::parse_next(&content, || content.parse::<LitStr>())?.value()
-                }
-                "description" => {
-                    server_variable.description =
-                        Some(parse_utils::parse_next(&content, || content.parse::<LitStr>())?.value())
-                }
-                "enum_values" => {
-                    server_variable.enum_values =
-                        Some(parse_utils::parse_comma_separated_within_parenthesis(&content)?)
-                }
-                _ => {
-                    return Err(Error::new(ident.span(), format!( "unexpected attribute: {attribute_name}, expected one of: default, description, enum_values")))
-                }
-            }
-
-            if !content.is_empty() {
-                content.parse::<Comma>()?;
-            }
-        }
-
-        Ok(server_variable)
-    }
-}
-
 pub(crate) struct OpenApi<'o>(pub Option<OpenApiAttr<'o>>, pub Ident);
 
 impl OpenApi<'_> {

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -11,6 +11,7 @@ use syn::{parenthesized, parse::Parse, Token};
 use syn::{Expr, ExprLit, Lit, LitStr};
 
 use crate::component::{features::attributes::Extensions, ComponentSchema, GenericType, TypeTree};
+use crate::openapi::Server;
 use crate::{
     as_tokens_or_diagnostics, parse_utils, Deprecated, Diagnostics, OptionExt, ToTokensDiagnostics,
 };
@@ -54,6 +55,7 @@ pub struct PathAttr<'p> {
     description: Option<parse_utils::LitStrOrExpr>,
     summary: Option<parse_utils::LitStrOrExpr>,
     extensions: Option<Extensions>,
+    servers: Vec<Server>,
 }
 
 impl<'p> PathAttr<'p> {
@@ -185,6 +187,13 @@ impl Parse for PathAttr<'_> {
                 }
                 "extensions" => {
                     path_attr.extensions = Some(input.parse::<Extensions>()?);
+                }
+                "servers" => {
+                    let servers;
+                    syn::parenthesized!(servers in input);
+                    path_attr.servers = Punctuated::<Server, Token![,]>::parse_terminated(&servers)?
+                        .into_iter()
+                        .collect();
                 }
                 _ => {
                     if let Some(path_operation) =
@@ -472,6 +481,7 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
             responses: self.path_attr.responses.as_ref(),
             security: self.path_attr.security.as_ref(),
             extensions: self.path_attr.extensions.as_ref(),
+            servers: self.path_attr.servers.as_ref(),
         };
         let operation = as_tokens_or_diagnostics!(&operation);
 
@@ -631,6 +641,7 @@ struct Operation<'a> {
     responses: &'a Vec<Response<'a>>,
     security: Option<&'a Array<'a, SecurityRequirementsAttr>>,
     extensions: Option<&'a Extensions>,
+    servers: &'a Vec<Server>,
 }
 
 impl ToTokensDiagnostics for Operation<'_> {
@@ -645,7 +656,7 @@ impl ToTokensDiagnostics for Operation<'_> {
         }
 
         let responses = Responses(self.responses);
-        let responses = as_tokens_or_diagnostics!(&responses);
+        let responses = as_tokens_or_diagnostics!(&responses);        
         tokens.extend(quote! {
             .responses(#responses)
         });
@@ -658,6 +669,13 @@ impl ToTokensDiagnostics for Operation<'_> {
         tokens.extend(quote_spanned! { operation_id.span() =>
             .operation_id(Some(#operation_id))
         });
+
+        if !self.servers.is_empty() {
+            let servers = self.servers.iter().collect::<Array<_>>();
+            tokens.extend(quote! {
+                .servers(Some(#servers))
+            })
+        }
 
         if self.deprecated {
             let deprecated: Deprecated = self.deprecated.into();

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -191,9 +191,10 @@ impl Parse for PathAttr<'_> {
                 "servers" => {
                     let servers;
                     syn::parenthesized!(servers in input);
-                    path_attr.servers = Punctuated::<Server, Token![,]>::parse_terminated(&servers)?
-                        .into_iter()
-                        .collect();
+                    path_attr.servers =
+                        Punctuated::<Server, Token![,]>::parse_terminated(&servers)?
+                            .into_iter()
+                            .collect();
                 }
                 _ => {
                     if let Some(path_operation) =
@@ -656,7 +657,7 @@ impl ToTokensDiagnostics for Operation<'_> {
         }
 
         let responses = Responses(self.responses);
-        let responses = as_tokens_or_diagnostics!(&responses);        
+        let responses = as_tokens_or_diagnostics!(&responses);
         tokens.extend(quote! {
             .responses(#responses)
         });

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -11,7 +11,7 @@ use syn::{parenthesized, parse::Parse, Token};
 use syn::{Expr, ExprLit, Lit, LitStr};
 
 use crate::component::{features::attributes::Extensions, ComponentSchema, GenericType, TypeTree};
-use crate::openapi::Server;
+use crate::server::Server;
 use crate::{
     as_tokens_or_diagnostics, parse_utils, Deprecated, Diagnostics, OptionExt, ToTokensDiagnostics,
 };

--- a/utoipa-gen/src/path/response/link.rs
+++ b/utoipa-gen/src/path/response/link.rs
@@ -5,7 +5,7 @@ use syn::punctuated::Punctuated;
 use syn::token::Comma;
 use syn::{Ident, Token};
 
-use crate::openapi::Server;
+use crate::server::Server;
 use crate::{parse_utils, AnyValue};
 
 /// ("name" = (link))

--- a/utoipa-gen/src/server.rs
+++ b/utoipa-gen/src/server.rs
@@ -1,0 +1,155 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use quote::ToTokens;
+use syn::Token;
+use syn::{
+    parenthesized,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+    token::Comma,
+    Error, Ident, LitStr,
+};
+
+use crate::{parse_utils, Array};
+
+// (url = "http:://url", description = "description", variables(...))
+#[derive(Default)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct Server {
+    url: String,
+    description: Option<String>,
+    variables: Punctuated<ServerVariable, Comma>,
+}
+
+impl Parse for Server {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let server_stream;
+        parenthesized!(server_stream in input);
+        let mut server = Server::default();
+        while !server_stream.is_empty() {
+            let ident = server_stream.parse::<Ident>()?;
+            let attribute_name = &*ident.to_string();
+
+            match attribute_name {
+                "url" => {
+                    server.url = parse_utils::parse_next(&server_stream, || server_stream.parse::<LitStr>())?.value()
+                }
+                "description" => {
+                    server.description =
+                        Some(parse_utils::parse_next(&server_stream, || server_stream.parse::<LitStr>())?.value())
+                }
+                "variables" => {
+                    server.variables = parse_utils::parse_comma_separated_within_parenthesis(&server_stream)?
+                }
+                _ => {
+                    return Err(Error::new(ident.span(), format!("unexpected attribute: {attribute_name}, expected one of: url, description, variables")))
+                }
+            }
+
+            if !server_stream.is_empty() {
+                server_stream.parse::<Comma>()?;
+            }
+        }
+
+        Ok(server)
+    }
+}
+
+impl ToTokens for Server {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let url = &self.url;
+        let description = &self
+            .description
+            .as_ref()
+            .map(|description| quote! { .description(Some(#description)) });
+
+        let parameters = self
+            .variables
+            .iter()
+            .map(|variable| {
+                let name = &variable.name;
+                let default_value = &variable.default;
+                let description = &variable
+                    .description
+                    .as_ref()
+                    .map(|description| quote! { .description(Some(#description)) });
+                let enum_values = &variable.enum_values.as_ref().map(|enum_values| {
+                    let enum_values = enum_values.iter().collect::<Array<&LitStr>>();
+
+                    quote! { .enum_values(Some(#enum_values)) }
+                });
+
+                quote! {
+                    .parameter(#name, utoipa::openapi::server::ServerVariableBuilder::new()
+                        .default_value(#default_value)
+                        #description
+                        #enum_values
+                    )
+                }
+            })
+            .collect::<TokenStream>();
+
+        tokens.extend(quote! {
+            utoipa::openapi::server::ServerBuilder::new()
+                .url(#url)
+                #description
+                #parameters
+                .build()
+        })
+    }
+}
+
+// ("username" = (default = "demo", description = "This is default username for the API")),
+// ("port" = (enum_values = (8080, 5000, 4545)))
+#[derive(Default)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+struct ServerVariable {
+    name: String,
+    default: String,
+    description: Option<String>,
+    enum_values: Option<Punctuated<LitStr, Comma>>,
+}
+
+impl Parse for ServerVariable {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let variable_stream;
+        parenthesized!(variable_stream in input);
+        let mut server_variable = ServerVariable {
+            name: variable_stream.parse::<LitStr>()?.value(),
+            ..ServerVariable::default()
+        };
+
+        variable_stream.parse::<Token![=]>()?;
+        let content;
+        parenthesized!(content in variable_stream);
+
+        while !content.is_empty() {
+            let ident = content.parse::<Ident>()?;
+            let attribute_name = &*ident.to_string();
+
+            match attribute_name {
+                "default" => {
+                    server_variable.default =
+                        parse_utils::parse_next(&content, || content.parse::<LitStr>())?.value()
+                }
+                "description" => {
+                    server_variable.description =
+                        Some(parse_utils::parse_next(&content, || content.parse::<LitStr>())?.value())
+                }
+                "enum_values" => {
+                    server_variable.enum_values =
+                        Some(parse_utils::parse_comma_separated_within_parenthesis(&content)?)
+                }
+                _ => {
+                    return Err(Error::new(ident.span(), format!( "unexpected attribute: {attribute_name}, expected one of: default, description, enum_values")))
+                }
+            }
+
+            if !content.is_empty() {
+                content.parse::<Comma>()?;
+            }
+        }
+
+        Ok(server_variable)
+    }
+}

--- a/utoipa-gen/src/server.rs
+++ b/utoipa-gen/src/server.rs
@@ -16,7 +16,7 @@ use crate::{parse_utils, Array};
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct Server {
-    url: String,
+    url: parse_utils::LitStrOrExpr,
     description: Option<String>,
     variables: Punctuated<ServerVariable, Comma>,
 }
@@ -32,7 +32,7 @@ impl Parse for Server {
 
             match attribute_name {
                 "url" => {
-                    server.url = parse_utils::parse_next(&server_stream, || server_stream.parse::<LitStr>())?.value()
+                    server.url = parse_utils::parse_next_literal_str_or_expr(&server_stream)?
                 }
                 "description" => {
                     server.description =


### PR DESCRIPTION
Hi! Just want to say thanks for developing this amazing library. I realized that this piece was missing as per these docs https://swagger.io/docs/specification/v3_0/api-host-and-base-path/ and is my use case to be able to override the servers. 
I see it is available in the corresponding trait but not the macro, so adding it here.

~Very much a WIP, will test and add a few more commits later~