### PR TITLE
Add support for parameter schemas in Path and add test

### DIFF
--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -514,6 +514,16 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
             .flatten()
             .fold(TokenStream2::new(), to_schema_references);
 
+        let parameter_schemas = self
+            .path_attr
+            .params
+            .iter()
+            .map(|param| param.get_component_schemas())
+            .collect::<Result<Vec<_>, Diagnostics>>()?
+            .into_iter()
+            .flatten()
+            .fold(TokenStream2::new(), to_schema_references);
+
         let schemas = self
             .path_attr
             .request_body
@@ -609,6 +619,7 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
 
             impl utoipa::__dev::SchemaReferences for #impl_for {
                 fn schemas(schemas: &mut Vec<(String, utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>)>) {
+                    #parameter_schemas
                     #schemas
                     #response_schemas
                 }


### PR DESCRIPTION
Fixes #1324 

> When I add an enum only in the header, it gets referenced in the yaml output, but there is no corresponding schema in the yaml schema definitions. When I additionally add the enum to a body, it appears in the schema definitions and works as expected.