### PR TITLE
Use pastey instead of unmaintained paste and fix some clippy warnings

### DIFF
--- a/utoipa-axum/CHANGELOG.md
+++ b/utoipa-axum/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-axum
 
+## Unreleased
+
+### Changed
+
+* Use pastey instead of unmaintained paste and fix some clippy warnings (https://github.com/juhaku/utoipa/pull/1452)
+
 ## 0.2.0 - Thu 16 2025
 
 * Re-release of what was released in 0.1.4 (https://github.com/juhaku/utoipa/pull/1295)

--- a/utoipa-axum/Cargo.toml
+++ b/utoipa-axum/Cargo.toml
@@ -28,7 +28,7 @@ utoipa = { version = "5.0.0", path = "../utoipa", default-features = false, feat
 ] }
 tower-service = "0.3"
 tower-layer = "0.3.3"
-paste = "1.0"
+pastey = "0.2"
 
 [dev-dependencies]
 utoipa = { path = "../utoipa", features = ["debug"] }

--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -75,7 +75,7 @@ impl PathItemExt for HttpMethod {
 
 /// re-export paste so users do not need to add the dependency.
 #[doc(hidden)]
-pub use paste::paste;
+pub use pastey::paste;
 
 /// Collect axum handlers annotated with [`utoipa::path`] to [`router::UtoipaMethodRouter`].
 ///

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 
 * Emit nullable_item last for OneOfBuilder (https://github.com/juhaku/utoipa/pull/1299)
+* Use pastey instead of unmaintained paste and fix some clippy warnings (https://github.com/juhaku/utoipa/pull/1452)
 
 ### Fixed
 

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -45,7 +45,7 @@ axum = { version = "0.8.4", default-features = false, features = [
     "json",
     "query",
 ] }
-paste = "1"
+pastey = "0.1"
 rocket = { version = "0.5", features = ["json"] }
 smallvec = { version = "1.15", features = ["serde"] }
 rust_decimal = { version = "1", default-features = false }

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -45,7 +45,7 @@ axum = { version = "0.8.4", default-features = false, features = [
     "json",
     "query",
 ] }
-pastey = "0.1"
+pastey = "0.2"
 rocket = { version = "0.5", features = ["json"] }
 smallvec = { version = "1.15", features = ["serde"] }
 rust_decimal = { version = "1", default-features = false }

--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -497,7 +497,7 @@ impl_feature! {
 
 impl ValueType {
     /// Create [`TypeTree`] from current [`syn::Type`].
-    pub fn as_type_tree(&self) -> Result<TypeTree, Diagnostics> {
+    pub fn as_type_tree(&self) -> Result<TypeTree<'_>, Diagnostics> {
         TypeTree::from_type(&self.0)
     }
 }

--- a/utoipa-gen/src/component/features/validators.rs
+++ b/utoipa-gen/src/component/features/validators.rs
@@ -31,6 +31,7 @@ impl Validator for IsString<'_> {
     }
 }
 
+#[allow(dead_code)]
 pub struct IsInteger<'a>(&'a SchemaType<'a>);
 
 impl Validator for IsInteger<'_> {

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -288,7 +288,7 @@ pub trait ArgumentResolver {
         _: &'_ Punctuated<syn::FnArg, Comma>,
         _: Option<Vec<MacroArg>>,
         _: String,
-    ) -> Result<Arguments, Diagnostics> {
+    ) -> Result<Arguments<'_>, Diagnostics> {
         Ok((None, None, None))
     }
 }

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1982,8 +1982,8 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// * `paths(...)`  List of method references having attribute [`#[utoipa::path]`][path] macro.
 /// * `components(schemas(...), responses(...))` Takes available _`component`_ configurations. Currently only
 ///   _`schema`_ and _`response`_ components are supported.
-///   * `schemas(...)` List of [`ToSchema`][to_schema]s in OpenAPI schema.
-///   * `responses(...)` List of types that implement [`ToResponse`][to_response_trait].
+/// * `schemas(...)` List of [`ToSchema`][to_schema]s in OpenAPI schema.
+/// * `responses(...)` List of types that implement [`ToResponse`][to_response_trait].
 /// * `modifiers(...)` List of items implementing [`Modify`][modify] trait for runtime OpenApi modification.
 ///   See the [trait documentation][modify] for more details.
 /// * `security(...)` List of [`SecurityRequirement`][security]s global to all operations.

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -72,7 +72,7 @@ impl<'o> OpenApiAttr<'o> {
     }
 }
 
