### PR TITLE
Add tagged_discriminator feature to generate cleaner OpenAPI schemas …

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also an awesome type of beer 
 - **`rc_schema`**: Add `ToSchema` support for `Arc<T>` and `Rc<T>` types. **Note!** serde `rc` feature flag must be enabled separately to allow
   serialization and deserialization of `Arc<T>` and `Rc<T>` types. See more about [serde feature flags](https://serde.rs/feature-flags.html).
 - **`config`** Enables [`utoipa-config`](./utoipa-config/README.md) for the project which allows defining global configuration options for `utoipa`.
+- **`tagged_discriminator`**: Changes the schema generation for internally tagged enums. Instead of wrapping variants in an anonymous `allOf` object to inject the discriminator tag, it generates a cleaner schema with `oneOf` and a top-level `discriminator` field. This provides better compatibility with some client generators (e.g. openapi-generator for TypeScript/Java) which struggle with the default nested structure.
 
 ### Default Library Support
 

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -75,6 +75,7 @@ smallvec = []
 repr = []
 indexmap = []
 rc_schema = []
+tagged_discriminator = []
 config = ["dep:utoipa-config", "dep:once_cell"]
 
 # EXPERIEMENTAL! use with cauntion

--- a/utoipa-gen/tests/tagged_discriminator.rs
+++ b/utoipa-gen/tests/tagged_discriminator.rs
@@ -1,0 +1,110 @@
+use utoipa::ToSchema;
+use serde::{Serialize, Deserialize};
+
+#[test]
+#[cfg(feature = "tagged_discriminator")]
+fn derive_enum_tagged_discriminator() {
+
+    #[derive(ToSchema, Serialize, Deserialize)]
+    struct OperationStatePending {
+        id: String,
+    }
+
+    #[derive(ToSchema, Serialize, Deserialize)]
+    struct OperationStateCompleted {
+        result: String,
+    }
+
+    #[derive(ToSchema, Serialize, Deserialize)]
+    #[serde(tag = "type")]
+    enum OperationState {
+        #[serde(rename = "pending")]
+        Pending(OperationStatePending),
+        #[serde(rename = "completed")]
+        Completed(OperationStateCompleted),
+    }
+
+    let schema = <OperationState as utoipa::PartialSchema>::schema();
+    let value = serde_json::to_value(schema).unwrap();
+
+    let expected = serde_json::json!({
+      "discriminator": {
+        "mapping": {
+          "completed": "#/components/schemas/OperationStateCompleted",
+          "pending": "#/components/schemas/OperationStatePending"
+        },
+        "propertyName": "type"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/components/schemas/OperationStatePending"
+        },
+        {
+          "$ref": "#/components/schemas/OperationStateCompleted"
+        }
+      ]
+    });
+
+    assert_eq!(value, expected);
+}
+
+#[test]
+#[cfg(feature = "tagged_discriminator")]
+fn derive_enum_tagged_discriminator_complex() {
+    #[derive(ToSchema, Serialize, Deserialize)]
+    struct Item {
+        name: String,
+    }
+
+    #[derive(ToSchema, Serialize, Deserialize)]
+    #[serde(tag = "kind", rename_all = "camelCase")]
+    enum ComplexEnum {
+        #[serde(rename = "renamed_variant")]
+        VariantRef(Item),
+        
+        InlineVariant {
+            value: i32
+        }
+    }
+    
+    let schema = <ComplexEnum as utoipa::PartialSchema>::schema();
+    let value = serde_json::to_value(schema).unwrap();
+
+    // Inline variants are NOT added to discriminator mapping, but have the tag injected.
+    // Ref variants are added to mapping and are bare refs in oneOf.
+    
+    let expected = serde_json::json!({
+      "discriminator": {
+        "mapping": {
+          "renamed_variant": "#/components/schemas/Item"
+        },
+        "propertyName": "kind"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/components/schemas/Item"
+        },
+        {
+          "type": "object",
+          "required": [
+            "value",
+            "kind"
+          ],
+          "properties": {
+            "kind": {
+              "type": "string",
+              "enum": [
+                "inlineVariant"
+              ]
+            },
+            "value": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      ]
+    });
+
+    assert_eq!(value, expected);
+}

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -51,6 +51,7 @@ repr = ["utoipa-gen?/repr"]
 preserve_order = []
 preserve_path_order = []
 rc_schema = ["utoipa-gen?/rc_schema"]
+tagged_discriminator = ["utoipa-gen?/tagged_discriminator"]
 macros = ["dep:utoipa-gen"]
 config = ["utoipa-gen?/config"]
 


### PR DESCRIPTION
…for internally tagged enums (fixes #1456)