### PR TITLE
Also use generics on ObjectBuilder::default(value) like other setter

### DIFF
--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -7,6 +7,7 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Added
 
+* Also use generics on `ObjectBuilder::default(value)` like other setter (https://github.com/juhaku/utoipa/pull/1537)
 * Add support for jiff v0.2 `Timestamp` (https://github.com/juahku/utoipa/pull/1416)
 
 ## 5.4.0 - Jun 16 2025

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -1170,8 +1170,8 @@ impl ObjectBuilder {
     }
 
     /// Add or change default value for the object which is provided when user has not provided the input in Swagger UI.
-    pub fn default(mut self, default: Option<Value>) -> Self {
-        set_value!(self default default)
+    pub fn default<V: Into<Value>>(mut self, default: Option<V>) -> Self {
+        set_value!(self default default.map(Into::into))
     }
 
     /// Add or change deprecated status for [`Object`].
@@ -2149,7 +2149,7 @@ mod tests {
                                         .schema_type(Type::Integer)
                                         .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                                         .description(Some("Id of credential"))
-                                        .default(Some(json!(1i32))),
+                                        .default(Some(1i32)),
                                 )
                                 .property(
                                     "name",
@@ -2161,7 +2161,7 @@ mod tests {
                                     "status",
                                     ObjectBuilder::new()
                                         .schema_type(Type::String)
-                                        .default(Some(json!("Active")))
+                                        .default(Some("Active"))
                                         .description(Some("Credential status"))
                                         .enum_values(Some([
                                             "Active",
@@ -2255,7 +2255,7 @@ mod tests {
                     .schema_type(Type::Integer)
                     .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                     .description(Some("Id of credential"))
-                    .default(Some(json!(1i32))),
+                    .default(Some(1i32)),
             )
             .property(
                 "name",
@@ -2267,7 +2267,7 @@ mod tests {
                 "status",
                 ObjectBuilder::new()
                     .schema_type(Type::String)
-                    .default(Some(json!("Active")))
+                    .default(Some("Active"))
                     .description(Some("Credential status"))
                     .enum_values(Some(["Active", "NotActive", "Locked", "Expired"])),
             )
@@ -2380,7 +2380,7 @@ mod tests {
                     .schema_type(Type::Integer)
                     .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                     .description(Some("Id of credential"))
-                    .default(Some(json!(1i32))),
+                    .default(Some(1i32)),
             ),
         );
 
@@ -2397,7 +2397,7 @@ mod tests {
                         .schema_type(Type::Integer)
                         .format(Some(SchemaFormat::KnownFormat(KnownFormat::Int32)))
                         .description(Some("Id of credential"))
-                        .default(Some(json!(1i32))),
+                        .default(Some(1i32)),
                 ),
             )
             .build();


### PR DESCRIPTION
# Quality of life

Currently all setters of ObjectBuilder use generics except `default()`.