### PR TITLE
Optional Header Parameters only set required=false

### DIFF
--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -305,6 +305,8 @@ impl Parse for ValueParameter<'_> {
 
             if parameter.parameter_in == ParameterIn::Query {
                 parameter_schema.option_is_nullable = false;
+            } else if parameter.parameter_in == ParameterIn::Header {
+                parameter_schema.option_is_nullable = false;
             }
         }
 


### PR DESCRIPTION
I have run into the following situation, I am trying to declare an optional Header Value for a request.

Here is a minimal working example to demonstrate the behavior.
``` rust
use actix_web::{get, web::Json, App, HttpServer};
use utoipa::{openapi::OpenApi, ToSchema};

#[derive(Debug, ToSchema)]
enum Test {
    A,
    B,
    C
}

#[utoipa::path(
    params(
        ("TEST" = Option<Test>, Header)
    ),
)]
#[get("/")]
async fn test() -> Json<OpenApi> {
    use utoipa::OpenApi;
    Json(ApiSpec::openapi())
}

#[derive(utoipa::OpenApi)]
#[openapi(
    paths(test),
    components(schemas(Test))
)]
struct ApiSpec;

#[actix_web::main]
async fn main() -> Result<(), std::io::Error> {
    let _ = HttpServer::new(move || {
        let app = App::new().service(test);
        app
    }).bind(("localhost", 8081))?.run().await;
    Ok(())
}

```

Running `curl http://localhost:8081 | jq` the schema of the Header field will look like this

``` json
"parameters": [
    {
      "name": "TEST",
      "in": "header",
      "required": false,
      "schema": {
        "oneOf": [
          {
            "type": "null"
          },
          {
            "$ref": "#/components/schemas/Test"
          }
        ]
      }
    }
  ],
```
With the PR applied the result is:

``` json
"parameters": [
  {
    "name": "TEST",
    "in": "header",
    "required": false,
    "schema": {
      "$ref": "#/components/schemas/Test"
    }
  }
],
```

This is more in line with what I would expect the result to be. Using swagger UI this is also a lot more practical because now it will actually give me a drop down for the header value 😉

Any thoughts?

Kind regards
ju6ge
`