### PR TITLE
Fix generation of null type for `Option<T>`

### DIFF
--- a/utoipa-gen/tests/schema_generics.rs
+++ b/utoipa-gen/tests/schema_generics.rs
@@ -168,6 +168,29 @@ fn schema_with_non_generic_root() {
 }
 
 #[test]
+fn schema_option_generic() {
+    #![allow(unused)]
+
+    #[derive(ToSchema)]
+    struct Top {
+        bounds: Bounds<i32>,
+    }
+
+    #[derive(ToSchema)]
+    struct Bounds<T> {
+        min: Option<T>,
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(components(schemas(Top)))]
+    struct ApiDoc;
+    let mut api = ApiDoc::openapi();
+    api.info = Info::new("title", "version");
+
+    assert_json_snapshot!(api);
+}
+
+#[test]
 fn derive_generic_schema_enum_variants() {
     #![allow(unused)]
 

--- a/utoipa-gen/tests/snapshots/schema_generics__schema_option_generic.snap
+++ b/utoipa-gen/tests/snapshots/schema_generics__schema_option_generic.snap
@@ -1,0 +1,43 @@
+---
+source: utoipa-gen/tests/schema_generics.rs
+expression: api
+---
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "title",
+    "version": "version"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Bounds_i32": {
+        "type": "object",
+        "properties": {
+          "min": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "type": "integer",
+                "format": "int32"
+              }
+            ]
+          }
+        }
+      },
+      "Top": {
+        "type": "object",
+        "required": [
+          "bounds"
+        ],
+        "properties": {
+          "bounds": {
+            "$ref": "#/components/schemas/Bounds_i32"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Schema**
```rust
#[derive(ToSchema)]
struct Top {
    bounds: Bounds<i32>,
}

#[derive(ToSchema)]
struct Bounds<T> {
    min: Option<T>,
}
```

**Current behaviour**
The `Bounds_i32` schema lists `min` as a non-nullable integer.

```json
{
  "components": {
    "schemas": {
      "Bounds_i32": {
        "type": "object",
        "properties": {
          "min": {
            "type": "integer",
            "format": "int32"
          }
        }
      },
      "Top": {
        "type": "object",
        "required": [
          "bounds"
        ],
        "properties": {
          "bounds": {
            "$ref": "#/components/schemas/Bounds_i32"
          }
        }
      }
    }
  }
}
```

**Expected behaviour**
The `Bounds_i32` schema should list `min` as a nullable integer.

```json
{
  "components": {
    "schemas": {
      "Bounds_i32": {
        "type": "object",
        "properties": {
          "min": {
            "oneOf": [
              {
                "type": "null"
              },
              {
                "type": "integer",
                "format": "int32"
              }
            ]
          }
        }
      },
      "Top": {
        "type": "object",
        "required": [
          "bounds"
        ],
        "properties": {
          "bounds": {
            "$ref": "#/components/schemas/Bounds_i32"
          }
        }
      }
    }
  }
}
```