### PR TITLE
Replace unmaintained paste with pastey in utoipa-axum

### DIFF
--- a/utoipa-axum/Cargo.toml
+++ b/utoipa-axum/Cargo.toml
@@ -28,7 +28,7 @@ utoipa = { version = "5.0.0", path = "../utoipa", default-features = false, feat
 ] }
 tower-service = "0.3"
 tower-layer = "0.3.2"
-paste = "1.0"
+pastey = "0.1.1"
 
 [dev-dependencies]
 utoipa = { path = "../utoipa", features = ["debug"] }

--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -75,7 +75,7 @@ impl PathItemExt for HttpMethod {
 
 /// re-export paste so users do not need to add the dependency.
 #[doc(hidden)]
-pub use paste::paste;
+pub use pastey::paste;
 
 /// Collect axum handlers annotated with [`utoipa::path`] to [`router::UtoipaMethodRouter`].
 ///

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -45,7 +45,7 @@ axum = { version = "0.8.0", default-features = false, features = [
     "json",
     "query",
 ] }
-paste = "1"
+pastey = "0.1.1"
 rocket = { version = "0.5", features = ["json"] }
 smallvec = { version = "1.10", features = ["serde"] }
 rust_decimal = { version = "1", default-features = false }

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use insta::assert_json_snapshot;
-use paste::paste;
+use pastey::paste;
 use serde::Serialize;
 use serde_json::{json, Value};
 use std::collections::HashMap;

--- a/utoipa-gen/tests/path_response_derive_test.rs
+++ b/utoipa-gen/tests/path_response_derive_test.rs
@@ -139,7 +139,7 @@ macro_rules! test_response_types {
     ( $( $name:ident=> $(body: $expected:expr,)? $( $content_type:literal, )? $( headers: $headers:expr, )?
         assert: $( $path:literal = $expectation:literal, $comment:literal )* )* ) => {
         $(
-            paste::paste! {
+            pastey::paste! {
                 test_fn! {
                     module: [<mod_ $name>],
                     responses: (
@@ -154,7 +154,7 @@ macro_rules! test_response_types {
 
             #[test]
             fn $name() {
-                paste::paste! {
+                pastey::paste! {
                     let doc = api_doc!(module: [<mod_ $name>]);
                 }
 


### PR DESCRIPTION
See: https://github.com/juhaku/utoipa/issues/1482
The paste crate has been archived and is no longer maintained (RUSTSEC-2024-0436). Replace it with pastey, a maintained fork that provides drop-in compatibility.