### PR TITLE
Add #[schema(skip)] option for enum variants

### DIFF
--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -104,6 +104,7 @@ pub enum Feature {
     Bound(attributes::Bound),
     Ignore(attributes::Ignore),
     NoRecursion(attributes::NoRecursion),
+    Skip(attributes::Skip),
     MultipleOf(validation::MultipleOf),
     Maximum(validation::Maximum),
     Minimum(validation::Minimum),
@@ -232,6 +233,7 @@ impl ToTokensDiagnostics for Feature {
                 TokenStream::new()
             }
             Feature::NoRecursion(_) => return Err(Diagnostics::new("NoRecursion does not support `ToTokens`")),
+            Feature::Skip(_) => return Err(Diagnostics::new("Skip does not support `ToTokens`")),
             Feature::IntoParamsNames(_) => {
                 return Err(Diagnostics::new("Names feature does not support `ToTokens`")
                     .help("Names is only used with IntoParams to artificially give names for unnamed struct type `IntoParams`."))
@@ -308,6 +310,7 @@ impl Display for Feature {
             Feature::Bound(bound) => bound.fmt(f),
             Feature::Ignore(ignore) => ignore.fmt(f),
             Feature::NoRecursion(no_recursion) => no_recursion.fmt(f),
+            Feature::Skip(skip) => skip.fmt(f),
             Feature::Extensions(extensions) => extensions.fmt(f),
         }
     }
@@ -360,6 +363,7 @@ impl Validatable for Feature {
             Feature::Bound(bound) => bound.is_validatable(),
             Feature::Ignore(ignore) => ignore.is_validatable(),
             Feature::NoRecursion(no_recursion) => no_recursion.is_validatable(),
+            Feature::Skip(skip) => skip.is_validatable(),
             Feature::Extensions(extensions) => extensions.is_validatable(),
         }
     }
@@ -410,6 +414,7 @@ is_validatable! {
     attributes::Bound,
     attributes::Ignore,
     attributes::NoRecursion,
+    attributes::Skip,
     validation::MultipleOf = true,
     validation::Maximum = true,
     validation::Minimum = true,
@@ -641,6 +646,7 @@ impl_feature_into_inner! {
     attributes::Bound,
     attributes::Ignore,
     attributes::NoRecursion,
+    attributes::Skip,
     validation::MultipleOf,
     validation::Maximum,
     validation::Minimum,

--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -1048,3 +1048,24 @@ impl From<NoRecursion> for Feature {
         Self::NoRecursion(value)
     }
 }
+
+impl_feature! {
+    #[derive(Clone)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct Skip;
+}
+
+impl Parse for Skip {
+    fn parse(_: ParseStream, _: Ident) -> syn::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(Self)
+    }
+}
+
+impl From<Skip> for Feature {
+    fn from(value: Skip) -> Self {
+        Self::Skip(value)
+    }
+}

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -3,6 +3,7 @@ use syn::{
     Attribute,
 };
 
+use crate::component::features::attributes::Skip;
 use crate::{
     component::features::{
         attributes::{
@@ -195,6 +196,18 @@ impl Parse for EnumUnnamedFieldVariantFeatures {
 
 impl_into_inner!(EnumUnnamedFieldVariantFeatures);
 
+pub struct EnumFieldVariantFilterFeatures(Vec<Feature>);
+
+impl Parse for EnumFieldVariantFilterFeatures {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(EnumFieldVariantFilterFeatures(parse_features!(
+            input as Skip
+        )))
+    }
+}
+
+impl_into_inner!(EnumFieldVariantFilterFeatures);
+
 pub trait FromAttributes {
     fn parse_features<T>(&self) -> Result<Option<T>, Diagnostics>
     where
@@ -226,7 +239,8 @@ impl_merge!(
     MixedEnumFeatures,
     NamedFieldFeatures,
     EnumNamedFieldVariantFeatures,
-    EnumUnnamedFieldVariantFeatures
+    EnumUnnamedFieldVariantFeatures,
+    EnumFieldVariantFilterFeatures
 );
 
 pub fn parse_schema_features<T: Sized + Parse + Merge<T>>(

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -272,6 +272,24 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 ///
 /// # Enum Optional Configuration Options for `#[schema(...)]`
 ///
+/// ## Enum Variant Filtering Options for `#[schema(...)]`
+///
+/// * `skip` Can be used to skip inclusion of an enum variant in the generated schema. This is similar
+///   to `#[serde(skip)]`, however, the variant will still be included in the generated serialization
+///   and deserialization code. This is particularly useful when you need to define a fixed known
+///   set of `Unit` variants, and one special variant to capture unrecognized values, and still want
+///   the generated schema to be a simple list of the known values. E.g.
+/// ```text
+/// #[derive(utoipa::ToSchema, serde::Serialize, serde::Deserialize)]
+/// enum MyEnum {
+///     OptionA,
+///     OptionB,
+///
+///     #[serde(untagged)]
+///     #[schema(skip)]
+///     Unknown(String),
+/// };
+/// ```
 /// ## Plain Enum having only `Unit` variants Optional Configuration Options for `#[schema(...)]`
 ///
 /// * `description = ...` Can be literal string or Rust expression e.g. [_`const`_][const] reference or

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_simple_enum_serde_skip.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_simple_enum_serde_skip.snap
@@ -1,0 +1,12 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 813
+expression: value
+---
+{
+  "enum": [
+    "One",
+    "Two"
+  ],
+  "type": "string"
+}


### PR DESCRIPTION
Adds a new `#[schema(skip)]` option which can be used to filter out enum variants before deciding if the set of variants is mixed or composed only of `Unit` values. We need this to support our use case, where we have enums with a set of known values, but also want to capture a single `Unknown(String)` value using `#[serde(untagged)]`, but need the resulting openApi documentation to include just a simple list of enum values.

I had hoped to reuse the existing `ignore` feature, however since the filtering needs to happen during the schema generation (but not rust code generation), it wasn't clear how the expression included with `ignore` could be evaluated, and the simple `skip` option matches nicely with the serde `skip` option. 