### PR TITLE
Enhance ToSchema and ComposeSchema implementations for HashMap and HashSet to support custom hashers

### DIFF
--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -608,9 +608,9 @@ where
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<K: ToSchema, T: ToSchema> ToSchema for std::collections::HashMap<K, T>
+impl<K: ToSchema, T: ToSchema, S> ToSchema for std::collections::HashMap<K, T, S>
 where
-    std::collections::HashMap<K, T>: PartialSchema,
+    std::collections::HashMap<K, T, S>: PartialSchema,
 {
     fn schemas(
         schemas: &mut Vec<(
@@ -642,9 +642,9 @@ where
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
-impl<K: ToSchema> ToSchema for std::collections::HashSet<K>
+impl<K: ToSchema, S> ToSchema for std::collections::HashSet<K, S>
 where
-    std::collections::HashSet<K>: PartialSchema,
+    std::collections::HashSet<K, S>: PartialSchema,
 {
     fn schemas(
         schemas: &mut Vec<(
@@ -1437,7 +1437,7 @@ pub mod __dev {
         }
     }
 
-    impl<K: ComposeSchema, T: ComposeSchema> ComposeSchema for std::collections::HashMap<K, T> {
+    impl<K: ComposeSchema, T: ComposeSchema, S> ComposeSchema for std::collections::HashMap<K, T, S> {
         fn compose(
             schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
@@ -1459,7 +1459,7 @@ pub mod __dev {
         }
     }
 
-    impl<K: ComposeSchema> ComposeSchema for std::collections::HashSet<K> {
+    impl<K: ComposeSchema, S> ComposeSchema for std::collections::HashSet<K, S> {
         fn compose(
             schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {


### PR DESCRIPTION
Fixes https://github.com/juhaku/utoipa/issues/1318

@dsgallups insightfully pointed out that the ToSchema implementation for HashSets and HashMaps does not support custom hash functions. This PR augments the code to allow for custom hash functions, providing greater flexibility in schema generation.