### PR TITLE
replaced `serde_yml` with `serde_norway`

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also an awesome type of beer 
 ## Crate Features
 
 - **`macros`** Enable `utoipa-gen` macros. **This is enabled by default.**
-- **`yaml`**: Enables **serde_yml** serialization of OpenAPI objects.
+- **`yaml`**: Enables **serde_norway** serialization of OpenAPI objects.
 - **`actix_extras`**: Enhances [actix-web](https://github.com/actix/actix-web/) integration with being able to
   parse `path`, `path` and `query` parameters from actix web path attribute macros. See
   [docs](https://docs.rs/utoipa/latest/utoipa/attr.path.html#actix_extras-feature-support-for-actix-web) or [examples](./examples) for more details.

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -7,7 +7,7 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Changed
 
-* Replaced `serde_yaml` with `serde_yml` (https://github.com/juhaku/utoipa/pull/1280)
+* Replaced `serde_yaml` with `serde_norway` (https://github.com/juhaku/utoipa/pull/1311)
 
 ## 5.3.1 - Jan 6 2025
 

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -38,7 +38,7 @@ chrono = ["utoipa-gen?/chrono"]
 decimal = ["utoipa-gen?/decimal"]
 decimal_float = ["utoipa-gen?/decimal_float"]
 non_strict_integers = ["utoipa-gen?/non_strict_integers"]
-yaml = ["serde_yml", "utoipa-gen?/yaml"]
+yaml = ["serde_norway", "utoipa-gen?/yaml"]
 uuid = ["utoipa-gen?/uuid"]
 ulid = ["utoipa-gen?/ulid"]
 url = ["utoipa-gen?/url"]
@@ -59,7 +59,7 @@ auto_into_responses = ["utoipa-gen?/auto_into_responses"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-serde_yml = { version = "0.0", optional = true }
+serde_norway = {version = "0.9.42", optional = true}
 utoipa-gen = { version = "5.3.1", path = "../utoipa-gen", optional = true }
 indexmap = { version = "2", features = ["serde"] }
 

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -60,7 +60,7 @@
 //! # Crate Features
 //!
 //! * **`macros`** Enable `utoipa-gen` macros. **This is enabled by default.**
-//! * **`yaml`** Enables **serde_yml** serialization of OpenAPI objects.
+//! * **`yaml`** Enables **serde_norway** serialization of OpenAPI objects.
 //! * **`actix_extras`** Enhances [actix-web](https://github.com/actix/actix-web/) integration with being able to
 //!   parse `path`, `path` and `query` parameters from actix web path attribute macros. See [actix extras support][actix_path] or
 //!   [examples](https://github.com/juhaku/utoipa/tree/master/examples) for more details.

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -163,11 +163,11 @@ impl OpenApi {
         serde_json::to_string_pretty(self)
     }
 
-    /// Converts this [`OpenApi`] to YAML String. This method essentially calls [`serde_yml::to_string`] method.
+    /// Converts this [`OpenApi`] to YAML String. This method essentially calls [`serde_norway::to_string`] method.
     #[cfg(feature = "yaml")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "yaml")))]
-    pub fn to_yaml(&self) -> Result<String, serde_yml::Error> {
-        serde_yml::to_string(self)
+    pub fn to_yaml(&self) -> Result<String, serde_norway::Error> {
+        serde_norway::to_string(self)
     }
 
     /// Merge `other` [`OpenApi`] moving `self` and returning combined [`OpenApi`].


### PR DESCRIPTION
@domenicquirl has mentioned that `serde_yml` is actually a  very bad replacement for `serde_yaml`.

I've chosen `serde_norway` as the replacement.
A fork of the original `serde_yaml` and way better.

For more information see the discussion here: https://github.com/juhaku/utoipa/issues/1168#issuecomment-2642797978

I am very sorry for introducing this dependency.
This pr should fix my error.

I've `serde_norway` is not wanted we could also go with https://github.com/acatton/serde-yaml-ng