### PR TITLE
Add customizable page title to `utoipa-scalar`

### DIFF
--- a/utoipa-scalar/CHANAGELOG.md
+++ b/utoipa-scalar/CHANAGELOG.md
@@ -1,5 +1,11 @@
 # Changelog - utoipa-scalar
 
+## Unreleased
+
+### Added
+
+* Add `Scalar::title` for customizing the HTML page title (https://github.com/juhaku/utoipa/pull/1515)
+
 ## 0.3.0 - Thu 16 2025
 
 ### Changed
@@ -45,4 +51,3 @@
 
 * Update docs and next versions
 * Use same licences for scalar as well
-

--- a/utoipa-scalar/res/scalar.html
+++ b/utoipa-scalar/res/scalar.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-    <title>Scalar</title>
+    <title>$title</title>
     <meta charset="utf-8"/>
     <meta
             name="viewport"

--- a/utoipa-scalar/src/lib.rs
+++ b/utoipa-scalar/src/lib.rs
@@ -239,14 +239,12 @@ impl<S: Spec> Scalar<S> {
     /// At this point in time, it is not possible to customize the HTML template used by the
     /// [`Scalar`] instance.
     pub fn to_html(&self) -> String {
-        self.html
-            .replace("$title", &self.title)
-            .replace(
-                "$spec",
-                &serde_json::to_string(&self.openapi).expect(
-                    "Invalid OpenAPI spec, expected OpenApi, String, &str or serde_json::Value",
-                ),
-            )
+        self.html.replace("$title", &self.title).replace(
+            "$spec",
+            &serde_json::to_string(&self.openapi).expect(
+                "Invalid OpenAPI spec, expected OpenApi, String, &str or serde_json::Value",
+            ),
+        )
     }
 
     /// Override the [default HTML template][scalar_html_quickstart] with new one. Refer to


### PR DESCRIPTION
This diff adds a `title` method to Scalar that allows customizing the HTML page title. Previously, the title was hardcoded to "Scalar" and the only way to change it was to override the entire HTML template with `custom_html()`.

The default HTML template now uses a `$title` placeholder which is replaced alongside `$spec` during `to_html`. The default title remains "Scalar" for backwards compatibility.