### PR TITLE
Fix: Refactor to avoid clippy::needless_for_each warning in derive(OpenApi)

### DIFF
--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -550,7 +550,9 @@ impl ToTokensDiagnostics for OpenApi<'_> {
 
                 quote! {
                     let _mods: [&dyn utoipa::Modify; #modifiers_len] = [#modifiers];
-                    _mods.iter().for_each(|modifier| modifier.modify(&mut openapi));
+                    for modifier in &_mods {
+                        modifier.modify(&mut openapi);
+                    }
                 }
             });
 


### PR DESCRIPTION
This pull request includes a small change to the `utoipa-gen/src/openapi.rs` file. The change replaces the use of `.iter().for_each` with a `for` loop for iterating over modifiers in the `ToTokensDiagnostics` implementation for `OpenApi`.

Closes #1420 