### PR TITLE
fix zip 2.5 semver breakage

### DIFF
--- a/utoipa-swagger-ui/build.rs
+++ b/utoipa-swagger-ui/build.rs
@@ -102,7 +102,7 @@ impl SwaggerZip {
             let mut file = self.by_index(index)?;
             let filepath = file
                 .enclosed_name()
-                .ok_or(ZipError::InvalidArchive("invalid path file"))?;
+                .ok_or(ZipError::InvalidArchive("invalid path file".into()))?;
 
             if index == 0 {
                 zip_top_level_folder = filepath


### PR DESCRIPTION
Fixes the build error when zip is updated to 2.5.0 

```
utoipa % cargo build
   Compiling utoipa-swagger-ui v9.0.0 (/Users/makro/utoipa/utoipa-swagger-ui)
error[E0308]: mismatched types
   --> utoipa-swagger-ui/build.rs:105:49
    |
105 |                 .ok_or(ZipError::InvalidArchive("invalid path file"))?;
    |                        ------------------------ ^^^^^^^^^^^^^^^^^^^ expected `Cow<'_, str>`, found `&str`
    |                        |
    |                        arguments to this enum variant are incorrect
    |
    = note:   expected enum `Cow<'static, str>`
            found reference `&'static str`
note: tuple variant defined here
   --> /Users/makro/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/zip-2.5.0/src/result.rs:23:5
    |
23  |     InvalidArchive(Cow<'static, str>),
    |     ^^^^^^^^^^^^^^
help: try wrapping the expression in `std::borrow::Cow::Borrowed`
    |
105 |                 .ok_or(ZipError::InvalidArchive(std::borrow::Cow::Borrowed("invalid path file")))?;
    |                                                 +++++++++++++++++++++++++++                   +

For more information about this error, try `rustc --explain E0308`.
```