### PR TITLE
fix(swagger-ui): fix build for breaking zip crate 2.6.0 change

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -49,7 +49,7 @@ no-default-features = true
 rustdoc-args = ["--cfg", "doc_cfg"]
 
 [build-dependencies]
-zip = { version = "2", default-features = false, features = ["deflate"] }
+zip = { version = "2.6", default-features = false, features = ["deflate"] }
 regex = "1.7"
 
 # used by cache feature


### PR DESCRIPTION
This fixes the build for the latest zip crate breaking change, which is not behind a different major version.

The difference is that `zip::ZipFile` now takes the generic parameter `<R: Read>` which it didn't before.