### PR TITLE
use ferroid

### DIFF
--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -29,7 +29,7 @@ syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 regex = { version = "1.7", optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }
-ulid = { version = "1", optional = true, default-features = false }
+ferroid = { version = "0.6", optional = true, features = ["ulid", "base32"] }
 url = { version = "2", optional = true }
 
 [dev-dependencies]
@@ -66,7 +66,7 @@ decimal_float = []
 rocket_extras = ["regex", "syn/extra-traits"]
 non_strict_integers = []
 uuid = ["dep:uuid"]
-ulid = ["dep:ulid"]
+ulid = ["dep:ferroid"]
 url = ["dep:url"]
 axum_extras = ["regex", "syn/extra-traits"]
 time = []

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -987,7 +987,7 @@ fn derive_path_with_uuid() {
 #[cfg(feature = "ulid")]
 #[test]
 fn derive_path_with_ulid() {
-    use ulid::Ulid;
+    use ferroid::ULID as Ulid;
 
     #[utoipa::path(
         get,

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1967,7 +1967,7 @@ fn derive_struct_with_uuid_type() {
 #[cfg(feature = "ulid")]
 #[test]
 fn derive_struct_with_ulid_type() {
-    use ulid::Ulid;
+    use ferroid::ULID as Ulid;
 
     let post = api_doc! {
         struct Post {


### PR DESCRIPTION
Replaces the [ulid](https://github.com/dylanhart/ulid-rs) crate with [ferroid](https://github.com/s0l0ist/ferroid/tree/main/crates/ferroid), a drop-in alternative with identical behavior in this context, but better performance for encode/decode.

There's no functional difference here, but `ferroid` provides a more modern foundation for ULID.