### PR TITLE
Add support for serde `rename_all_fields` container attribute

### DIFF
--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -363,6 +363,12 @@ impl RenameAll {
     }
 }
 
+impl From<RenameRule> for RenameAll {
+    fn from(value: RenameRule) -> Self {
+        Self(value)
+    }
+}
+
 impl Parse for RenameAll {
     fn parse(input: syn::parse::ParseStream, _: Ident) -> syn::Result<Self> {
         let litstr = parse_utils::parse_next(input, || input.parse::<LitStr>())?;

--- a/utoipa-gen/src/component/schema/enums.rs
+++ b/utoipa-gen/src/component/schema/enums.rs
@@ -492,6 +492,16 @@ impl MixedEnumContent {
         );
         let name = renamed.unwrap_or(Cow::Owned(name));
 
+        if let Some(rename_all_fields) = &serde_container.rename_all_fields {
+            if !variant_features
+                .iter()
+                .any(|f| matches!(f, Feature::RenameAll(_)))
+            {
+                variant_features
+                    .push(Feature::RenameAll(rename_all_fields.clone().into()));
+            }
+        }
+
         let root = &Root {
             ident: &variant.ident,
             attributes: &variant.attrs,

--- a/utoipa-gen/src/component/serde.rs
+++ b/utoipa-gen/src/component/serde.rs
@@ -115,6 +115,7 @@ pub enum SerdeEnumRepr {
 #[cfg_attr(test, derive(PartialEq, Eq))]
 pub struct SerdeContainer {
     pub rename_all: Option<RenameRule>,
+    pub rename_all_fields: Option<RenameRule>,
     pub enum_repr: SerdeEnumRepr,
     pub default: bool,
     pub deny_unknown_fields: bool,
@@ -123,6 +124,7 @@ pub struct SerdeContainer {
 impl SerdeContainer {
     /// Parse a single serde attribute, currently supported attributes are:
     ///     * `rename_all = ...`
+    ///     * `rename_all_fields = ...`
     ///     * `tag = ...`
     ///     * `content = ...`
     ///     * `untagged = ...`
@@ -133,6 +135,15 @@ impl SerdeContainer {
             "rename_all" => {
                 if let Some((literal, span)) = parse_next_lit_str(next) {
                     self.rename_all = Some(
+                        literal
+                            .parse::<RenameRule>()
+                            .map_err(|error| Error::new(span, error.to_string()))?,
+                    );
+                }
+            }
+            "rename_all_fields" => {
+                if let Some((literal, span)) = parse_next_lit_str(next) {
+                    self.rename_all_fields = Some(
                         literal
                             .parse::<RenameRule>()
                             .map_err(|error| Error::new(span, error.to_string()))?,
@@ -281,6 +292,9 @@ pub fn parse_container(attributes: &[Attribute]) -> Result<SerdeContainer, Diagn
             }
             if value.rename_all.is_some() {
                 acc.rename_all = value.rename_all;
+            }
+            if value.rename_all_fields.is_some() {
+                acc.rename_all_fields = value.rename_all_fields;
             }
 
             acc
@@ -501,6 +515,22 @@ mod tests {
         let expected = SerdeContainer {
             default: true,
             deny_unknown_fields: true,
+            ..Default::default()
+        };
+
+        let result = parse_container(attributes).expect("parse success");
+        assert_eq!(expected, result);
+    }
+
+    #[test]
+    fn test_serde_parse_container_rename_all_fields() {
+        let rename_all_fields_attribute: syn::Attribute = parse_quote! {
+            #[serde(rename_all_fields = "camelCase")]
+        };
+        let attributes: &[Attribute] = &[rename_all_fields_attribute];
+
+        let expected = SerdeContainer {
+            rename_all_fields: Some(RenameRule::Camel),
             ..Default::default()
         };
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1306,6 +1306,147 @@ fn derive_mixed_enum_with_ref_serde_untagged_named_fields_rename_all() {
 }
 
 #[test]
+fn derive_mixed_enum_serde_rename_all_fields() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(rename_all_fields = "camelCase")]
+        enum Foo {
+            One { some_number: i32, another_field: String },
+            Two { yet_another: bool },
+            Unit,
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_rename_all_fields_with_variant_rename_all_override() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(rename_all_fields = "camelCase")]
+        enum Foo {
+            #[serde(rename_all = "UPPERCASE")]
+            One { some_number: i32, another_field: String },
+            Two { yet_another: bool },
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_rename_all_and_rename_all_fields() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(rename_all = "snake_case", rename_all_fields = "camelCase")]
+        enum Foo {
+            UnitValue,
+            NamedFields { some_number: i32, another_field: String },
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_rename_all_fields_untagged() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(untagged, rename_all_fields = "camelCase")]
+        enum Foo {
+            One { some_number: i32 },
+            Two { another_field: String },
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_rename_all_fields_with_field_rename_override() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(rename_all_fields = "camelCase")]
+        enum Foo {
+            One {
+                some_number: i32,
+                #[serde(rename = "custom_name")]
+                another_field: String,
+            },
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_rename_all_fields_internally_tagged() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type", rename_all_fields = "camelCase")]
+        enum Foo {
+            One { some_number: i32, another_field: String },
+            Two { yet_another: bool },
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_rename_all_fields_adjacently_tagged() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "tag", content = "content", rename_all_fields = "camelCase")]
+        enum Foo {
+            One { some_number: i32, another_field: String },
+            Two { yet_another: bool },
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_rename_all_fields_with_schema_rename_all_on_variant() {
+    // variant `#[schema(rename_all)]` overrides enum `#[serde(rename_all_fields)]`
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(rename_all_fields = "camelCase")]
+        enum Foo {
+            #[schema(rename_all = "SCREAMING-KEBAB-CASE")]
+            One { some_number: i32, another_field: String },
+            Two { yet_another: bool },
+        }
+    };
+
+    assert_value! {value=>
+        "oneOf.[0].properties.One.properties.SOME-NUMBER.type" = r#""integer""#, "variant schema rename_all overrides enum rename_all_fields"
+        "oneOf.[0].properties.One.properties.ANOTHER-FIELD.type" = r#""string""#, "variant schema rename_all overrides enum rename_all_fields"
+        "oneOf.[1].properties.Two.properties.yetAnother.type" = r#""boolean""#, "variant without override uses rename_all_fields"
+    };
+}
+
+#[test]
+fn derive_mixed_enum_serde_rename_all_fields_does_not_affect_unnamed_variant() {
+    #[derive(Serialize, ToSchema)]
+    struct Bar(String);
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(rename_all_fields = "camelCase")]
+        enum Foo {
+            Named { some_number: i32 },
+            Unnamed(Bar),
+            Unit,
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
 fn derive_mixed_enum_serde_adjacently_tagged() {
     let value: Value = api_doc! {
         #[derive(Serialize)]

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_and_rename_all_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_and_rename_all_fields.snap
@@ -1,0 +1,39 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1349
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "enum": [
+        "unit_value"
+      ],
+      "type": "string"
+    },
+    {
+      "properties": {
+        "named_fields": {
+          "properties": {
+            "anotherField": {
+              "type": "string"
+            },
+            "someNumber": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "someNumber",
+            "anotherField"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "named_fields"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields.snap
@@ -1,0 +1,58 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1320
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "One": {
+          "properties": {
+            "anotherField": {
+              "type": "string"
+            },
+            "someNumber": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "someNumber",
+            "anotherField"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "One"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "Two": {
+          "properties": {
+            "yetAnother": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "yetAnother"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "Two"
+      ],
+      "type": "object"
+    },
+    {
+      "enum": [
+        "Unit"
+      ],
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_adjacently_tagged.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_adjacently_tagged.snap
@@ -1,0 +1,66 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1408
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "content": {
+          "properties": {
+            "anotherField": {
+              "type": "string"
+            },
+            "someNumber": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "someNumber",
+            "anotherField"
+          ],
+          "type": "object"
+        },
+        "tag": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "tag"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "content": {
+          "properties": {
+            "yetAnother": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "yetAnother"
+          ],
+          "type": "object"
+        },
+        "tag": {
+          "enum": [
+            "Two"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "tag"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_does_not_affect_unnamed_variant.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_does_not_affect_unnamed_variant.snap
@@ -1,0 +1,46 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1441
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "Named": {
+          "properties": {
+            "someNumber": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "someNumber"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "Named"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "Unnamed": {
+          "$ref": "#/components/schemas/Bar"
+        }
+      },
+      "required": [
+        "Unnamed"
+      ],
+      "type": "object"
+    },
+    {
+      "enum": [
+        "Unit"
+      ],
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_internally_tagged.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_internally_tagged.snap
@@ -1,0 +1,50 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1394
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "anotherField": {
+          "type": "string"
+        },
+        "someNumber": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "someNumber",
+        "anotherField",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "type": {
+          "enum": [
+            "Two"
+          ],
+          "type": "string"
+        },
+        "yetAnother": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "yetAnother",
+        "type"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_untagged.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_untagged.snap
@@ -1,0 +1,32 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1363
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "someNumber": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "someNumber"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "anotherField": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "anotherField"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_with_field_rename_override.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_with_field_rename_override.snap
@@ -1,0 +1,33 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1380
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "One": {
+          "properties": {
+            "custom_name": {
+              "type": "string"
+            },
+            "someNumber": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "someNumber",
+            "custom_name"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "One"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_with_variant_rename_all_override.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_rename_all_fields_with_variant_rename_all_override.snap
@@ -1,0 +1,52 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+assertion_line: 1335
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "One": {
+          "properties": {
+            "ANOTHER_FIELD": {
+              "type": "string"
+            },
+            "SOME_NUMBER": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "SOME_NUMBER",
+            "ANOTHER_FIELD"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "One"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "Two": {
+          "properties": {
+            "yetAnother": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "yetAnother"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "Two"
+      ],
+      "type": "object"
+    }
+  ]
+}


### PR DESCRIPTION
Adds support for serde's [`rename_all_fields`](https://serde.rs/container-attrs.html#rename_all_fields) container attribute on enums.

```rust
#[derive(Serialize, ToSchema)]
#[serde(rename_all_fields = "camelCase")]
enum MyEnum {
    One { some_number: i32 },       // -> someNumber
    Two { another_field: String },   // -> anotherField
    Unit,                            // unaffected
}
```

Per-variant `#[serde(rename_all = "...")]` overrides `rename_all_fields`, following serde's specification.

Closes #853