### PR TITLE
Fix merging routes when nesting

### DIFF
--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -301,14 +301,13 @@ impl OpenApi {
         O: Into<OpenApi>,
         F: Fn(&str, &str) -> String,
     >(
-        mut self,
+        self,
         path: P,
         other: O,
         composer: F,
     ) -> Self {
         let path: String = path.into();
         let mut other_api: OpenApi = other.into();
-
         let nested_paths = other_api
             .paths
             .paths
@@ -318,11 +317,7 @@ impl OpenApi {
                 (path, item)
             })
             .collect::<PathsMap<_, _>>();
-
-        self.paths.paths.extend(nested_paths);
-
-        // paths are already merged, thus we can ignore them
-        other_api.paths.paths = PathsMap::new();
+        other_api.paths.paths = nested_paths;
         self.merge_from(other_api)
     }
 }
@@ -905,6 +900,51 @@ mod tests {
             .build();
 
         let nest_merged = api.nest("/api/v1/user", user_api);
+        let value = serde_json::to_value(nest_merged).expect("should serialize as json");
+        let paths = value
+            .pointer("/paths")
+            .expect("paths should exits in openapi");
+
+        assert_json_snapshot!(paths);
+    }
+
+    /// Assert that nesting "merged" properly with existing routes
+    #[test]
+    fn test_nest_open_apis_same_path_diff_methods() {
+        let user_api_1 = OpenApiBuilder::new()
+            .paths(
+                PathsBuilder::new().path(
+                    "/api/v1/status",
+                    PathItem::new(
+                        HttpMethod::Get,
+                        OperationBuilder::new()
+                            .description(Some("Get status"))
+                            .build(),
+                    ),
+                ),
+            )
+            .build();
+
+        let user_api_2 = OpenApiBuilder::new()
+            .paths(
+                PathsBuilder::new()
+                    .path(
+                        "/status",
+                        PathItem::new(
+                            HttpMethod::Post,
+                            OperationBuilder::new()
+                                .description(Some("Post status"))
+                                .build(),
+                        ),
+                    )
+                    .path(
+                        "/foo",
+                        PathItem::new(HttpMethod::Post, OperationBuilder::new().build()),
+                    ),
+            )
+            .build();
+
+        let nest_merged = user_api_1.nest("/api/v1", user_api_2);
         let value = serde_json::to_value(nest_merged).expect("should serialize as json");
         let paths = value
             .pointer("/paths")

--- a/utoipa/src/snapshots/utoipa__openapi__tests__nest_open_apis_same_path_diff_methods.snap
+++ b/utoipa/src/snapshots/utoipa__openapi__tests__nest_open_apis_same_path_diff_methods.snap
@@ -1,0 +1,21 @@
+---
+source: utoipa/src/openapi.rs
+expression: paths
+---
+{
+  "/api/v1/foo": {
+    "post": {
+      "responses": {}
+    }
+  },
+  "/api/v1/status": {
+    "get": {
+      "description": "Get status",
+      "responses": {}
+    },
+    "post": {
+      "description": "Post status",
+      "responses": {}
+    }
+  }
+}


### PR DESCRIPTION
I have two (or more) (openapi-)routers (from `utoipa-axum`) which both/all get nested into a top-level router using the same path prefix. (the reason is that i apply different (service) layers to the routers before assembling them.) however, while the axum router "merge" upon nesting works as expected, the openapi-router simply discards the old "paths" from openapi. this should correct the situation.

a possible workaround is:
```rust
let routes_1: OpenApiRouter = ...;
let routes_2: OpenApiRouter = ...;

let routes_1 = OpenApiRouter::default().nest("/foo", routes_1);
let routes_2 = OpenApiRouter::default().nest("/foo", routes_2);
let all_routes = routes1.merge(routes2);
```
or with vanilla utoipa:
```rust
        let mut all_routes = OpenApiBuilder::default()
            .build()
            .nest("/foo", routes1);
        routes.merge(
            OpenApiBuilder::default()
                .build()
                .nest("/foo", routes_2),
        );
```
