### PR TITLE
Add `#[automatically_derived]` to all macro-generated impls

### DIFF
--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -157,6 +157,7 @@ impl ToTokensDiagnostics for IntoParams {
             .collect::<Result<Array<TokenStream>, Diagnostics>>()?;
 
         tokens.extend(quote! {
+            #[automatically_derived]
             impl #impl_generics utoipa::IntoParams for #ident #ty_generics #where_clause {
                 fn into_params(parameter_in_provider: impl Fn() -> Option<utoipa::openapi::path::ParameterIn>) -> Vec<utoipa::openapi::path::Parameter> {
                     #params.into_iter().filter(Option::is_some).flatten().collect()

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -160,6 +160,7 @@ impl ToTokensDiagnostics for Schema<'_> {
         }
 
         tokens.extend(quote! {
+            #[automatically_derived]
             impl #impl_generics utoipa::__dev::ComposeSchema for #ident #ty_generics #where_clause {
                 fn compose(
                     mut generics: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>
@@ -168,6 +169,7 @@ impl ToTokensDiagnostics for Schema<'_> {
                 }
             }
 
+            #[automatically_derived]
             impl #impl_generics utoipa::ToSchema for #ident #ty_generics #where_clause {
                 fn name() -> std::borrow::Cow<'static, str> {
                     std::borrow::Cow::Borrowed(#name)

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -450,6 +450,7 @@ impl OpenApi<'_> {
                         .nest(#path, {
                             #[allow(non_camel_case_types)]
                             struct #nest_api_config;
+                            #[automatically_derived]
                             impl utoipa::__dev::NestedApiConfig for #nest_api_config {
                                 fn config() -> (utoipa::openapi::OpenApi, Vec<&'static str>, &'static str) {
                                     let api = <#nest_api as utoipa::OpenApi>::openapi();
@@ -558,6 +559,7 @@ impl ToTokensDiagnostics for OpenApi<'_> {
             .nested_tokens()
             .map(|tokens| quote! {openapi = openapi #tokens;});
         tokens.extend(quote! {
+            #[automatically_derived]
             impl utoipa::OpenApi for #ident {
                 fn openapi() -> utoipa::openapi::OpenApi {
                     use utoipa::{ToSchema, Path};
@@ -732,6 +734,7 @@ fn impl_paths(handler_paths: Option<&Punctuated<ExprPath, Comma>>) -> Paths {
                 #[allow(non_camel_case_types)]
                 struct #handler_ident_nested;
                 #[allow(non_camel_case_types)]
+                #[automatically_derived]
                 impl utoipa::__dev::PathConfig for #handler_ident_nested {
                     fn path() -> String {
                         #usage::path()

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -549,16 +549,19 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
                 if self.path_attr.impl_for.is_none() && !self.ext_methods.is_empty() {
                     let fn_ident = self.fn_ident;
                     tokens.extend(quote! {
+                        #[automatically_derived]
                         impl ::actix_web::dev::HttpServiceFactory for #path_struct {
                             fn register(self, __config: &mut actix_web::dev::AppService) {
                                 ::actix_web::dev::HttpServiceFactory::register(#fn_ident, __config);
                             }
                         }
+                        #[automatically_derived]
                         impl<'t> utoipa::__dev::Tags<'t> for #fn_ident {
                             fn tags() -> Vec<&'t str> {
                                 #path_struct::tags()
                             }
                         }
+                        #[automatically_derived]
                         impl utoipa::Path for #fn_ident {
                             fn path() -> String {
                                 #path_struct::path()
@@ -573,6 +576,7 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
                             }
                         }
 
+                        #[automatically_derived]
                         impl utoipa::__dev::SchemaReferences for #fn_ident {
                             fn schemas(schemas: &mut Vec<(String, utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>)>) {
                                 <#path_struct as utoipa::__dev::SchemaReferences>::schemas(schemas);
@@ -586,11 +590,13 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
         };
 
         tokens.extend(quote! {
+            #[automatically_derived]
             impl<'t> utoipa::__dev::Tags<'t> for #impl_for {
                 fn tags() -> Vec<&'t str> {
                     #tags_list.into()
                 }
             }
+            #[automatically_derived]
             impl utoipa::Path for #impl_for {
                 fn path() -> String {
                     #path_with_context_path
@@ -607,6 +613,7 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
                 }
             }
 
+            #[automatically_derived]
             impl utoipa::__dev::SchemaReferences for #impl_for {
                 fn schemas(schemas: &mut Vec<(String, utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>)>) {
                     #schemas

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -96,6 +96,7 @@ impl ToTokensDiagnostics for ToResponse<'_> {
         let (to_response_impl_generics, _, _) = to_response_generics.split_for_impl();
 
         tokens.extend(quote! {
+            #[automatically_derived]
             impl #to_response_impl_generics utoipa::ToResponse <#lifetime> for #ident #ty_generics #where_clause {
                 fn response() -> (& #lifetime str, utoipa::openapi::RefOr<utoipa::openapi::response::Response>) {
                     (#name, #response.into())
@@ -196,6 +197,7 @@ impl ToTokensDiagnostics for IntoResponses {
             None
         };
         tokens.extend(quote!{
+            #[automatically_derived]
                 impl #impl_generics utoipa::IntoResponses for #ident #ty_generics #where_clause {
                     fn responses() -> std::collections::BTreeMap<String, utoipa::openapi::RefOr<utoipa::openapi::response::Response>> {
                         utoipa::openapi::response::ResponsesBuilder::new()

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -198,15 +198,15 @@ impl ToTokensDiagnostics for IntoResponses {
         };
         tokens.extend(quote!{
             #[automatically_derived]
-                impl #impl_generics utoipa::IntoResponses for #ident #ty_generics #where_clause {
-                    fn responses() -> std::collections::BTreeMap<String, utoipa::openapi::RefOr<utoipa::openapi::response::Response>> {
-                        utoipa::openapi::response::ResponsesBuilder::new()
-                            #responses
-                            .build()
-                            .into()
-                    }
+            impl #impl_generics utoipa::IntoResponses for #ident #ty_generics #where_clause {
+                fn responses() -> std::collections::BTreeMap<String, utoipa::openapi::RefOr<utoipa::openapi::response::Response>> {
+                    utoipa::openapi::response::ResponsesBuilder::new()
+                        #responses
+                        .build()
+                        .into()
                 }
-            });
+            }
+        });
 
         Ok(())
     }

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3273,3 +3273,13 @@ fn test_new_type_struct_pattern() {
 
     assert_json_snapshot!(value);
 }
+
+#[test]
+fn no_single_use_lifetimes() {
+    #![allow(unused)]
+    #![deny(single_use_lifetimes)]
+    #[derive(ToSchema)]
+    struct Demo<'a> {
+        a: &'a str,
+    }
+}


### PR DESCRIPTION
This allows certain lints to be silenced. For example, the following code now compiles:

```rs
#![deny(single_use_lifetimes)]
#[derive(ToSchema)]
struct Demo<'a> {
    a: &'a str,
}
```