### PR TITLE
feat: optimize enum schema generation by grouping unit variants

### DIFF
--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utoipa-gen"
 description = "Code generation implementation for utoipa"
-version = "5.3.1"
+version = "5.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -27,7 +27,7 @@ once_cell = { version = "1.19.0", optional = true }
 proc-macro2 = "1.0"
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
-regex = { version = "1.7", optional = true }
+regex = "1.7"
 uuid = { version = "1", features = ["serde"], optional = true }
 ulid = { version = "1", optional = true, default-features = false }
 url = { version = "2", optional = true }
@@ -57,17 +57,17 @@ insta = { version = "1.41", features = ["json"] }
 [features]
 # See README.md for list and explanations of features
 debug = ["syn/extra-traits"]
-actix_extras = ["regex", "syn/extra-traits"]
+actix_extras = ["syn/extra-traits"]
 chrono = []
 yaml = []
 decimal = []
 decimal_float = []
-rocket_extras = ["regex", "syn/extra-traits"]
+rocket_extras = ["syn/extra-traits"]
 non_strict_integers = []
 uuid = ["dep:uuid"]
 ulid = ["dep:ulid"]
 url = ["dep:url"]
-axum_extras = ["regex", "syn/extra-traits"]
+axum_extras = ["syn/extra-traits"]
 time = []
 smallvec = []
 repr = []

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -737,7 +737,7 @@ impl ToTokens for ComponentDescription<'_> {
 /// references. E.g. field: Vec<Foo> should have name: Foo::name(), tokens: Foo::schema() and
 /// references: Foo::schemas()
 #[cfg_attr(feature = "debug", derive(Debug))]
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct SchemaReference {
     pub name: TokenStream,
     pub tokens: TokenStream,

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_component_with_mixed_enum_lifetimes.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_component_with_mixed_enum_lifetimes.snap.new
@@ -1,0 +1,35 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 2148
+expression: doc
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "A": {
+          "properties": {
+            "foo": {
+              "$ref": "#/components/schemas/Foo"
+            }
+          },
+          "required": [
+            "foo"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "A"
+      ],
+      "type": "object"
+    },
+    {
+      "enum": [
+        "B",
+        "C"
+      ],
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum.snap.new
@@ -1,0 +1,54 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 922
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "NamedFields": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "names": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "NamedFields"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "UnnamedFields": {
+          "$ref": "#/components/schemas/Foo"
+        }
+      },
+      "required": [
+        "UnnamedFields"
+      ],
+      "type": "object"
+    },
+    {
+      "enum": [
+        "UnitValue"
+      ],
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_deprecated_variants.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_deprecated_variants.snap.new
@@ -1,0 +1,58 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 947
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "deprecated": true,
+      "properties": {
+        "NamedFields": {
+          "deprecated": true,
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "names": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "NamedFields"
+      ],
+      "type": "object"
+    },
+    {
+      "deprecated": true,
+      "properties": {
+        "UnnamedFields": {
+          "$ref": "#/components/schemas/Foo"
+        }
+      },
+      "required": [
+        "UnnamedFields"
+      ],
+      "type": "object"
+    },
+    {
+      "deprecated": true,
+      "enum": [
+        "UnitValue"
+      ],
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_description_override.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_description_override.snap.new
@@ -1,0 +1,27 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 2910
+expression: value
+---
+{
+  "description": "This is description from include_str!\n",
+  "oneOf": [
+    {
+      "properties": {
+        "User": {
+          "$ref": "#/components/schemas/User"
+        }
+      },
+      "required": [
+        "User"
+      ],
+      "type": "object"
+    },
+    {
+      "enum": [
+        "Value1"
+      ],
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_example.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_example.snap.new
@@ -1,0 +1,49 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 991
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "example": "EX: Named",
+      "properties": {
+        "NamedFields": {
+          "properties": {
+            "id": {
+              "example": "EX: Named id field",
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "NamedFields"
+      ],
+      "type": "object"
+    },
+    {
+      "example": "EX: Unnamed",
+      "properties": {
+        "UnnamedFields": {
+          "$ref": "#/components/schemas/Foo"
+        }
+      },
+      "required": [
+        "UnnamedFields"
+      ],
+      "type": "object"
+    },
+    {
+      "enum": [
+        "UnitValue"
+      ],
+      "example": "EX: Unit",
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all.snap.new
@@ -1,0 +1,54 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1012
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "named_fields": {
+          "properties": {
+            "id": {
+              "type": "string"
+            },
+            "names": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "named_fields"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "unnamed_fields": {
+          "$ref": "#/components/schemas/Foo"
+        }
+      },
+      "required": [
+        "unnamed_fields"
+      ],
+      "type": "object"
+    },
+    {
+      "enum": [
+        "unit_value"
+      ],
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_variant.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_variant.snap.new
@@ -1,0 +1,54 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1037
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "renamed_named_fields": {
+          "properties": {
+            "renamed_id": {
+              "type": "string"
+            },
+            "renamed_names": {
+              "items": {
+                "type": "string"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "renamed_id"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "renamed_named_fields"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "renamed_unnamed_fields": {
+          "$ref": "#/components/schemas/Foo"
+        }
+      },
+      "required": [
+        "renamed_unnamed_fields"
+      ],
+      "type": "object"
+    },
+    {
+      "enum": [
+        "renamed_unit_value"
+      ],
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_tag.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_tag.snap.new
@@ -1,0 +1,50 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1161
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "names": {
+          "items": {
+            "type": "string"
+          },
+          "type": [
+            "array",
+            "null"
+          ]
+        },
+        "tag": {
+          "enum": [
+            "NamedFields"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "tag"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "tag": {
+          "enum": [
+            "UnitValue"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "tag"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_tag_title.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_tag_title.snap.new
@@ -1,0 +1,43 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1461
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "tag": {
+          "enum": [
+            "NamedFields"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "tag"
+      ],
+      "title": "Named",
+      "type": "object"
+    },
+    {
+      "properties": {
+        "tag": {
+          "enum": [
+            "UnitValue"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "tag"
+      ],
+      "title": "Unit",
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_title.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_title.snap.new
@@ -1,0 +1,48 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 968
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "NamedFields": {
+          "properties": {
+            "id": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "NamedFields"
+      ],
+      "title": "Named",
+      "type": "object"
+    },
+    {
+      "properties": {
+        "UnnamedFields": {
+          "$ref": "#/components/schemas/Foo"
+        }
+      },
+      "required": [
+        "UnnamedFields"
+      ],
+      "title": "Unnamed",
+      "type": "object"
+    },
+    {
+      "enum": [
+        "UnitValue"
+      ],
+      "title": "Unit",
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_schema_with_docstring_on_unit_variant_of_enum.snap.new
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_schema_with_docstring_on_unit_variant_of_enum.snap.new
@@ -1,0 +1,29 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 2817
+expression: value
+---
+{
+  "description": "top level doc for My enum",
+  "oneOf": [
+    {
+      "description": "non-unit doc",
+      "properties": {
+        "NonUnitVariant": {
+          "description": "non-unit doc",
+          "type": "string"
+        }
+      },
+      "required": [
+        "NonUnitVariant"
+      ],
+      "type": "object"
+    },
+    {
+      "enum": [
+        "UnitVariant"
+      ],
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "utoipa"
 description = "Compile time generated OpenAPI documentation for Rust"
-version = "5.3.1"
+version = "5.3.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This is just a prototype I've put together to see if I can unblock myself.

The general idea is that even if one of the enums is special, we generate the rest of enums as one.