### PR TITLE
Make value field in SecurityRequirement `pub`

### DIFF
--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -27,8 +27,9 @@ use super::{builder, extensions::Extensions};
 #[derive(Serialize, Deserialize, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct SecurityRequirement {
+    /// Map of security requirement names to list of scopes required for the security scheme.
     #[serde(flatten)]
-    value: BTreeMap<String, Vec<String>>,
+    pub value: BTreeMap<String, Vec<String>>,
 }
 
 impl SecurityRequirement {


### PR DESCRIPTION
In our project we use the `OpenApi` data structure to test our implementation corresponds to our documentation. However we cannot acces the the value of `SecurityRequirement` without serializing the struct.

We propose to make the value field `pub`.