### PR TITLE
Pass through for axum::Router::has_routes

### DIFF
--- a/utoipa-axum/CHANGELOG.md
+++ b/utoipa-axum/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 * Use pastey instead of unmaintained paste and fix some clippy warnings (https://github.com/juhaku/utoipa/pull/1452)
+* Pass through for axum::Router::has_routes (https://github.com/juhaku/utoipa/pull/1458)
 
 ## 0.2.0 - Thu 16 2025
 

--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -463,4 +463,14 @@ mod tests {
         let response = router.oneshot(request).await.unwrap();
         assert_eq!(response.status(), http::StatusCode::BAD_REQUEST);
     }
+
+    #[test]
+    fn openapi_router_has_routes() {
+        // no routes
+        assert!(!OpenApiRouter::<()>::new().has_routes());
+        // some routes
+        assert!(OpenApiRouter::<()>::new()
+            .routes(routes!(get_user))
+            .has_routes())
+    }
 }

--- a/utoipa-axum/src/router.rs
+++ b/utoipa-axum/src/router.rs
@@ -247,6 +247,11 @@ where
         Self(router, self.1)
     }
 
+    /// Pass through method for [`axum::Router<S>::has_routes`].
+    pub fn has_routes(&self) -> bool {
+        self.0.has_routes()
+    }
+
     /// Pass through method for [`axum::Router<S>::route`].
     pub fn route(self, path: &str, method_router: MethodRouter<S>) -> Self {
         Self(self.0.route(path, method_router), self.1)


### PR DESCRIPTION
Expose `OpenApiRouter`'s underlying `axum::Router::has_routes` to be able to make decisions without decomposing via `OpenApiRouter::split_for_parts`.