### PR TITLE
Adding support for Content in Parameters

### DIFF
--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -8,6 +8,7 @@ to look into changes introduced to **`utoipa-gen`**.
 ### Added
 
 * Add support for jiff v0.2 (https://github.com/juhaku/utoipa/pull/1332)
+* Add support for content in parameter (https://github.com/juhaku/utoipa/pull/1399)
 
 ### Changed
 


### PR DESCRIPTION
The goal is to support the `content` key in the `Parameter Object`

Described here : https://spec.openapis.org/oas/v3.1.0.html#fixed-fields-9

> For more complex scenarios, the [content](https://spec.openapis.org/oas/v3.1.0.html#parameterContent) property can define the media type and schema of the parameter. A parameter MUST contain either a schema property, or a content property, but not both. When example or examples are provided in conjunction with the schema object, the example MUST follow the prescribed serialization strategy for the parameter.

It offers the possibility to create openapi spec like this : 

```yaml
paths:
  /api/v1/myendpoint
    get:
      tags:
      - myendpoint
      summary: Some summary of my endpoint
      operationId: myendpoint_operation
      parameters:
      - name: filters
        in: query
        description: Additional filters to add to the query
        required: false
        content: 
          application/json:
            schema:            
              $ref: '#/components/schemas/Filters'
```

The implementation is quite simplistic as it does not forbid to had both a schema and a content to a parameter
Also I am not familiar with macro 

This is linked to [this issue](https://github.com/juhaku/utoipa/issues/620)