### PR TITLE
Support extensions in `utoipa::IntoParams` attribute macros

### DIFF
--- a/examples/simple-x-extensions/src/main.rs
+++ b/examples/simple-x-extensions/src/main.rs
@@ -155,6 +155,17 @@ impl utoipa::Modify for ApiModify {
     }
 }
 
+#[derive(Debug, Clone, utoipa::IntoParams)]
+#[into_params(parameter_in = Query, extensions(("x-on-both-struct-params" = json!(true))))]
+pub struct ParamStruct {
+    /// Another param.
+    pub param_1: i32,
+
+    /// Yet another param.
+    #[param(extensions(("x-on-one-param" = json!({ "key": "value" }))))]
+    pub param_2: String,
+}
+
 #[utoipa::path(
     get,
     path = "/openapi",
@@ -168,6 +179,7 @@ impl utoipa::Modify for ApiModify {
           ("x-ext-macro" = json!( "[Macro] openapi>Paths>PathItem>Operation>Parameters>item" ) )
         )
       ),
+      ParamStruct
     ),
     responses(
       ( status = 200,

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -641,6 +641,7 @@ impl_feature_into_inner! {
     attributes::Bound,
     attributes::Ignore,
     attributes::NoRecursion,
+    attributes::Extensions,
     validation::MultipleOf,
     validation::Maximum,
     validation::Minimum,

--- a/utoipa-gen/src/component/features/attributes/extensions.rs
+++ b/utoipa-gen/src/component/features/attributes/extensions.rs
@@ -21,6 +21,12 @@ impl_feature! {
     }
 }
 
+impl Extensions {
+    pub fn merge(&mut self, extensions: Extensions) {
+        self.extensions.extend(extensions.extensions);
+    }
+}
+
 impl Parse for Extensions {
     fn parse(input: syn::parse::ParseStream, _: proc_macro2::Ident) -> syn::Result<Self> {
         syn::parse::Parse::parse(input)

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -2286,6 +2286,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///    supplied, then the value is determined by the `parameter_in_provider` in
 ///    [`IntoParams::into_params()`](trait.IntoParams.html#tymethod.into_params).
 /// * `rename_all = ...` Can be provided to alternatively to the serde's `rename_all` attribute. Effectively provides same functionality.
+/// * `extensions(...)` List of extensions applied to all parameters in the struct. Additive with extensions specfied in field-level `#[param(...)]` attributes.
 ///
 /// Use `names` to define name for single unnamed argument.
 /// ```rust
@@ -2383,6 +2384,8 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 ///
 /// * `ignore` or `ignore = ...` Can be used to skip the field from being serialized to OpenAPI schema. It accepts either a literal `bool` value
 ///   or a path to a function that returns `bool` (`Fn() -> bool`).
+///
+/// * `extensions(...)` List of extensions local to the parameter. Additive with extensions specfied in struct-level `#[into_params(...)]` attributes.
 ///
 /// #### Field nullability and required rules
 ///


### PR DESCRIPTION
Hello! This is my PR addressing the feature I proposed in Issue #1473, adding support to specifying OpenAPI extensions   on parameters using the `#[into_params]` and `#[param]` attribute macros for structs that derive `utoipa::IntoParams`.
The implementation follows the form proposed in the issue:

```rust
#[derive(Debug, Clone, utoipa::IntoParams)]
#[into_params(parameter_in = Query, extensions(("x-on-all-params" = json!(true))))]
pub struct ParamStruct {
    /// A param.
    pub param_1: i32,

    /// Another param.
    #[param(extensions(("x-on-one-param" = json!({ "key": "value" }))))]
    pub param_2: String,
}
```

I updated the macro documentation, added unit tests for the various flavors, and updated the example introduced with the feature in #1292, `simple-x-extensions`.

I couldn't find any special docs about contribution guidelines, please let me know if I'm missing anything!

Closes issue #1473 