### PR TITLE
Implement support for serde "partially untagged" enums

### DIFF
--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1284,6 +1284,154 @@ fn derive_mixed_enum_with_ref_serde_untagged_named_fields() {
 }
 
 #[test]
+fn derive_mixed_enum_serde_partially_untagged() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One,
+            #[serde(untagged)]
+            Two(String),
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_untagged_named_fields() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two { m: i32 },
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_untagged_unit_variant() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two,
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn mixed_enum_serde_partially_untagged_unit_variant_proof() {
+    #[derive(Serialize)]
+    enum Foo {
+        One {
+            n: i32,
+        },
+        #[serde(untagged)]
+        Two,
+    }
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"One":{"n":3}}"#
+    );
+    assert_eq!(serde_json::to_string(&Foo::Two).unwrap(), r#"null"#);
+}
+
+#[test]
+fn mixed_enum_serde_partially_untagged_named_fields_proof() {
+    #[derive(Serialize)]
+    enum Foo {
+        One {
+            n: i32,
+        },
+        #[serde(untagged)]
+        Two {
+            m: i32,
+        },
+    }
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"One":{"n":3}}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Two { m: 3 }).unwrap(),
+        r#"{"m":3}"#
+    );
+}
+
+#[test]
+#[ignore = "not implemented"]
+fn derive_unit_variants_serde_partially_untagged() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            TaggedOne,
+            #[serde(untagged)]
+            UntaggedTwo,
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn unit_variants_serde_partially_untagged_proof() {
+    #[derive(Serialize)]
+    enum Foo {
+        TaggedOne,
+        #[serde(untagged)]
+        UntaggedTwo,
+    }
+
+    assert_eq!(
+        serde_json::to_string(&Foo::TaggedOne).unwrap(),
+        r#""TaggedOne""#
+    );
+    assert_eq!(serde_json::to_string(&Foo::UntaggedTwo).unwrap(), r#"null"#);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_untagged_partially_renamed() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            #[serde(rename = "First")]
+            One,
+            #[serde(untagged)]
+            Two(usize),
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn mixed_enum_serde_partially_untagged_partially_renamed_proof() {
+    #[derive(Serialize, serde::Deserialize)]
+    enum Foo {
+        #[serde(rename = "First")]
+        One,
+        #[serde(untagged)]
+        Two(usize),
+    }
+
+    assert_eq!(serde_json::to_string(&Foo::One).unwrap(), "\"First\"");
+    assert_eq!(serde_json::to_string(&Foo::Two(5)).unwrap(), "5");
+    assert!(matches!(
+        serde_json::from_str("\"First\"").unwrap(),
+        Foo::One
+    ));
+    assert!(matches!(serde_json::from_str("5").unwrap(), Foo::Two(5)));
+}
+
+#[test]
 fn derive_mixed_enum_with_ref_serde_untagged_named_fields_rename_all() {
     #[derive(Serialize, ToSchema)]
     struct Bar {

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged.snap
@@ -1,0 +1,17 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "enum": [
+        "One"
+      ],
+      "type": "string"
+    },
+    {
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_named_fields.snap
@@ -1,0 +1,40 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "One": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "One"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "m": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "m"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_partially_renamed.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_partially_renamed.snap
@@ -1,0 +1,18 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "enum": [
+        "First"
+      ],
+      "type": "string"
+    },
+    {
+      "minimum": 0,
+      "type": "integer"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_unit_variant.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_unit_variant.snap
@@ -1,0 +1,32 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "One": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "One"
+      ],
+      "type": "object"
+    },
+    {
+      "default": null,
+      "type": "null"
+    }
+  ]
+}


### PR DESCRIPTION
See here: https://serde.rs/variant-attrs.html#untagged

> Irrespective of the enum representation, serialize and deserialize this variant as untagged, i.e. simply as the variant's data with no record of the variant name.

For a simple example:

```rust
enum SomeEnum {
    Tagged(u32)
    #[serde(untagged)]
    Untagged(u32)
}
```

This would serialize to an optionally tagged integer:

```json
{"Tagged": 3}
3
```

With resulting JSON Schema:

```json
{
    "oneOf": [
        {"type": "object", "properties": {"Tagged": {"type": "integer"} }, "required": ["Tagged"] },
        {"type": "integer"}
    ]
}
```

---

Somewhat related, but __NOT__ implemented in this PR (as it seems like it will take some deeper refactoring of the "plain enum" handling):

```rust
enum SomeEnum {
    One,
    Two,
    #[serde(untagged)]
    Null
}
```

For this enum, serde would emit JSON values `"One"`, `"Two"` and `null`, but utoipa still generates a JSON schema for an enum:

```json
{
    "enum": ["One", "Two", "Null"],
    "type": "string"
}
```