-pub fn parse_openapi_attrs(attrs: &[Attribute]) -> Result<Option<OpenApiAttr>, Error> {
+pub fn parse_openapi_attrs(attrs: &[Attribute]) -> Result<Option<OpenApiAttr<'_>>, Error> {
     attrs
         .iter()
         .filter(|attribute| attribute.path().is_ident("openapi"))

--- a/utoipa-gen/src/path/media_type.rs
+++ b/utoipa-gen/src/path/media_type.rs
@@ -233,7 +233,7 @@ impl Default for Schema<'_> {
 }
 
 impl Schema<'_> {
-    pub fn get_type_tree(&self) -> Result<Option<Cow<TypeTree<'_>>>, Diagnostics> {
+    pub fn get_type_tree(&self) -> Result<Option<Cow<'_, TypeTree<'_>>>, Diagnostics> {
         match self {
             Self::Default(def) => def.get_type_tree(),
             Self::Ext(ext) => ext.get_type_tree(),
@@ -421,7 +421,7 @@ pub struct ParsedType<'i> {
 
 impl ParsedType<'_> {
     /// Get's the underlying [`syn::Type`] as [`TypeTree`].
-    fn to_type_tree(&self) -> Result<TypeTree, Diagnostics> {
+    fn to_type_tree(&self) -> Result<TypeTree<'_>, Diagnostics> {
         TypeTree::from_type(&self.ty)
     }
 }

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -676,11 +676,11 @@ struct ResponseStatus(TokenStream2);
 
 impl Parse for ResponseStatus {
     fn parse(input: ParseStream) -> syn::Result<Self> {
-        fn parse_lit_int(input: ParseStream) -> syn::Result<Cow<'_, str>> {
+        fn parse_lit_int(input: ParseStream<'_>) -> syn::Result<Cow<'_, str>> {
             input.parse::<LitInt>()?.base10_parse().map(Cow::Owned)
         }
 
-        fn parse_lit_str_status_range(input: ParseStream) -> syn::Result<Cow<'_, str>> {
+        fn parse_lit_str_status_range(input: ParseStream<'_>) -> syn::Result<Cow<'_, str>> {
             const VALID_STATUS_RANGES: [&str; 6] = ["default", "1XX", "2XX", "3XX", "4XX", "5XX"];
 
             input

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -673,7 +673,7 @@ impl<'r> EnumResponse<'r> {
         Ok(Self(response_value.into()))
     }
 
-    fn parse_variant_attributes(variant: &Variant) -> Result<VariantAttributes, Diagnostics> {
+    fn parse_variant_attributes(variant: &Variant) -> Result<VariantAttributes<'_>, Diagnostics> {
         let variant_derive_response_value =
             DeriveToResponseValue::from_attributes(variant.attrs.as_slice())?;
         // named enum variant should not have field attributes

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use insta::assert_json_snapshot;
-use paste::paste;
+use pastey::paste;
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::HashMap;

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -139,7 +139,7 @@ macro_rules! test_response_types {
     ( $( $name:ident=> $(body: $expected:expr,)? $( $content_type:literal, )? $( headers: $headers:expr, )?
         assert: $( $path:literal = $expectation:literal, $comment:literal )* )* ) => {
         $(
-            paste::paste! {
+            pastey::paste! {
                 test_fn! {
                     module: [<mod_ $name>],
                     responses: (
@@ -154,7 +154,7 @@ macro_rules! test_response_types {
 
             #[test]
             fn $name() {
-                paste::paste! {
+                pastey::paste! {
                     let doc = api_doc!(module: [<mod_ $name>]);
                 }
 


### PR DESCRIPTION
* Use pastey instead of paste as paste is unmaintained, see https://github.com/dtolnay/paste/blob/master/README.md
* Fix clippy warnings


Fixes #1482 Fixes #1563 Fixes #1336