### PR TITLE
More helpful error message

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -160,7 +160,7 @@ impl<'p> SynPathExt for &'p Path {
                             let path = type_tree
                                 .path
                                 .as_ref()
-                                .expect("TypeTree must have a path")
+                                .expect(&format!("utoipa does not understand this type, for which type_tree must have a path: {ty:?}"))
                                 .as_ref();
 
                             if let Some(default_type) = PrimitiveType::new(path) {


### PR DESCRIPTION
This change is related to https://github.com/juhaku/utoipa/issues/1312 and https://github.com/juhaku/utoipa/issues/1377.

Every so often, I'm hitting a `TypeTree must have a path` error. Usually, it can be worked around by creating a newtype that somehow is better supported by utoipa (see [an example here](https://github.com/juhaku/utoipa/issues/1312#issuecomment-2672692588)).
I'm not versed enough in proc-macros to fix this myself. However, I have been using this trick, that at least points me at what type is not "understood" by utoipa.

Example of error message before:
> TypeTree must have a path

Example of error message after:
>  utoipa does not understand this type, for which type_tree must have a path:: Type::Tuple { paren_token: Paren, elems: [Type::Path { qself: None, path: Path { leading_colon: None, segments: [PathSegment { ident: Ident { ident: "SomeCustomType", span: #0 bytes(174539..174557) }, arguments: PathArguments::None }] } }, Comma, Type::Path { qself: None, path: Path { leading_colon: None, segments: [PathSegment { ident: Ident { ident: "T", span: #0 bytes(174559..174560) }, arguments: PathArguments::None }] } }] }
