### PR TITLE
fix(swagger-ui): Use relative redirect to add trailing slash

### DIFF
--- a/utoipa-swagger-ui/src/axum.rs
+++ b/utoipa-swagger-ui/src/axum.rs
@@ -63,7 +63,8 @@ where
             };
             debug_assert!(!path.is_empty());
 
-            let slash_path = format!("{}/", path);
+            let last_segment = path.rsplit('/').next().unwrap_or(path);
+            let slash_path = format!("{}/", last_segment);
             router
                 .route(
                     path,
@@ -172,6 +173,11 @@ mod tests {
         let app = Router::<()>::from(SwaggerUi::new("/swagger-ui/"));
         let response = app.clone().oneshot(get("/swagger-ui")).await.unwrap();
         assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response.headers()[axum::http::header::LOCATION],
+            "swagger-ui/",
+            "redirect Location should be a relative URL"
+        );
         let response = app.clone().oneshot(get("/swagger-ui/")).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         let request = get("/swagger-ui/swagger-ui.css");
@@ -184,6 +190,11 @@ mod tests {
         let app = Router::<()>::from(SwaggerUi::new("/swagger-ui"));
         let response = app.clone().oneshot(get("/swagger-ui")).await.unwrap();
         assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(
+            response.headers()[axum::http::header::LOCATION],
+            "swagger-ui/",
+            "redirect Location should be a relative URL"
+        );
         let response = app.clone().oneshot(get("/swagger-ui/")).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
         let request = get("/swagger-ui/swagger-ui.css");

--- a/utoipa-swagger-ui/src/rocket.rs
+++ b/utoipa-swagger-ui/src/rocket.rs
@@ -98,7 +98,15 @@ impl Handler for ServeSwagger {
         let request_path = request.uri().path().as_str();
         let request_path = match request_path.strip_prefix(base_path) {
             Some(stripped) => stripped,
-            None => return Outcome::from(request, RedirectResponder(base_path.into())),
+            None => {
+                let last_segment = base_path
+                    .trim_end_matches('/')
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or(base_path);
+                let relative = format!("{}/", last_segment);
+                return Outcome::from(request, RedirectResponder(relative));
+            }
         };
         match super::serve(request_path, self.1.clone()) {
             Ok(swagger_file) => swagger_file
@@ -189,6 +197,24 @@ mod tests {
         let rocket = rocket::build().mount("/", routes);
         let client = Client::tracked(rocket).unwrap();
         let response = client.get("/swagger-ui").dispatch();
+        assert_eq!(response.status(), Status::Ok);
+    }
+
+    #[test]
+    fn redirect_to_trailing_slash_is_relative() {
+        let routes: Vec<Route> = SwaggerUi::new("/swagger-ui/<path..>").into();
+        let rocket = rocket::build().mount("/", routes);
+        let client = Client::untracked(rocket).unwrap();
+
+        let response = client.get("/swagger-ui").dispatch();
+        assert_eq!(response.status(), Status::Found);
+        assert_eq!(
+            response.headers().get_one("Location"),
+            Some("swagger-ui/"),
+            "redirect Location should be a relative URL"
+        );
+
+        let response = client.get("/swagger-ui/").dispatch();
         assert_eq!(response.status(), Status::Ok);
     }
 


### PR DESCRIPTION
Given SwaggerUi::new("/path"), we would previously redirect requests for `/path` to `/path/` (adding the trailing slash). Using an absolute redirect path like this can cause issues when the HTTP server is behind a proxy doing path rewriting.

Example scenario detailing the issue:

Say you have a Rust application which exposes a HTTP server with `utoipa-swagger-ui` at path `/path/to/swagger/`. The server is available at hostname `my.server`.

You also have a proxy server at `my.proxy`, which handles incoming requests to the path `/api/...` by stripping the path prefix `/api`, and forwarding the request to `my.server`.

Then you do the following:

1. You send a request to `my.proxy/api/path/to/swagger`
2. The server at `my.proxy` forwards the request to `my.server/path/to/swagger` (note the stripped `/api` prefix)
3. The server at `my.server` redirects it to `/path/to/swagger/` (to "add a trailing slash")
4. The client then follows this redirect, sending a new request to `my.proxy/path/to/swagger/`
5. The request fails, because the proxy does not serve anything at this path (the path has no `/api/` prefix).

Solution:

Redirecting to the relative path `swagger/`* should be more robust, as it more precisely expresses the intent of simply adding a slash to the end of the path, instead of replacing the entire path.

*Or more generally, redirecting to `X/` where `X` is the last path segment of the configured swagger-ui path.