### PR TITLE
Update utoipa-auxm version

### DIFF
--- a/utoipa-axum/CHANGELOG.md
+++ b/utoipa-axum/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog - utoipa-axum
 
+## 0.2.0 - Thu 16 2025
+
+* Re-release of what was released in 0.1.4 (https://github.com/juhaku/utoipa/pull/1295)
+
 ## 0.1.4 - Jan 6 2025
 
 ### Changed

--- a/utoipa-axum/Cargo.toml
+++ b/utoipa-axum/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utoipa-axum"
 description = "Utoipa's axum bindings for seamless integration for the two"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/utoipa-axum/README.md
+++ b/utoipa-axum/README.md
@@ -19,7 +19,7 @@ Add dependency declaration to `Cargo.toml`.
 
 ```toml
 [dependencies]
-utoipa-axum = "0.1"
+utoipa-axum = "0.2"
 ```
 
 ## Examples

--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -16,7 +16,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! utoipa-axum = "0.1"
+//! utoipa-axum = "0.2"
 //! ```
 //!
 //! ## Examples


### PR DESCRIPTION
Update utoipa-axum release version to 0.2 for it was incorrectly released as a patch.

Fixes #1282