### PR TITLE
utoipa-swagger-ui: enable rust-embed's new deterministic-timestamps feature

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -22,7 +22,7 @@ vendored = ["dep:utoipa-swagger-ui-vendored"]
 cache = ["dep:dirs", "dep:sha2"]
 
 [dependencies]
-rust-embed = { version = "8" }
+rust-embed = { version = "8.7", features = ["deterministic-timestamps"] }
 mime_guess = { version = "2.0" }
 actix-web = { version = "4", optional = true, default-features = false, features = ["macros"] }
 rocket = { version = "0.5", features = ["json"], optional = true }


### PR DESCRIPTION
Enabling this feature will set the file timestamps of the embedded files to 0 so they will be deterministic and therefore produce deterministic binaries.

Fixes https://github.com/juhaku/utoipa/issues/1333

Either activate it directly or add it for users to activate. Let me know what you prefer.