### PR TITLE
[swagger-ui]◘Pin zip dependency

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -49,7 +49,7 @@ no-default-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [build-dependencies]
-zip = { version = "2", default-features = false, features = ["deflate"] }
+zip = { version = "2.5.0", default-features = false, features = ["deflate"] }
 regex = "1.7"
 
 # used by cache feature


### PR DESCRIPTION
The PR fix the issue https://github.com/juhaku/utoipa/pull/1343, but doesn't pin the version.

I propose to define explicitly the zip crate version to avoid further complication.