### PR TITLE
feat: support chrono::Weekday

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also an awesome type of beer 
   defining the `parameter_in` attribute. See [docs](https://docs.rs/utoipa/latest/utoipa/attr.path.html#axum_extras-feature-support-for-axum)
   or [examples](./examples) for more details.
 - **`debug`**: Add extra traits such as debug traits to openapi definitions and elsewhere.
-- **`chrono`**: Add support for [chrono](https://crates.io/crates/chrono) `DateTime`, `Date`, `NaiveDate`, `NaiveDateTime`, `NaiveTime` and `Duration`
+- **`chrono`**: Add support for [chrono](https://crates.io/crates/chrono) `DateTime`, `Date`, `NaiveDate`, `NaiveDateTime`, `NaiveTime`, `Duration` and `Weekday`
   types. By default these types are parsed to `string` types with additional `format` information.
   `format: date-time` for `DateTime` and `NaiveDateTime` and `format: date` for `Date` and `NaiveDate` according
   [RFC3339](https://www.rfc-editor.org/rfc/rfc3339#section-5.6) as `ISO-8601`. To

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -215,7 +215,7 @@ fn is_primitive(name: &str) -> bool {
 fn is_primitive_chrono(name: &str) -> bool {
     matches!(
         name,
-        "DateTime" | "Date" | "NaiveDate" | "NaiveTime" | "Duration" | "NaiveDateTime"
+        "DateTime" | "Date" | "NaiveDate" | "NaiveTime" | "Duration" | "NaiveDateTime" | "Weekday"
     )
 }
 
@@ -269,7 +269,7 @@ impl ToTokensDiagnostics for SchemaType<'_> {
             "f32" | "f64" => schema_type_tokens(tokens, SchemaTypeInner::Number, self.nullable),
 
             #[cfg(feature = "chrono")]
-            "DateTime" | "NaiveDateTime" | "NaiveDate" | "NaiveTime" => {
+            "DateTime" | "NaiveDateTime" | "NaiveDate" | "NaiveTime" | "Weekday" => {
                 schema_type_tokens(tokens, SchemaTypeInner::String, self.nullable)
             }
 
@@ -700,7 +700,7 @@ impl PrimitiveType {
             "f32" | "f64" => syn::parse_quote!(#path),
 
             #[cfg(feature = "chrono")]
-            "DateTime" | "NaiveDateTime" | "NaiveDate" | "NaiveTime" => {
+            "DateTime" | "NaiveDateTime" | "NaiveDate" | "NaiveTime" | "Weekday" => {
                 syn::parse_quote!(String)
             }
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1613,7 +1613,7 @@ fn derive_struct_xml_with_optional_vec() {
 #[test]
 fn derive_component_with_chrono_feature() {
     #![allow(deprecated)] // allow deprecated Date in tests as long as it is available from chrono
-    use chrono::{Date, DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+    use chrono::{Date, DateTime, Duration, NaiveDate, NaiveDateTime, NaiveTime, Utc, Weekday};
 
     let post = api_doc! {
         struct Post {
@@ -1625,6 +1625,7 @@ fn derive_component_with_chrono_feature() {
             naive_date: NaiveDate,
             naive_time: NaiveTime,
             duration: Duration,
+            weekday: Weekday,
         }
     };
 
@@ -1641,6 +1642,8 @@ fn derive_component_with_chrono_feature() {
         "properties.naive_time.format" = r#"null"#, "Post time format"
         "properties.duration.type" = r#""string""#, "Post duration type"
         "properties.duration.format" = r#"null"#, "Post duration format"
+        "properties.weekday.type" = r#""string""#, "Post weekday type"
+        "properties.weekday.format" = r#"null"#, "Post weekday format"
         "properties.id.type" = r#""integer""#, "Post id type"
         "properties.id.format" = r#""int32""#, "Post id format"
         "properties.value.type" = r#""string""#, "Post value type"

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -71,7 +71,7 @@
 //!   without defining the `parameter_in` attribute. See [axum extras support][axum_path]
 //!   or [examples](https://github.com/juhaku/utoipa/tree/master/examples) for more details.
 //! * **`debug`** Add extra traits such as debug traits to openapi definitions and elsewhere.
-//! * **`chrono`** Add support for [chrono](https://crates.io/crates/chrono) `DateTime`, `Date`, `NaiveDate`, `NaiveTime` and `Duration`
+//! * **`chrono`** Add support for [chrono](https://crates.io/crates/chrono) `DateTime`, `Date`, `NaiveDate`, `NaiveTime`, `Duration` and `Weekday`
 //!   types. By default these types are parsed to `string` types with additional `format` information.
 //!   `format: date-time` for `DateTime` and `format: date` for `Date` and `NaiveDate` according
 //!   [RFC3339](https://xml2rfc.ietf.org/public/rfc/html/rfc3339.html#anchor14) as `ISO-8601`. To


### PR DESCRIPTION
close #1213 

I haven't check it return Enum values.

When I debug with
```
utoipa = { git = "ssh://github.com/yuki0418/utoipa.git", branch = "feat/support-chrono-weekday", features = [
    "uuid",
    "axum_extras",
    "debug",
    "chrono",
    "config",
] }
utoipa-swagger-ui = { version = "9.0.0", features = [
    "axum",
    "vendored",
], default-features = false }
utoipa-axum = { version = "0.2.0", features = ["debug"] }
```

I get error
```
error: could not compile `utoipa-axum` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
[Running 'cargo check']==============> ] 610/613: utoipa                                
    Blocking waiting for file lock on build directory
    Checking utoipa-axum v0.2.0
error[E0277]: `utoipa::openapi::OpenApi` doesn't implement `Debug`
   --> /Users/yuki/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/utoipa-axum-0.2.0/src/router.rs:129:45
    |
128 | #[cfg_attr(feature = "debug", derive(Debug))]
    |                                      ----- in this derive macro expansion
129 | pub struct OpenApiRouter<S = ()>(Router<S>, utoipa::openapi::OpenApi);
    |                                             ^^^^^^^^^^^^^^^^^^^^^^^^ `utoipa::openapi::OpenApi` cannot be formatted using `{:?}` because it doesn't implement `Debug`
    |
    = help: the trait `Debug` is not implemented for `utoipa::openapi::OpenApi`
```

If I remove `debug`, I get this error
```
.merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", doc))
    |                                              ---                           ^^^ expected `utoipa::openapi::OpenApi`, found a different `utoipa::openapi::OpenApi`
    |                                              |
    |                                              arguments to this method are incorrect
```

Do you have any other ideas to how to debug?