### PR TITLE
Emit nullable_item last for OneOfBuilder

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1294,8 +1294,8 @@ impl ComponentSchema {
                         {
                             quote_spanned! {type_path.span()=>
                                 utoipa::openapi::schema::OneOfBuilder::new()
-                                    #nullable_item
                                     .item(#items_tokens)
+                                    #nullable_item
                                 #title_tokens
                                 #default_tokens
                                 #description_stream
@@ -1361,11 +1361,11 @@ impl ComponentSchema {
                         let schema = if default.is_some() || nullable || title.is_some() {
                             composed_or_ref(quote_spanned! {type_path.span()=>
                                 utoipa::openapi::schema::OneOfBuilder::new()
-                                    #nullable_item
                                     .item(utoipa::openapi::schema::RefBuilder::new()
                                         #description_stream
                                         .ref_location_from_schema_name(#name_tokens)
                                     )
+                                    #nullable_item
                                     #title_tokens
                                     #default_tokens
                             })

--- a/utoipa-gen/tests/snapshots/openapi_derive__openapi_resolvle_recursive_references.snap
+++ b/utoipa-gen/tests/snapshots/openapi_derive__openapi_resolvle_recursive_references.snap
@@ -29,10 +29,10 @@ snapshot_kind: text
         "items": {
           "oneOf": [
             {
-              "type": "null"
+              "$ref": "#/components/schemas/Account"
             },
             {
-              "$ref": "#/components/schemas/Account"
+              "type": "null"
             }
           ]
         },

--- a/utoipa-gen/tests/snapshots/openapi_derive__openapi_schemas_resolve_schema_references.snap
+++ b/utoipa-gen/tests/snapshots/openapi_derive__openapi_schemas_resolve_schema_references.snap
@@ -67,10 +67,10 @@ snapshot_kind: text
                   "items": {
                     "oneOf": [
                       {
-                        "type": "null"
+                        "$ref": "#/components/schemas/Account"
                       },
                       {
-                        "$ref": "#/components/schemas/Account"
+                        "type": "null"
                       }
                     ]
                   },
@@ -105,10 +105,10 @@ snapshot_kind: text
                     "items": {
                       "oneOf": [
                         {
-                          "type": "null"
+                          "$ref": "#/components/schemas/Account"
                         },
                         {
-                          "$ref": "#/components/schemas/Account"
+                          "type": "null"
                         }
                       ]
                     },
@@ -239,10 +239,10 @@ snapshot_kind: text
           "items": {
             "oneOf": [
               {
-                "type": "null"
+                "$ref": "#/components/schemas/Account"
               },
               {
-                "$ref": "#/components/schemas/Account"
+                "type": "null"
               }
             ]
           },
@@ -271,10 +271,10 @@ snapshot_kind: text
           "items": {
             "oneOf": [
               {
-                "type": "null"
+                "$ref": "#/components/schemas/Account"
               },
               {
-                "$ref": "#/components/schemas/Account"
+                "type": "null"
               }
             ]
           },

--- a/utoipa-gen/tests/snapshots/request_body_derive_test__derive_request_body_complex_required_explicit_false_success.snap
+++ b/utoipa-gen/tests/snapshots/request_body_derive_test__derive_request_body_complex_required_explicit_false_success.snap
@@ -9,10 +9,10 @@ snapshot_kind: text
       "schema": {
         "oneOf": [
           {
-            "type": "null"
+            "$ref": "#/components/schemas/Foo"
           },
           {
-            "$ref": "#/components/schemas/Foo"
+            "type": "null"
           }
         ]
       }

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_struct_with_default_attr_field.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_struct_with_default_attr_field.snap
@@ -11,10 +11,10 @@ snapshot_kind: text
       },
       "oneOf": [
         {
-          "type": "null"
+          "$ref": "#/components/schemas/Book"
         },
         {
-          "$ref": "#/components/schemas/Book"
+          "type": "null"
         }
       ]
     },

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_struct_with_inline.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_struct_with_inline.snap
@@ -19,9 +19,6 @@ snapshot_kind: text
     "foo2": {
       "oneOf": [
         {
-          "type": "null"
-        },
-        {
           "properties": {
             "name": {
               "type": "string"
@@ -31,15 +28,15 @@ snapshot_kind: text
             "name"
           ],
           "type": "object"
+        },
+        {
+          "type": "null"
         }
       ]
     },
     "foo3": {
       "oneOf": [
         {
-          "type": "null"
-        },
-        {
           "properties": {
             "name": {
               "type": "string"
@@ -49,6 +46,9 @@ snapshot_kind: text
             "name"
           ],
           "type": "object"
+        },
+        {
+          "type": "null"
         }
       ]
     },

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_struct_with_optional_properties.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_struct_with_optional_properties.snap
@@ -40,10 +40,10 @@ snapshot_kind: text
     "optional_book": {
       "oneOf": [
         {
-          "type": "null"
+          "$ref": "#/components/schemas/Book"
         },
         {
-          "$ref": "#/components/schemas/Book"
+          "type": "null"
         }
       ]
     }


### PR DESCRIPTION
This PR changes the order in which the `#nullable_item` is emitted when processing the `OneOfBuilder`. This leads to much better example values in the Swagger UI, as by default the example just picks the first one of the options.

This change is inspired by this comment: https://github.com/juhaku/utoipa/issues/1260#issuecomment-2568216834
> What we could at least do is to change the order of the types in oneOf to make the null variant below, which will help the Swagger UI to use the correct spec as an example because it chooses the first one from the list.

Please take a look!