### PR TITLE
Add `serde` to the helper attributes for `ToSchema`

### DIFF
--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -69,7 +69,7 @@ use self::{
 static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
     once_cell::sync::Lazy::new(utoipa_config::Config::read_from_file);
 
-#[proc_macro_derive(ToSchema, attributes(schema))]
+#[proc_macro_derive(ToSchema, attributes(schema, serde))]
 /// Generate reusable OpenAPI schema to be used
 /// together with [`OpenApi`][openapi_derive].
 ///


### PR DESCRIPTION
See #1471 

This tells the compiler that the `ToSchema` macro looks at `#[serde]` attributes. Without it, structs annotated with `#[serde]` won't compile unless the struct also derives Serialize or Deserialize.

In cases where the Serialize/Deserialize are implemented manually but the schema can still be derived, it may be useful to use serde attributes that don't have a `#[schema]` equivalent, such as `#[serde(untagged)]`.