### PR TITLE
fix(todo-actix): examples

### DIFF
--- a/examples/todo-actix/src/todo.rs
+++ b/examples/todo-actix/src/todo.rs
@@ -116,7 +116,7 @@ async fn create_todo(todo: Json<Todo>, todo_store: Data<TodoStore>) -> impl Resp
         .unwrap_or_else(|| {
             todos.push(todo.clone());
 
-            HttpResponse::Ok().json(todo)
+            HttpResponse::Created().json(todo)
         })
 }
 


### PR DESCRIPTION
According to the documentation, the /api/todo endpoint should return a 201 status when a new resource is created. Fixed the response handling to comply with this expectation.