### PR TITLE
Chore fix clippy lints

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "stable"

--- a/utoipa-config/src/lib.rs
+++ b/utoipa-config/src/lib.rs
@@ -102,7 +102,7 @@ impl<'de> Deserialize<'de> for SchemaCollect {
         D: serde::Deserializer<'de>,
     {
         struct SchemaCollectVisitor;
-        impl<'d> Visitor<'d> for SchemaCollectVisitor {
+        impl Visitor<'_> for SchemaCollectVisitor {
             type Value = SchemaCollect;
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
                 formatter.write_str("expected str `all` or `non_inlined`")

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -87,7 +87,7 @@ enum TypeTreeValueIter<'a, T> {
     Iter(Box<dyn std::iter::Iterator<Item = T> + 'a>),
 }
 
-impl<'a, T> TypeTreeValueIter<'a, T> {
+impl<T> TypeTreeValueIter<'_, T> {
     fn once(item: T) -> Self {
         Self::Once(std::iter::once(item))
     }
@@ -97,7 +97,7 @@ impl<'a, T> TypeTreeValueIter<'a, T> {
     }
 }
 
-impl<'a, T> Iterator for TypeTreeValueIter<'a, T> {
+impl<T> Iterator for TypeTreeValueIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -137,7 +137,7 @@ pub trait SynPathExt {
     fn rewrite_path(&self) -> Result<syn::Path, Diagnostics>;
 }
 
-impl<'p> SynPathExt for &'p Path {
+impl SynPathExt for &Path {
     fn rewrite_path(&self) -> Result<syn::Path, Diagnostics> {
         let last_segment = self
             .segments
@@ -1562,7 +1562,7 @@ enum ChildRefIter<'c, T> {
     Empty,
 }
 
-impl<'a, T> Iterator for ChildRefIter<'a, T> {
+impl<T> Iterator for ChildRefIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/utoipa-gen/src/component/schema/enums.rs
+++ b/utoipa-gen/src/component/schema/enums.rs
@@ -997,7 +997,7 @@ pub struct OneOf<'a, T: ToTokens> {
     discriminator: Option<Feature>,
 }
 
-impl<'a, T> ToTokens for OneOf<'a, T>
+impl<T> ToTokens for OneOf<'_, T>
 where
     T: ToTokens,
 {
@@ -1035,7 +1035,7 @@ pub enum Roo<'t, T> {
     Owned(T),
 }
 
-impl<'t, T> Deref for Roo<'t, T> {
+impl<T> Deref for Roo<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -1046,7 +1046,7 @@ impl<'t, T> Deref for Roo<'t, T> {
     }
 }
 
-impl<'t, T> AsRef<T> for Roo<'t, T> {
+impl<T> AsRef<T> for Roo<'_, T> {
     fn as_ref(&self) -> &T {
         self.deref()
     }

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -378,25 +378,25 @@ pub mod fn_arg {
         }
     }
 
-    impl<'a> Ord for FnArg<'a> {
+    impl Ord for FnArg<'_> {
         fn cmp(&self, other: &Self) -> std::cmp::Ordering {
             self.arg_type.cmp(&other.arg_type)
         }
     }
 
-    impl<'a> PartialOrd for FnArg<'a> {
+    impl PartialOrd for FnArg<'_> {
         fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
             Some(self.arg_type.cmp(&other.arg_type))
         }
     }
 
-    impl<'a> PartialEq for FnArg<'a> {
+    impl PartialEq for FnArg<'_> {
         fn eq(&self, other: &Self) -> bool {
             self.ty == other.ty && self.arg_type == other.arg_type
         }
     }
 
-    impl<'a> Eq for FnArg<'a> {}
+    impl Eq for FnArg<'_> {}
 
     pub fn get_fn_args(
         fn_args: &Punctuated<syn::FnArg, Comma>,

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -3123,7 +3123,7 @@ where
     }
 }
 
-impl<'a, T> Deref for Array<'a, T>
+impl<T> Deref for Array<'_, T>
 where
     T: Sized + ToTokens,
 {
@@ -3415,7 +3415,7 @@ trait GenericsExt {
     fn get_generic_type_param_index(&self, type_tree: &TypeTree) -> Option<usize>;
 }
 
-impl<'g> GenericsExt for &'g syn::Generics {
+impl GenericsExt for &syn::Generics {
     fn get_generic_type_param_index(&self, type_tree: &TypeTree) -> Option<usize> {
         let ident = &type_tree
             .path
@@ -3615,7 +3615,7 @@ impl AttributesExt for Vec<syn::Attribute> {
     }
 }
 
-impl<'a> AttributesExt for &'a [syn::Attribute] {
+impl AttributesExt for &[syn::Attribute] {
     fn has_deprecated(&self) -> bool {
         self.iter().any(|attr| {
             matches!(attr.path().get_ident(), Some(ident) if &*ident.to_string() == "deprecated")

--- a/utoipa-gen/src/openapi/info.rs
+++ b/utoipa-gen/src/openapi/info.rs
@@ -459,7 +459,7 @@ mod tests {
             _ => panic!(),
         }
 
-        assert!(matches!(info.terms_of_service, None));
+        assert!(info.terms_of_service.is_none());
 
         match info.license {
             Some(license) => {

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -332,7 +332,7 @@ impl<'p> Path<'p> {
     }
 }
 
-impl<'p> ToTokensDiagnostics for Path<'p> {
+impl ToTokensDiagnostics for Path<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) -> Result<(), Diagnostics> {
         let fn_name = &*self.fn_ident.to_string();
         let operation_id = self
@@ -727,7 +727,7 @@ pub trait PathTypeTree {
     fn is_array(&self) -> bool;
 }
 
-impl<'p> PathTypeTree for TypeTree<'p> {
+impl PathTypeTree for TypeTree<'_> {
     /// Resolve default content type based on current [`Type`].
     fn get_default_content_type(&self) -> Cow<'static, str> {
         if self.is_array()

--- a/utoipa-gen/src/path/handler.rs
+++ b/utoipa-gen/src/path/handler.rs
@@ -10,7 +10,7 @@ pub struct Handler<'p> {
     pub handler_fn: &'p ItemFn,
 }
 
-impl<'p> ToTokensDiagnostics for Handler<'p> {
+impl ToTokensDiagnostics for Handler<'_> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) -> Result<(), crate::Diagnostics> {
         let ast_fn = &self.handler_fn;
         let path = as_tokens_or_diagnostics!(&self.path);

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -86,7 +86,7 @@ pub enum ResponseComponentSchemaIter<'a, T> {
     Empty,
 }
 
-impl<'a, T> Iterator for ResponseComponentSchemaIter<'a, T> {
+impl<T> Iterator for ResponseComponentSchemaIter<'_, T> {
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -414,7 +414,7 @@ struct ToResponseNamedStructResponse<'p>(ResponseTuple<'p>);
 
 impl Response for ToResponseNamedStructResponse<'_> {}
 
-impl<'p> ToResponseNamedStructResponse<'p> {
+impl ToResponseNamedStructResponse<'_> {
     fn new(
         attributes: &[Attribute],
         ident: &Ident,

--- a/utoipa-swagger-ui/CHANGELOG.md
+++ b/utoipa-swagger-ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-swagger-ui
 
+## Unreleased
+
+### Fixed
+
+* fix: mismatch error from InvalidArchive (#1343)
+
 ## 9.0.0 - Thu 16 2025
 
 ### Changed

--- a/utoipa-swagger-ui/build.rs
+++ b/utoipa-swagger-ui/build.rs
@@ -9,14 +9,14 @@ use std::{
 use regex::Regex;
 use zip::{result::ZipError, ZipArchive};
 
-/// the following env variables control the build process:
-/// 1. SWAGGER_UI_DOWNLOAD_URL:
-/// + the url from where to download the swagger-ui zip file if starts with http:// or https://
-/// + the file path from where to copy the swagger-ui zip file if starts with file://
-/// + default value is SWAGGER_UI_DOWNLOAD_URL_DEFAULT
-/// + for other versions, check https://github.com/swagger-api/swagger-ui/tags
-/// 2. SWAGGER_UI_OVERWRITE_FOLDER
-/// + absolute path to a folder containing files to overwrite the default swagger-ui files
+// the following env variables control the build process:
+// 1. SWAGGER_UI_DOWNLOAD_URL:
+// + the url from where to download the swagger-ui zip file if starts with http:// or https://
+// + the file path from where to copy the swagger-ui zip file if starts with file://
+// + default value is SWAGGER_UI_DOWNLOAD_URL_DEFAULT
+// + for other versions, check https://github.com/swagger-api/swagger-ui/tags
+// 2. SWAGGER_UI_OVERWRITE_FOLDER
+// + absolute path to a folder containing files to overwrite the default swagger-ui files
 
 const SWAGGER_UI_DOWNLOAD_URL_DEFAULT: &str =
     "https://github.com/swagger-api/swagger-ui/archive/refs/tags/v5.17.14.zip";

--- a/utoipa-swagger-ui/src/lib.rs
+++ b/utoipa-swagger-ui/src/lib.rs
@@ -498,7 +498,7 @@ impl From<String> for Url<'_> {
     }
 }
 
-impl<'a> From<Cow<'static, str>> for Url<'a> {
+impl From<Cow<'static, str>> for Url<'_> {
     fn from(url: Cow<'static, str>) -> Self {
         Self {
             url,

--- a/utoipa-swagger-ui/src/rocket.rs
+++ b/utoipa-swagger-ui/src/rocket.rs
@@ -82,10 +82,7 @@ impl Handler for ServeSwagger {
             let request_guard = request.guard::<BasicAuth>().await;
             match request_guard {
                 request::Outcome::Success(BasicAuth { username, password })
-                    if username == basic_auth.username && password == basic_auth.password =>
-                {
-                    ()
-                }
+                    if username == basic_auth.username && password == basic_auth.password => {}
                 _ => return Outcome::from(request, BasicAuthErrorResponse),
             }
         }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1507,7 +1507,7 @@ pub mod __dev {
         }
     }
 
-    impl<'a, T: ComposeSchema + Clone> ComposeSchema for std::borrow::Cow<'a, T> {
+    impl<T: ComposeSchema + Clone> ComposeSchema for std::borrow::Cow<'_, T> {
         fn compose(
             schemas: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>,
         ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -394,7 +394,7 @@ impl<'de> Deserialize<'de> for OpenApiVersion {
     {
         struct VersionVisitor;
 
-        impl<'v> Visitor<'v> for VersionVisitor {
+        impl Visitor<'_> for VersionVisitor {
             type Value = OpenApiVersion;
 
             fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
@@ -460,7 +460,7 @@ impl<'de> Deserialize<'de> for Deprecated {
         D: serde::Deserializer<'de>,
     {
         struct BoolVisitor;
-        impl<'de> Visitor<'de> for BoolVisitor {
+        impl Visitor<'_> for BoolVisitor {
             type Value = Deprecated;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -508,7 +508,7 @@ impl<'de> Deserialize<'de> for Required {
         D: serde::Deserializer<'de>,
     {
         struct BoolVisitor;
-        impl<'de> Visitor<'de> for BoolVisitor {
+        impl Visitor<'_> for BoolVisitor {
             type Value = Required;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -1552,7 +1552,7 @@ mod array_items_false {
     pub fn deserialize<'de, D: serde::Deserializer<'de>>(deserializer: D) -> Result<(), D::Error> {
         struct ItemsFalseVisitor;
 
-        impl<'de> Visitor<'de> for ItemsFalseVisitor {
+        impl Visitor<'_> for ItemsFalseVisitor {
             type Value = ();
             fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
             where


### PR DESCRIPTION
This commit addresses latest clippy lints, mainly elides lifetimes. Adds rust-toolchain.toml file and updates utoipa-swagger-ui CHANGELOG to contain the PR for zip fix.