### PR TITLE
Initial support for ntex integration via utoipa-ntex

### DIFF
--- a/utoipa-ntex/Cargo.toml
+++ b/utoipa-ntex/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "utoipa-ntex"
+version = "0.1.0"
+edition = "2024"
+license = "MIT OR Apache-2.0"
+readme = "README.md"
+keywords = ["utoipa", "ntex", "bindings"]
+repository = "https://github.com/Rayato159/utoipa"
+categories = ["web-programming"]
+authors = ["Ruangyot Nanchiang <rayato159@gmail.com>"]
+rust-version.workspace = true
+
+[dependencies]
+utoipa = { path = "../utoipa", version = "5" }
+ntex = { path = "../../ntex/ntex" }
+
+[dev-dependencies]
+utoipa = { path = "../utoipa", version = "5", features = ["macros", "debug"] }
+ntex = { path = "../../ntex/ntex", features = [
+    "tokio",
+] }
+serde = "1"
+
+[package.metadata.docs.rs]
+features = []
+rustdoc-args = ["--cfg", "doc_cfg"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/utoipa-ntex/Cargo.toml
+++ b/utoipa-ntex/Cargo.toml
@@ -12,14 +12,18 @@ rust-version.workspace = true
 
 [dependencies]
 utoipa = { path = "../utoipa", version = "5" }
-# Need to update this when ntex is updated to pub WebStack to available for passthrough the Scope::wrap
-ntex = { path = "../../ntex/ntex" }
+# For local testing
+# ntex = { path = "../../ntex/ntex" }
+ntex = { version = "2", default-features = false }
 
 [dev-dependencies]
 utoipa = { path = "../utoipa", version = "5", features = ["macros", "debug"] }
-# Need to update this when ntex is updated to pub WebStack to available for passthrough the Scope::wrap
-ntex = { path = "../../ntex/ntex", features = ["tokio"] }
+# For local testing
+# ntex = { path = "../../ntex/ntex", features = ["tokio"] }
+ntex = { version = "2", features = ["tokio"] }
 serde = "1"
+assert-json-diff = "2"
+serde_json = "1"
 
 [package.metadata.docs.rs]
 features = []

--- a/utoipa-ntex/Cargo.toml
+++ b/utoipa-ntex/Cargo.toml
@@ -12,13 +12,13 @@ rust-version.workspace = true
 
 [dependencies]
 utoipa = { path = "../utoipa", version = "5" }
+# Need to update this when ntex is updated to pub WebStack to available for passthrough the Scope::wrap
 ntex = { path = "../../ntex/ntex" }
 
 [dev-dependencies]
 utoipa = { path = "../utoipa", version = "5", features = ["macros", "debug"] }
-ntex = { path = "../../ntex/ntex", features = [
-    "tokio",
-] }
+# Need to update this when ntex is updated to pub WebStack to available for passthrough the Scope::wrap
+ntex = { path = "../../ntex/ntex", features = ["tokio"] }
 serde = "1"
 
 [package.metadata.docs.rs]

--- a/utoipa-ntex/README.md
+++ b/utoipa-ntex/README.md
@@ -1,0 +1,54 @@
+# utoipa-ntex - Bindings for Ntex and utoipa
+
+[![Utoipa build](https://github.com/juhaku/utoipa/actions/workflows/build.yaml/badge.svg)](https://github.com/juhaku/utoipa/actions/workflows/build.yaml)
+[![crates.io](https://img.shields.io/crates/v/utoipa-ntex.svg?label=crates.io&color=orange&logo=rust)](https://crates.io/crates/utoipa-ntex)
+[![docs.rs](https://img.shields.io/static/v1?label=docs.rs&message=utoipa-ntex&color=blue&logo=data:image/svg+xml;base64,PHN2ZyByb2xlPSJpbWciIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgdmlld0JveD0iMCAwIDUxMiA1MTIiPjxwYXRoIGZpbGw9IiNmNWY1ZjUiIGQ9Ik00ODguNiAyNTAuMkwzOTIgMjE0VjEwNS41YzAtMTUtOS4zLTI4LjQtMjMuNC0zMy43bC0xMDAtMzcuNWMtOC4xLTMuMS0xNy4xLTMuMS0yNS4zIDBsLTEwMCAzNy41Yy0xNC4xIDUuMy0yMy40IDE4LjctMjMuNCAzMy43VjIxNGwtOTYuNiAzNi4yQzkuMyAyNTUuNSAwIDI2OC45IDAgMjgzLjlWMzk0YzAgMTMuNiA3LjcgMjYuMSAxOS45IDMyLjJsMTAwIDUwYzEwLjEgNS4xIDIyLjEgNS4xIDMyLjIgMGwxMDMuOS01MiAxMDMuOSA1MmMxMC4xIDUuMSAyMi4xIDUuMSAzMi4yIDBsMTAwLTUwYzEyLjItNi4xIDE5LjktMTguNiAxOS45LTMyLjJWMjgzLjljMC0xNS05LjMtMjguNC0yMy40LTMzLjd6TTM1OCAyMTQuOGwtODUgMzEuOXYtNjguMmw4NS0zN3Y3My4zek0xNTQgMTA0LjFsMTAyLTM4LjIgMTAyIDM4LjJ2LjZsLTEwMiA0MS40LTEwMi00MS40di0uNnptODQgMjkxLjFsLTg1IDQyLjV2LTc5LjFsODUtMzguOHY3NS40em0wLTExMmwtMTAyIDQxLjQtMTAyLTQxLjR2LS42bDEwMi0zOC4yIDEwMiAzOC4ydi42em0yNDAgMTEybC04NSA0Mi41di03OS4xbDg1LTM4Ljh2NzUuNHptMC0xMTJsLTEwMiA0MS40LTEwMi00MS40di0uNmwxMDItMzguMiAxMDIgMzguMnYuNnoiPjwvcGF0aD48L3N2Zz4K)](https://docs.rs/utoipa-ntex/latest/)
+![rustc](https://img.shields.io/static/v1?label=rustc&message=1.75&color=orange&logo=rust)
+
+This crate implements necessary bindings for automatically collecting `paths` and `schemas` recursively from Ntex
+`App`, `Scope` and `ServiceConfig`. It provides natural API reducing duplication and support for scopes while generating
+OpenAPI specification without the need to declare `paths` and `schemas` to `#[openapi(...)]` attribute of `OpenApi` derive.
+
+Currently only `service(...)` calls supports automatic collection of schemas and paths. Manual routes via `route(...)` or
+`Route::new().to(...)` is not supported.
+
+## Install
+
+Add dependency declaration to `Cargo.toml`.
+
+```toml
+[dependencies]
+utoipa-ntex = "0.1"
+```
+
+## Examples
+
+Collect handlers annotated with `#[utoipa::path]` recursively from `service(...)` calls to compose OpenAPI spec.
+
+```rust
+use ntex::web::{get, App};
+use utoipa_ntex::{scope, AppExt};
+
+#[derive(utoipa::ToSchema)]
+struct User {
+    id: i32,
+}
+
+#[utoipa::path(responses((status = OK, body = User)))]
+#[get("/user")]
+async fn get_user() -> Json<User> {
+    Json(User { id: 1 })
+}
+
+let (_, mut api) = App::new()
+    .into_utoipa_app()
+    .service(scope::scope("/api/v1").service(get_user))
+    .split_for_parts();
+```
+
+## License
+
+Licensed under either of [Apache 2.0](LICENSE-APACHE) or [MIT](LICENSE-MIT) license at your option.
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in this crate
+by you, shall be dual licensed, without any additional terms or conditions.

--- a/utoipa-ntex/src/handler.rs
+++ b/utoipa-ntex/src/handler.rs
@@ -1,0 +1,116 @@
+//! Implement `utoipa` extended [`WebServiceFactory`] for [`UtoipaHandler`].
+//!
+//! See usage from [`register`][fn@register].
+use ntex::web::{ErrorRenderer, WebServiceFactory, dev::WebServiceConfig};
+use utoipa::{
+    __dev::{SchemaReferences, Tags},
+    Path,
+};
+
+use crate::OpenApiFactory;
+
+/// A wrapper that associates a handler function `H` with its corresponding
+/// `utoipa::path` metadata type `P` to enable automatic OpenAPI schema generation.
+///
+/// This is useful when using `utoipa_ntex::UtoipaApp` or `Scope` and needing to
+/// register individual handler functions that are annotated with `#[utoipa::path(...)]`.
+///
+/// The macro `#[utoipa::path(...)]` generates a hidden type like `__path_my_handler`,
+/// which implements `utoipa::Path`, `SchemaReferences`, and `Tags`. `UtoipaHandler`
+/// binds this generated type with your actual route handler so both the OpenAPI schema
+/// and the actual service can be registered at once.
+///
+/// # Example
+/// ```rust
+/// use ntex::web;
+/// use utoipa::OpenApi;
+/// use utoipa_ntex::{AppExt, handler::UtoipaHandler, scope};
+///
+/// #[derive(OpenApi)]
+/// #[openapi(paths(get_user), components(schemas(User)))]
+/// struct ApiDoc;
+///
+/// #[derive(utoipa::ToSchema, serde::Serialize)]
+/// struct User {
+///     id: i32,
+/// }
+///
+/// #[utoipa::path(get, path = "/user", responses((status = 200, body = User)))]
+/// #[web::get("/user")]
+/// async fn get_user() -> web::types::Json<User> {
+///    web::types::Json(User { id: 1 })
+/// }
+///
+/// let handler = UtoipaHandler::<_, __path_get_user>::new(get_user);
+/// ```
+pub struct UtoipaHandler<H, P> {
+    /// The handler that is registered to Ntex service config.
+    handler: H,
+
+    /// Marker type for the generated OpenAPI metadata struct `P`.
+    _phantom: std::marker::PhantomData<P>,
+}
+
+impl<H, P> UtoipaHandler<H, P> {
+    /// Creates a new `UtoipaHandler` from the provided handler.
+    ///
+    /// # Arguments
+    /// * `handler` - The Ntex-compatible handler function.
+    ///
+    /// # Returns
+    /// A new `UtoipaHandler` that can be passed to `.service(...)`
+    /// in `UtoipaApp` or `Scope` for both routing and OpenAPI generation.
+    pub fn new(handler: H) -> Self {
+        Self {
+            handler,
+            _phantom: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<H, P, Err> WebServiceFactory<Err> for UtoipaHandler<H, P>
+where
+    H: WebServiceFactory<Err>,
+    Err: ErrorRenderer,
+{
+    fn register(self, config: &mut WebServiceConfig<Err>) {
+        self.handler.register(config);
+    }
+}
+
+impl<'t, H, P> OpenApiFactory for UtoipaHandler<H, P>
+where
+    P: Path + SchemaReferences + Tags<'t>,
+{
+    fn paths(&self) -> utoipa::openapi::path::Paths {
+        let methods = P::methods();
+        methods
+            .into_iter()
+            .fold(
+                utoipa::openapi::path::Paths::builder(),
+                |mut builder, method| {
+                    let mut operation = P::operation();
+                    let other_tags = P::tags();
+                    if !other_tags.is_empty() {
+                        let tags = operation.tags.get_or_insert(Vec::new());
+                        tags.extend(other_tags.into_iter().map(ToString::to_string));
+                    }
+
+                    let path_item = utoipa::openapi::PathItem::new(method, operation);
+                    builder = builder.path(P::path(), path_item);
+                    builder
+                },
+            )
+            .build()
+    }
+
+    fn schemas(
+        &self,
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        P::schemas(schemas);
+    }
+}

--- a/utoipa-ntex/src/lib.rs
+++ b/utoipa-ntex/src/lib.rs
@@ -18,27 +18,42 @@
 //!
 //! _**Collect handlers annotated with `#[utoipa::path]` recursively from `service(...)` calls to compose OpenAPI spec.**_
 //!
-//! ```rust
-//! use ntex::web::{Json, get, App};
-//! use utoipa_ntex::{scope, AppExt};
+//! ```no_run
+//! use ntex::web;
+//! use utoipa::OpenApi;
+//! use utoipa_ntex::{AppExt, handler::UtoipaHandler, scope};
 //!
 //! #[derive(utoipa::ToSchema, serde::Serialize)]
 //! struct User {
 //!     id: i32,
 //! }
 //!
-//! #[utoipa::path(responses((status = OK, body = User)))]
-//! #[get("/user")]
-//! async fn get_user() -> Json<User> {
-//!     Json(User { id: 1 })
+//! #[utoipa::path(get, path = "/user", responses((status = 200, body = User)))]
+//! #[web::get("/user")]
+//! async fn get_user() -> web::types::Json<User> {
+//!     web::types::Json(User { id: 1 })
 //! }
 //!
-//! let (_, mut api) = App::new()
-//!     .into_utoipa_app()
-//!     .service(scope::scope("/api/v1").service(get_user))
-//!     .split_for_parts();
+//! #[derive(OpenApi)]
+//! #[openapi(paths(get_user), components(schemas(User)))]
+//! struct ApiDoc;
+//!
+//! #[ntex::main]
+//! async fn main() -> std::io::Result<()> {
+//!     web::HttpServer::new(|| {
+//!         web::App::new()
+//!             .into_utoipa_app()
+//!             .openapi(ApiDoc::openapi())
+//!             .service(
+//!                 scope::scope("/api").service(UtoipaHandler::<_, __path_get_user>::new(get_user)),
+//!             )
+//!             .into_app()
+//!     })
+//!     .bind(("127.0.0.1", 8080))?
+//!     .run()
+//!     .await
+//! }
 //! ```
-
 #![cfg_attr(doc_cfg, feature(doc_cfg))]
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
@@ -51,7 +66,7 @@ use std::fmt;
 
 use ntex::{
     IntoServiceFactory, ServiceFactory,
-    web::{ErrorRenderer, Route, WebRequest, WebResponse, WebServiceFactory, stack::WebStack},
+    web::{ErrorRenderer, Route, WebRequest, WebResponse, WebServiceFactory},
 };
 use service_config::ServiceConfig;
 use utoipa::{OpenApi, openapi::PathItem};
@@ -144,16 +159,17 @@ where
 ///
 /// _**Create new [`UtoipaApp`] instance.**_
 /// ```rust
-/// # use utoipa_ntex::{AppExt, UtoipaApp};
-/// # use ntex::web::App;
+/// use utoipa_ntex::{AppExt, UtoipaApp};
+/// use ntex::web::App;
+///
 /// let utoipa_app = App::new().into_utoipa_app();
 /// ```
 ///
 /// _**Convert `ntex::web::App<M, F, Err>` to `UtoipaApp<M, F, Err>`.**_
 /// ```rust
-/// # use utoipa_ntex::{AppExt, UtoipaApp};
-/// # use ntex::web::App;
-/// let a: UtoipaApp<_> = ntex::web::App::new().into();
+/// use utoipa_ntex::{AppExt, UtoipaApp};
+///
+/// let a: UtoipaApp<_, _, _> = ntex::web::App::new().into();
 /// ```
 pub struct UtoipaApp<M, F, Err>(ntex::web::App<M, F, Err>, utoipa::openapi::OpenApi)
 where
@@ -180,23 +196,23 @@ where
         >,
     Err: ErrorRenderer,
 {
-    /// Replace the wrapped [`utoipa::openapi::OpenApi`] with given _`openapi`_.
-    ///
-    /// This is useful to prepend OpenAPI doc generated with [`UtoipaApp`]
-    /// with content that cannot be provided directly via [`UtoipaApp`].
-    ///
     /// # Examples
     ///
     /// _**Replace wrapped [`utoipa::openapi::OpenApi`] with custom one.**_
     /// ```rust
-    /// # use utoipa_ntex::web::{AppExt, UtoipaApp};
-    /// # use ntex::web::App;
-    /// # use utoipa::OpenApi;
+    /// use ntex::web::App;
+    /// use utoipa_ntex::{AppExt, UtoipaApp};
+    /// use utoipa::OpenApi;
+    ///
     /// #[derive(OpenApi)]
     /// #[openapi(info(title = "Api title"))]
     /// struct Api;
     ///
-    /// let _ = ntex::web::App::new().into_utoipa_app().openapi(Api::openapi());
+    /// fn example() {
+    ///     let _app = App::new()
+    ///         .into_utoipa_app()
+    ///         .openapi(Api::openapi());
+    /// }
     /// ```
     pub fn openapi(mut self, openapi: utoipa::openapi::OpenApi) -> Self {
         self.1 = openapi;
@@ -313,30 +329,6 @@ where
 
     /// Convenience method to add custom configuration to [`ntex::web::App`] that is not directly
     /// exposed via [`UtoipaApp`]. This could for example be adding middlewares.
-    ///
-    /// # Examples
-    ///
-    /// _**Add middleware via `map` method.**_
-    ///
-    /// ```rust
-    /// # use utoipa_btex::{AppExt, UtoipaApp};
-    /// # use actix_service::Service;
-    /// # use ntex::web::{App, http::header::{HeaderValue, CONTENT_TYPE}};
-    ///
-    ///  let _ = App::new()
-    ///     .into_utoipa_app()
-    ///     .map(|app| {
-    ///            app.wrap_fn(|req, srv| {
-    ///                let fut = srv.call(req);
-    ///                async {
-    ///                    let mut res = fut.await?;
-    ///                    res.headers_mut()
-    ///                        .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
-    ///                    Ok(res)
-    ///                }
-    ///            })
-    ///        });
-    /// ```
     pub fn map<F: FnOnce(ntex::web::App<M, T, Err>) -> ntex::web::App<M, T, Err>>(
         self,
         op: F,
@@ -367,9 +359,9 @@ where
     }
 
     /// Passthrough implementation for [`ntex::web::App::wrap`].
-    pub fn wrap<U>(self, mw: U) -> UtoipaApp<WebStack<M, U, Err>, T, Err> {
-        UtoipaApp(self.0.wrap(mw), self.1)
-    }
+    // pub fn wrap<U>(self, mw: U) -> UtoipaApp<WebStack<M, U, Err>, T, Err> {
+    //     UtoipaApp(self.0.wrap(mw), self.1)
+    // }
 
     /// Passthrough implementation for [`ntex::web::App::case_insensitive_routing`].
     pub fn case_insensitive_routing(self) -> Self {
@@ -394,5 +386,76 @@ where
 {
     fn from(value: UtoipaApp<M, F, Err>) -> Self {
         value.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_json_diff::assert_json_eq;
+    use ntex::web;
+
+    use super::*;
+    use crate::handler::UtoipaHandler;
+
+    #[derive(utoipa::ToSchema, serde::Serialize)]
+    struct User {
+        id: i32,
+    }
+
+    #[utoipa::path(get, path = "/user", responses((status = 200, body = User)))]
+    #[web::get("/user")]
+    async fn get_user() -> web::types::Json<User> {
+        web::types::Json(User { id: 1 })
+    }
+
+    #[utoipa::path(get, path = "/normal", responses((status = 200, body = &str)))]
+    #[web::get("/normal")]
+    async fn normal_service() -> &'static str {
+        "OK"
+    }
+
+    #[utoipa::path(get, path = "/handler1", responses((status = 200, body = &str)))]
+    #[web::get("/handler1")]
+    async fn handler1() -> &'static str {
+        "Handler1"
+    }
+
+    #[utoipa::path(get, path = "/handler2", responses((status = 200, body = &str)))]
+    #[web::get("/handler2")]
+    async fn handler2() -> &'static str {
+        "Handler2"
+    }
+
+    #[test]
+    fn test_app_generate_correct_openapi() {
+        fn config(cfg: &mut service_config::ServiceConfig<web::DefaultError>) {
+            cfg.service(UtoipaHandler::<_, __path_get_user>::new(get_user)) // ✅ fixed here
+                .map(|config| {
+                    config.service(UtoipaHandler::<_, __path_normal_service>::new(
+                        normal_service,
+                    ))
+                });
+        }
+
+        let (_, mut api) = web::App::new()
+            .into_utoipa_app()
+            .service(UtoipaHandler::<_, __path_handler1>::new(handler1))
+            .configure(config)
+            .service(scope::scope("/api/v1/inner").configure(|cfg| {
+                cfg.service(UtoipaHandler::<_, __path_handler1>::new(handler1))
+                    .service(UtoipaHandler::<_, __path_handler2>::new(handler2))
+                    .state(String::new());
+            }))
+            .split_for_parts();
+
+        api.info = utoipa::openapi::info::Info::new("title", "version");
+        let json = api.to_pretty_json().expect("OpenAPI is JSON serializable");
+        println!("{json}");
+
+        let expected = include_str!("../testdata/app_generated_openapi");
+        assert_json_eq!(
+            serde_json::from_str::<serde_json::Value>(&json).unwrap(),
+            serde_json::from_str::<serde_json::Value>(expected).unwrap()
+        );
     }
 }

--- a/utoipa-ntex/src/lib.rs
+++ b/utoipa-ntex/src/lib.rs
@@ -1,0 +1,396 @@
+//! This crate implements necessary bindings for automatically collecting `paths` and `schemas` recursively from Actix Web
+//! `App`, `Scope` and `ServiceConfig`. It provides natural API reducing duplication and support for scopes while generating
+//! OpenAPI specification without the need to declare `paths` and `schemas` to `#[openapi(...)]` attribute of `OpenApi` derive.
+//!
+//! Currently only `service(...)` calls supports automatic collection of schemas and paths. Manual routes via `route(...)` or
+//! `Route::new().to(...)` is not supported.
+//!
+//! ## Install
+//!
+//! Add dependency declaration to `Cargo.toml`.
+//!
+//! ```toml
+//! [dependencies]
+//! utoipa-ntex = "0.1"
+//! ```
+//!
+//! ## Examples
+//!
+//! _**Collect handlers annotated with `#[utoipa::path]` recursively from `service(...)` calls to compose OpenAPI spec.**_
+//!
+//! ```rust
+//! use ntex::web::{Json, get, App};
+//! use utoipa_ntex::{scope, AppExt};
+//!
+//! #[derive(utoipa::ToSchema, serde::Serialize)]
+//! struct User {
+//!     id: i32,
+//! }
+//!
+//! #[utoipa::path(responses((status = OK, body = User)))]
+//! #[get("/user")]
+//! async fn get_user() -> Json<User> {
+//!     Json(User { id: 1 })
+//! }
+//!
+//! let (_, mut api) = App::new()
+//!     .into_utoipa_app()
+//!     .service(scope::scope("/api/v1").service(get_user))
+//!     .split_for_parts();
+//! ```
+
+#![cfg_attr(doc_cfg, feature(doc_cfg))]
+#![warn(missing_docs)]
+#![warn(rustdoc::broken_intra_doc_links)]
+
+pub mod scope;
+pub mod service_config;
+
+use std::fmt;
+
+use ntex::{
+    IntoServiceFactory, ServiceFactory,
+    web::{ErrorRenderer, Route, WebRequest, WebResponse, WebServiceFactory, stack::WebStack},
+};
+use service_config::ServiceConfig;
+use utoipa::{OpenApi, openapi::PathItem};
+
+/// This trait is used to unify OpenAPI items collection from types implementing this trait.
+pub trait OpenApiFactory {
+    /// Get OpenAPI paths.
+    fn paths(&self) -> utoipa::openapi::path::Paths;
+    /// Collect schema reference and append them to the _`schemas`_.
+    fn schemas(
+        &self,
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    );
+}
+
+impl<'t, T: utoipa::Path + utoipa::__dev::SchemaReferences + utoipa::__dev::Tags<'t>> OpenApiFactory
+    for T
+{
+    fn paths(&self) -> utoipa::openapi::path::Paths {
+        let methods = T::methods();
+
+        methods
+            .into_iter()
+            .fold(
+                utoipa::openapi::path::Paths::builder(),
+                |mut builder, method| {
+                    let mut operation = T::operation();
+                    let other_tags = T::tags();
+                    if !other_tags.is_empty() {
+                        let tags = operation.tags.get_or_insert(Vec::new());
+                        tags.extend(other_tags.into_iter().map(ToString::to_string));
+                    };
+
+                    let path_item = PathItem::new(method, operation);
+                    builder = builder.path(T::path(), path_item);
+
+                    builder
+                },
+            )
+            .build()
+    }
+
+    fn schemas(
+        &self,
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        <T as utoipa::__dev::SchemaReferences>::schemas(schemas);
+    }
+}
+
+/// Extends [`ntex::web::App`] with `utoipa` related functionality.
+pub trait AppExt<M, F, Err>
+where
+    Err: ErrorRenderer,
+{
+    /// Convert's this [`ntex::web::App`] to [`UtoipaApp`].
+    ///
+    /// See usage from [`UtoipaApp`][struct@UtoipaApp]
+    fn into_utoipa_app(self) -> UtoipaApp<M, F, Err>;
+}
+
+impl<M, F, Err> AppExt<M, F, Err> for ntex::web::App<M, F, Err>
+where
+    Err: ErrorRenderer,
+{
+    fn into_utoipa_app(self) -> UtoipaApp<M, F, Err> {
+        UtoipaApp::from(self)
+    }
+}
+
+/// Wrapper type for [`ntex::web::App`] and [`utoipa::openapi::OpenApi`].
+///
+/// [`UtoipaApp`] behaves exactly same way as [`ntex::web::App`] but allows automatic _`schema`_ and
+/// _`path`_ collection from `service(...)` calls directly or via [`ServiceConfig::service`].
+///
+/// It exposes typical methods from [`ntex::web::App`] and provides custom [`UtoipaApp::map`]
+/// method to add additional configuration options to wrapper [`ntex::web::App`].
+///
+/// This struct need be instantiated from [`ntex::web::App`] by calling `.into_utoipa_app()`
+/// because we do not have access to _`ntex::web::App<M, F, Err>`_ generic argument and the _`App`_ does
+/// not provide any default implementation.
+///
+/// # Examples
+///
+/// _**Create new [`UtoipaApp`] instance.**_
+/// ```rust
+/// # use utoipa_ntex::{AppExt, UtoipaApp};
+/// # use ntex::web::App;
+/// let utoipa_app = App::new().into_utoipa_app();
+/// ```
+///
+/// _**Convert `ntex::web::App<M, F, Err>` to `UtoipaApp<M, F, Err>`.**_
+/// ```rust
+/// # use utoipa_ntex::{AppExt, UtoipaApp};
+/// # use ntex::web::App;
+/// let a: UtoipaApp<_> = ntex::web::App::new().into();
+/// ```
+pub struct UtoipaApp<M, F, Err>(ntex::web::App<M, F, Err>, utoipa::openapi::OpenApi)
+where
+    Err: ErrorRenderer;
+
+impl<M, T, Err> From<ntex::web::App<M, T, Err>> for UtoipaApp<M, T, Err>
+where
+    Err: ErrorRenderer,
+{
+    fn from(value: ntex::web::App<M, T, Err>) -> Self {
+        #[derive(OpenApi)]
+        struct Api;
+        UtoipaApp(value, Api::openapi())
+    }
+}
+
+impl<M, T, Err> UtoipaApp<M, T, Err>
+where
+    T: ServiceFactory<
+            WebRequest<Err>,
+            Response = WebRequest<Err>,
+            Error = Err::Container,
+            InitError = (),
+        >,
+    Err: ErrorRenderer,
+{
+    /// Replace the wrapped [`utoipa::openapi::OpenApi`] with given _`openapi`_.
+    ///
+    /// This is useful to prepend OpenAPI doc generated with [`UtoipaApp`]
+    /// with content that cannot be provided directly via [`UtoipaApp`].
+    ///
+    /// # Examples
+    ///
+    /// _**Replace wrapped [`utoipa::openapi::OpenApi`] with custom one.**_
+    /// ```rust
+    /// # use utoipa_ntex::web::{AppExt, UtoipaApp};
+    /// # use ntex::web::App;
+    /// # use utoipa::OpenApi;
+    /// #[derive(OpenApi)]
+    /// #[openapi(info(title = "Api title"))]
+    /// struct Api;
+    ///
+    /// let _ = ntex::web::App::new().into_utoipa_app().openapi(Api::openapi());
+    /// ```
+    pub fn openapi(mut self, openapi: utoipa::openapi::OpenApi) -> Self {
+        self.1 = openapi;
+
+        self
+    }
+
+    /// Passthrough implementation for [`ntex::web::App::state`].
+    pub fn state<U: 'static>(self, state: U) -> Self {
+        Self(self.0.state(state), self.1)
+    }
+
+    /// Passthrough implementation for [`ntex::web::App::state_factory`].
+    pub fn state_factory<F, Out, D, E>(self, state: F) -> Self
+    where
+        F: Fn() -> Out + 'static,
+        Out: Future<Output = Result<D, E>> + 'static,
+        D: 'static,
+        E: fmt::Debug,
+    {
+        Self(self.0.state_factory(state), self.1)
+    }
+
+    /// Extended version of [`ntex::web::App::configure`] which handles _`schema`_ and _`path`_
+    /// collection from [`ServiceConfig`] into the wrapped [`utoipa::openapi::OpenApi`] instance.
+    pub fn configure<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&mut ServiceConfig<Err>),
+    {
+        let mut openapi = self.1;
+
+        let app = self.0.configure(|config| {
+            let mut service_config = ServiceConfig::new(config);
+
+            f(&mut service_config);
+
+            let paths = service_config.paths.take();
+            openapi.paths.merge(paths);
+            let schemas = service_config.schemas.take();
+            let components = openapi
+                .components
+                .get_or_insert(utoipa::openapi::Components::new());
+            components.schemas.extend(schemas);
+        });
+
+        Self(app, openapi)
+    }
+
+    /// Passthrough implementation for [`ntex::web::App::route`].
+    pub fn route(self, path: &str, route: Route<Err>) -> Self {
+        Self(self.0.route(path, route), self.1)
+    }
+
+    /// Extended version of [`ntex::web::App::service`] method which handles _`schema`_ and _`path`_
+    /// collection from [`HttpServiceFactory`].
+    pub fn service<F>(self, factory: F) -> Self
+    where
+        F: WebServiceFactory<Err> + OpenApiFactory + 'static,
+    {
+        let mut schemas = Vec::<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>::new();
+
+        factory.schemas(&mut schemas);
+        let paths = factory.paths();
+
+        let mut openapi = self.1;
+
+        openapi.paths.merge(paths);
+        let components = openapi
+            .components
+            .get_or_insert(utoipa::openapi::Components::new());
+        components.schemas.extend(schemas);
+
+        let app = self.0.service(factory);
+
+        Self(app, openapi)
+    }
+
+    /// Helper method to serve wrapped [`utoipa::openapi::OpenApi`] via [`HttpServiceFactory`].
+    ///
+    /// This method functions as a convenience to serve the wrapped OpenAPI spec alternatively to
+    /// first call [`UtoipaApp::split_for_parts`] and then calling [`ntex::web::App::service`].
+    pub fn openapi_service<O, F>(self, factory: F) -> Self
+    where
+        F: FnOnce(utoipa::openapi::OpenApi) -> O,
+        O: WebServiceFactory<Err> + 'static,
+    {
+        let service = factory(self.1.clone());
+        let app = self.0.service(service);
+        Self(app, self.1)
+    }
+
+    /// Passthrough implementation for [`ntex::web::App::default_service`].
+    pub fn default_service<F, U>(self, f: F) -> Self
+    where
+        F: IntoServiceFactory<U, WebRequest<Err>>,
+        U: ServiceFactory<WebRequest<Err>, Response = WebResponse, Error = Err::Container>
+            + 'static,
+        U::InitError: fmt::Debug,
+    {
+        Self(self.0.default_service(f), self.1)
+    }
+
+    /// Passthrough implementation for [`ntex::web::App::external_resource`].
+    pub fn external_resource<N, U>(self, name: N, url: U) -> Self
+    where
+        N: AsRef<str>,
+        U: AsRef<str>,
+    {
+        Self(self.0.external_resource(name, url), self.1)
+    }
+
+    /// Convenience method to add custom configuration to [`ntex::web::App`] that is not directly
+    /// exposed via [`UtoipaApp`]. This could for example be adding middlewares.
+    ///
+    /// # Examples
+    ///
+    /// _**Add middleware via `map` method.**_
+    ///
+    /// ```rust
+    /// # use utoipa_btex::{AppExt, UtoipaApp};
+    /// # use actix_service::Service;
+    /// # use ntex::web::{App, http::header::{HeaderValue, CONTENT_TYPE}};
+    ///  let _ = App::new()
+    ///     .into_utoipa_app()
+    ///     .map(|app| {
+    ///            app.wrap_fn(|req, srv| {
+    ///                let fut = srv.call(req);
+    ///                async {
+    ///                    let mut res = fut.await?;
+    ///                    res.headers_mut()
+    ///                        .insert(CONTENT_TYPE, HeaderValue::from_static("text/plain"));
+    ///                    Ok(res)
+    ///                }
+    ///            })
+    ///        });
+    /// ```
+    pub fn map<F: FnOnce(ntex::web::App<M, T, Err>) -> ntex::web::App<M, T, Err>>(
+        self,
+        op: F,
+    ) -> UtoipaApp<M, T, Err> {
+        let app = op(self.0);
+        UtoipaApp(app, self.1)
+    }
+
+    /// Passthrough implementation for [`ntex::web::App::filter`].
+    pub fn filter<S, U>(
+        self,
+        filter: U,
+    ) -> UtoipaApp<
+        M,
+        impl ServiceFactory<
+            WebRequest<Err>,
+            Response = WebRequest<Err>,
+            Error = Err::Container,
+            InitError = (),
+        >,
+        Err,
+    >
+    where
+        S: ServiceFactory<WebRequest<Err>, Response = WebRequest<Err>, Error = Err::Container>,
+        U: IntoServiceFactory<S, WebRequest<Err>>,
+    {
+        UtoipaApp(self.0.filter(filter), self.1)
+    }
+
+    /// Passthrough implementation for [`ntex::web::App::wrap`].
+    pub fn wrap<U>(self, mw: U) -> UtoipaApp<WebStack<M, U, Err>, T, Err> {
+        UtoipaApp(self.0.wrap(mw), self.1)
+    }
+
+    /// Passthrough implementation for [`ntex::web::App::case_insensitive_routing`].
+    pub fn case_insensitive_routing(self) -> Self {
+        Self(self.0.case_insensitive_routing(), self.1)
+    }
+
+    /// Split this [`UtoipaApp`] into parts returning tuple of [`actix_web::App`] and
+    /// [`utoipa::openapi::OpenApi`] of this instance.
+    pub fn split_for_parts(self) -> (ntex::web::App<M, T, Err>, utoipa::openapi::OpenApi) {
+        (self.0, self.1)
+    }
+
+    /// Converts this [`UtoipaApp`] into the wrapped [`ntex::web::App`].
+    pub fn into_app(self) -> ntex::web::App<M, T, Err> {
+        self.0
+    }
+}
+
+impl<M, F, Err> From<UtoipaApp<M, F, Err>> for ntex::web::App<M, F, Err>
+where
+    Err: ErrorRenderer,
+{
+    fn from(value: UtoipaApp<M, F, Err>) -> Self {
+        value.0
+    }
+}

--- a/utoipa-ntex/src/lib.rs
+++ b/utoipa-ntex/src/lib.rs
@@ -43,6 +43,7 @@
 #![warn(missing_docs)]
 #![warn(rustdoc::broken_intra_doc_links)]
 
+pub mod handler;
 pub mod scope;
 pub mod service_config;
 
@@ -321,6 +322,7 @@ where
     /// # use utoipa_btex::{AppExt, UtoipaApp};
     /// # use actix_service::Service;
     /// # use ntex::web::{App, http::header::{HeaderValue, CONTENT_TYPE}};
+    ///
     ///  let _ = App::new()
     ///     .into_utoipa_app()
     ///     .map(|app| {

--- a/utoipa-ntex/src/scope.rs
+++ b/utoipa-ntex/src/scope.rs
@@ -9,8 +9,8 @@ use std::{
 use ntex::{
     IntoServiceFactory, ServiceFactory,
     web::{
-        ErrorRenderer, Route, WebRequest, WebResponse, WebServiceFactory, guard::Guard,
-        stack::WebStack,
+        ErrorRenderer, Route, WebRequest, WebResponse, WebServiceFactory, dev::WebServiceConfig,
+        guard::Guard, stack::WebStack,
     },
 };
 
@@ -265,5 +265,15 @@ where
         if let Some(components) = &mut api.components {
             schemas.extend(std::mem::take(&mut components.schemas));
         }
+    }
+}
+
+impl<Err, M, T> WebServiceFactory<Err> for Scope<Err, M, T>
+where
+    ntex::web::Scope<Err, M, T>: WebServiceFactory<Err>,
+    Err: ErrorRenderer,
+{
+    fn register(self, config: &mut WebServiceConfig<Err>) {
+        self.0.register(config)
     }
 }

--- a/utoipa-ntex/src/scope.rs
+++ b/utoipa-ntex/src/scope.rs
@@ -10,7 +10,7 @@ use ntex::{
     IntoServiceFactory, ServiceFactory,
     web::{
         ErrorRenderer, Route, WebRequest, WebResponse, WebServiceFactory, dev::WebServiceConfig,
-        guard::Guard, stack::WebStack,
+        guard::Guard,
     },
 };
 
@@ -75,19 +75,22 @@ where
 /// _**Create new scoped service.**_
 ///
 /// ```rust
-/// # use ntex::web::{get, App};
-/// # use utoipa_ntex::{AppExt, scope};
-/// #
-///  #[utoipa::path()]
-///  #[get("/handler")]
-///  pub async fn handler() -> &'static str {
-///      "OK"
-///  }
-/// let _ = App::new()
-///     .into_utoipa_app()
-///     .service(scope::scope("/api/v1/inner").configure(|cfg| {
-///         cfg.service(handler);
-///     }));
+/// use ntex::web::{get, App};
+/// use utoipa_ntex::{AppExt, scope, handler::UtoipaHandler};
+///
+/// #[utoipa::path(get, path = "/handler", responses((status = 200)))]
+/// #[get("/handler")]
+/// async fn handler() -> &'static str {
+///     "OK"
+/// }
+///
+/// fn example() {
+///     let _ = App::new()
+///         .into_utoipa_app()
+///         .service(scope::scope("/api/v1/inner").configure(|cfg| {
+///             cfg.service(UtoipaHandler::<_, __path_handler>::new(handler));
+///         }));
+/// }
 /// ```
 pub fn scope<Err, M, T, I>(scope: I) -> Scope<Err, M, T>
 where
@@ -219,10 +222,11 @@ where
         Scope(self.0.filter(filter), self.1, self.2)
     }
 
-    /// Passthrough implementation for [`ntex::web::Scope::wrap`].
-    pub fn wrap<U>(self, mw: U) -> Scope<Err, WebStack<M, U, Err>, T> {
-        Scope(self.0.wrap(mw), self.1, self.2)
-    }
+    // Need to update this when ntex is updated to pub WebStack to available for passthrough the Scope::wrap
+    // / Passthrough implementation for [`ntex::web::Scope::wrap`].
+    // pub fn wrap<U>(self, mw: U) -> Scope<Err, WebStack<M, U, Err>, T> {
+    //     Scope(self.0.wrap(mw), self.1, self.2)
+    // }
 }
 
 impl<Err, M, T> OpenApiFactory for Scope<Err, M, T>

--- a/utoipa-ntex/src/scope.rs
+++ b/utoipa-ntex/src/scope.rs
@@ -1,0 +1,269 @@
+//! Implement `utoipa` extended [`Scope`] for [`ntex::web::Scope`].
+//!
+//! See usage from [`scope`][fn@scope].
+use std::{
+    cell::{Cell, RefCell},
+    fmt,
+};
+
+use ntex::{
+    IntoServiceFactory, ServiceFactory,
+    web::{
+        ErrorRenderer, Route, WebRequest, WebResponse, WebServiceFactory, guard::Guard,
+        stack::WebStack,
+    },
+};
+
+use crate::{OpenApiFactory, service_config::ServiceConfig};
+
+/// Wrapper type for [`ntex::web::Scope`] and [`utoipa::openapi::OpenApi`] with additional path
+/// prefix created with `scope::scope("path-prefix")` call.
+///
+/// See usage from [`scope`][fn@scope].
+pub struct Scope<Err, M, T>(
+    ntex::web::Scope<Err, M, T>,
+    RefCell<utoipa::openapi::OpenApi>,
+    Cell<String>,
+)
+where
+    Err: ErrorRenderer;
+
+impl<Err, M, T> From<ntex::web::Scope<Err, M, T>> for Scope<Err, M, T>
+where
+    T: ServiceFactory<
+            WebRequest<Err>,
+            Response = WebRequest<Err>,
+            Error = Err::Container,
+            InitError = (),
+        >,
+    Err: ErrorRenderer,
+{
+    fn from(value: ntex::web::Scope<Err, M, T>) -> Self {
+        Self(
+            value,
+            RefCell::new(utoipa::openapi::OpenApiBuilder::new().build()),
+            Cell::new(String::new()),
+        )
+    }
+}
+
+impl<'s, Err, M, T> From<&'s str> for Scope<Err, M, T>
+where
+    Scope<Err, M, T>: std::convert::From<ntex::web::Scope<Err>>,
+    T: ServiceFactory<
+            WebRequest<Err>,
+            Response = WebRequest<Err>,
+            Error = Err::Container,
+            InitError = (),
+        >,
+    Err: ErrorRenderer,
+{
+    fn from(value: &'s str) -> Self {
+        let scope = ntex::web::Scope::<Err>::new(value);
+        let s: Scope<Err, M, T> = scope.into();
+        Scope(s.0, s.1, Cell::new(String::from(value)))
+    }
+}
+
+/// Create a new [`Scope`] with given _`scope`_ e.g. `scope("/api/v1")`.
+///
+/// This behaves exactly same way as [`ntex::web::Scope`] but allows automatic _`schema`_ and
+/// _`path`_ collection from `service(...)` calls directly or via [`ServiceConfig::service`].
+///
+/// # Examples
+///
+/// _**Create new scoped service.**_
+///
+/// ```rust
+/// # use ntex::web::{get, App};
+/// # use utoipa_ntex::{AppExt, scope};
+/// #
+///  #[utoipa::path()]
+///  #[get("/handler")]
+///  pub async fn handler() -> &'static str {
+///      "OK"
+///  }
+/// let _ = App::new()
+///     .into_utoipa_app()
+///     .service(scope::scope("/api/v1/inner").configure(|cfg| {
+///         cfg.service(handler);
+///     }));
+/// ```
+pub fn scope<Err, M, T, I>(scope: I) -> Scope<Err, M, T>
+where
+    I: Into<Scope<Err, M, T>>,
+    T: ServiceFactory<
+            WebRequest<Err>,
+            Response = WebRequest<Err>,
+            Error = Err::Container,
+            InitError = (),
+        >,
+    Err: ErrorRenderer,
+{
+    scope.into()
+}
+
+impl<Err, M, T> Scope<Err, M, T>
+where
+    T: ServiceFactory<
+            WebRequest<Err>,
+            Response = WebRequest<Err>,
+            Error = Err::Container,
+            InitError = (),
+        >,
+    Err: ErrorRenderer,
+{
+    /// Passthrough implementation for [`ntex::web::Scope::guard`].
+    pub fn guard<G: Guard + 'static>(self, guard: G) -> Self {
+        Self(self.0.guard(guard), self.1, self.2)
+    }
+
+    /// Passthrough implementation for [`ntex::web::Scope::state`].
+    pub fn state<D: 'static>(self, st: D) -> Self {
+        Self(self.0.state(st), self.1, self.2)
+    }
+
+    /// Passthrough implementation for [`ntex::web::Scope::case_insensitive_routing`].
+    pub fn case_insensitive_routing(self) -> Self {
+        Self(self.0.case_insensitive_routing(), self.1, self.2)
+    }
+
+    /// Synonymous for [`UtoipaApp::configure`][utoipa_app_configure]
+    ///
+    /// [utoipa_app_configure]: ../struct.UtoipaApp.html#method.configure
+    pub fn configure<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&mut ServiceConfig<Err>),
+    {
+        let mut openapi = self.1.borrow_mut();
+
+        let scope = self.0.configure(|config| {
+            let mut service_config = ServiceConfig::new(config);
+
+            f(&mut service_config);
+
+            let other_paths = service_config.paths.take();
+            openapi.paths.merge(other_paths);
+            let schemas = service_config.schemas.take();
+            let components = openapi
+                .components
+                .get_or_insert(utoipa::openapi::Components::new());
+            components.schemas.extend(schemas);
+        });
+        drop(openapi);
+
+        Self(scope, self.1, self.2)
+    }
+
+    /// Synonymous for [`UtoipaApp::service`][utoipa_app_service]
+    ///
+    /// [utoipa_app_service]: ../struct.UtoipaApp.html#method.service
+    pub fn service<F>(self, factory: F) -> Self
+    where
+        F: WebServiceFactory<Err> + OpenApiFactory + 'static,
+    {
+        let mut schemas = Vec::<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>::new();
+        {
+            let mut openapi = self.1.borrow_mut();
+            let other_paths = factory.paths();
+            factory.schemas(&mut schemas);
+            openapi.paths.merge(other_paths);
+            let components = openapi
+                .components
+                .get_or_insert(utoipa::openapi::Components::new());
+            components.schemas.extend(schemas);
+        }
+
+        let app = self.0.service(factory);
+
+        Self(app, self.1, self.2)
+    }
+
+    /// Passthrough implementation for [`ntex::web::Scope::route`].
+    pub fn route(self, path: &str, route: Route<Err>) -> Self {
+        Self(self.0.route(path, route), self.1, self.2)
+    }
+
+    /// Passthrough implementation for [`ntex::web::Scope::default_service`].
+    pub fn default_service<F, S>(self, f: F) -> Self
+    where
+        F: IntoServiceFactory<S, WebRequest<Err>>,
+        S: ServiceFactory<WebRequest<Err>, Response = WebResponse, Error = Err::Container>
+            + 'static,
+        S::InitError: fmt::Debug,
+    {
+        Self(self.0.default_service(f), self.1, self.2)
+    }
+
+    /// Passthrough implementation for [`ntex::web::Scope::filter`].
+    pub fn filter<U, F>(
+        self,
+        filter: F,
+    ) -> Scope<
+        Err,
+        M,
+        impl ServiceFactory<
+            WebRequest<Err>,
+            Response = WebRequest<Err>,
+            Error = Err::Container,
+            InitError = (),
+        >,
+    >
+    where
+        U: ServiceFactory<WebRequest<Err>, Response = WebRequest<Err>, Error = Err::Container>,
+        F: IntoServiceFactory<U, WebRequest<Err>>,
+    {
+        Scope(self.0.filter(filter), self.1, self.2)
+    }
+
+    /// Passthrough implementation for [`ntex::web::Scope::wrap`].
+    pub fn wrap<U>(self, mw: U) -> Scope<Err, WebStack<M, U, Err>, T> {
+        Scope(self.0.wrap(mw), self.1, self.2)
+    }
+}
+
+impl<Err, M, T> OpenApiFactory for Scope<Err, M, T>
+where
+    T: ServiceFactory<
+            WebRequest<Err>,
+            Response = WebRequest<Err>,
+            Error = Err::Container,
+            InitError = (),
+        >,
+    Err: ErrorRenderer,
+{
+    fn paths(&self) -> utoipa::openapi::path::Paths {
+        let prefix = self.2.take();
+        let mut openapi = self.1.borrow_mut();
+        let mut paths = std::mem::take(&mut openapi.paths);
+
+        let prefixed_paths = paths
+            .paths
+            .into_iter()
+            .map(|(path, item)| {
+                let path = format!("{prefix}{path}");
+
+                (path, item)
+            })
+            .collect::<utoipa::openapi::path::PathsMap<_, _>>();
+        paths.paths = prefixed_paths;
+
+        paths
+    }
+
+    fn schemas(
+        &self,
+        schemas: &mut Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    ) {
+        let mut api = self.1.borrow_mut();
+        if let Some(components) = &mut api.components {
+            schemas.extend(std::mem::take(&mut components.schemas));
+        }
+    }
+}

--- a/utoipa-ntex/src/service_config.rs
+++ b/utoipa-ntex/src/service_config.rs
@@ -1,0 +1,88 @@
+//! Implement `utoipa` extended [`ServiceConfig`] for [`ntex::web::ServiceConfig`].
+
+use std::cell::Cell;
+
+use ntex::web::{ErrorRenderer, Route, WebServiceFactory};
+
+use crate::OpenApiFactory;
+
+/// Wrapper type for [`ntex::web::ServiceConfig`], [`utoipa::openapi::path::Paths`] and
+/// vec of [`utoipa::openapi::schema::Schema`] references.
+pub struct ServiceConfig<'s, Err> {
+    pub(super) service_config: &'s mut ntex::web::ServiceConfig<Err>,
+    pub(super) paths: Cell<utoipa::openapi::path::Paths>,
+    pub(super) schemas: Cell<
+        Vec<(
+            String,
+            utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>,
+        )>,
+    >,
+}
+
+impl<'s, Err: ErrorRenderer> ServiceConfig<'s, Err> {
+    /// Construct a new [`ServiceConfig`] from given [`ntex::web::ServiceConfig`].
+    pub fn new(service_config: &'s mut ntex::web::ServiceConfig<Err>) -> ServiceConfig<'s, Err> {
+        ServiceConfig {
+            service_config,
+            paths: Cell::new(utoipa::openapi::path::Paths::new()),
+            schemas: Cell::new(Vec::new()),
+        }
+    }
+
+    /// Passthrough implementation for [`ntex::web::ServiceConfig::state`].
+    pub fn state<S: 'static>(&mut self, st: S) -> &mut Self {
+        self.service_config.state(st);
+        self
+    }
+
+    /// Passthrough implementation for [`ntex::web::ServiceConfig::route`].
+    pub fn route(&mut self, path: &str, route: Route<Err>) -> &mut Self {
+        self.service_config.route(path, route);
+        self
+    }
+
+    /// Counterpart for [`UtoipaApp::service`][utoipa_app_service].
+    ///
+    /// [utoipa_app_service]: ../struct.UtoipaApp.html#method.service
+    pub fn service<F>(&mut self, factory: F) -> &mut Self
+    where
+        F: WebServiceFactory<Err> + OpenApiFactory + 'static,
+    {
+        let mut paths = self.paths.take();
+        let other_paths = factory.paths();
+        paths.merge(other_paths);
+
+        let mut schemas = self.schemas.take();
+        factory.schemas(&mut schemas);
+        self.schemas.set(schemas);
+
+        self.service_config.service(factory);
+        self.paths.set(paths);
+
+        self
+    }
+
+    /// Passthrough implementation for [`ntex::web::ServiceConfig::external_resource`].
+    pub fn external_resource<N, U>(&mut self, name: N, url: U) -> &mut Self
+    where
+        N: AsRef<str>,
+        U: AsRef<str>,
+    {
+        self.service_config.external_resource(name, url);
+        self
+    }
+
+    /// Synonymous for [`UtoipaApp::map`][utoipa_app_map]
+    ///
+    /// [utoipa_app_map]: ../struct.UtoipaApp.html#method.map
+    pub fn map<
+        F: FnOnce(&mut ntex::web::ServiceConfig<Err>) -> &mut ntex::web::ServiceConfig<Err>,
+    >(
+        &mut self,
+        op: F,
+    ) -> &mut Self {
+        op(self.service_config);
+
+        self
+    }
+}

--- a/utoipa-ntex/testdata/app_generated_openapi
+++ b/utoipa-ntex/testdata/app_generated_openapi
@@ -1,0 +1,93 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "title",
+    "version": "version"
+  },
+  "paths": {
+    "/api/v1/inner/handler1": {
+      "get": {
+        "operationId": "handler1",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/inner/handler2": {
+      "get": {
+        "operationId": "handler2",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/handler1": {
+      "get": {
+        "operationId": "handler1",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user": {
+      "get": {
+        "operationId": "get_user",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "User": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

This PR introduces an initial implementation of `utoipa-ntex`, a crate that integrates Utoipa with the `ntex` web framework.

While the core functionality is working, and some basic unit tests have been written to verify basic documentation generation, the crate is still in a preliminary stage and may require additional refinements.

## Motivation

There has been growing interest in using `utoipa` with alternative Rust web frameworks. This crate aims to fill that gap for `ntex`, by providing derive-based OpenAPI documentation support similar to `utoipa-actix-web` and `utoipa-axum`.

## Current Limitations

- The implementation currently wraps the `App`, `ServiceConfig`, `Scope` and related types to enable extraction and documentation.
- However, we are awaiting a potential change in the `ntex` crate to make `WebStack` public that I available to do the wrapper for `wrap()` in `Scope`, which is necessary to properly support certain integrations.
- As such, this PR may be considered a starting point, and feedback is highly appreciated.

## What's Next

- Improve wrappers for better completeness and edge-case handling.
- Add Swagger UI integration to make it easier to visualize and test the docs.

## Request

I’d appreciate your review and input on this initial implementation:
- Are there design changes you'd suggest before this can be considered for inclusion or endorsement?
- Once `WebStack` is made public in `ntex`, this crate should be able to support more advanced use cases.

Thank you for creating and maintaining `utoipa`.
It's an amazing library and I’m excited to contribute to its ecosystem.

---

Best regards 🙇‍♂️,  
Ruangyot (Rayato159)
