### PR TITLE
Support generating enum varnames/descriptions

### DIFF
--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -116,6 +116,8 @@ pub enum Feature {
     MinItems(validation::MinItems),
     MaxProperties(validation::MaxProperties),
     MinProperties(validation::MinProperties),
+    EnumVarnames(attributes::EnumVarnames),
+    EnumDescriptions(attributes::EnumDescriptions),
     Extensions(attributes::Extensions),
 }
 
@@ -244,6 +246,8 @@ impl ToTokensDiagnostics for Feature {
                 quote! { .#name(#required) }
             }
             Feature::Ignore(_) => return Err(Diagnostics::new("Ignore does not support `ToTokens`")),
+            Feature::EnumVarnames(_) => quote! { .enum_varnames() },
+            Feature::EnumDescriptions(_) => quote! { .enum_descriptions() },
             Feature::Extensions(extensions) => quote! { .extensions(Some(#extensions)) },
         };
 
@@ -308,6 +312,8 @@ impl Display for Feature {
             Feature::Bound(bound) => bound.fmt(f),
             Feature::Ignore(ignore) => ignore.fmt(f),
             Feature::NoRecursion(no_recursion) => no_recursion.fmt(f),
+            Feature::EnumVarnames(ev) => ev.fmt(f),
+            Feature::EnumDescriptions(ed) => ed.fmt(f),
             Feature::Extensions(extensions) => extensions.fmt(f),
         }
     }
@@ -360,6 +366,8 @@ impl Validatable for Feature {
             Feature::Bound(bound) => bound.is_validatable(),
             Feature::Ignore(ignore) => ignore.is_validatable(),
             Feature::NoRecursion(no_recursion) => no_recursion.is_validatable(),
+            Feature::EnumVarnames(ev) => ev.is_validatable(),
+            Feature::EnumDescriptions(ed) => ed.is_validatable(),
             Feature::Extensions(extensions) => extensions.is_validatable(),
         }
     }
@@ -410,6 +418,8 @@ is_validatable! {
     attributes::Bound,
     attributes::Ignore,
     attributes::NoRecursion,
+    attributes::EnumVarnames,
+    attributes::EnumDescriptions,
     validation::MultipleOf = true,
     validation::Maximum = true,
     validation::Minimum = true,
@@ -641,6 +651,8 @@ impl_feature_into_inner! {
     attributes::Bound,
     attributes::Ignore,
     attributes::NoRecursion,
+    attributes::EnumVarnames,
+    attributes::EnumDescriptions,
     validation::MultipleOf,
     validation::Maximum,
     validation::Minimum,

--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -1026,6 +1026,56 @@ impl From<bool> for Ignore {
     }
 }
 
+impl_feature! {
+    /// Include enum variable names in a schema extension
+    ///
+    /// Can be specified as `varnames = "x-something"` to specify the key for
+    /// the extension, or just `varnames`, to use `x-enum-varnames`.
+    #[derive(Clone)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct EnumVarnames;
+}
+
+impl Parse for EnumVarnames {
+    fn parse(_: syn::parse::ParseStream, _: Ident) -> syn::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(Self)
+    }
+}
+
+impl From<EnumVarnames> for Feature {
+    fn from(value: EnumVarnames) -> Self {
+        Self::EnumVarnames(value)
+    }
+}
+
+impl_feature! {
+    /// Include enum variable names in a schema extension
+    ///
+    /// Can be specified as `varnames = "x-something"` to specify the key for
+    /// the extension, or just `varnames`, to use `x-enum-varnames`.
+    #[derive(Clone)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct EnumDescriptions;
+}
+
+impl Parse for EnumDescriptions {
+    fn parse(_: syn::parse::ParseStream, _: Ident) -> syn::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        Ok(Self)
+    }
+}
+
+impl From<EnumDescriptions> for Feature {
+    fn from(value: EnumDescriptions) -> Self {
+        Self::EnumDescriptions(value)
+    }
+}
+
 // Nothing to parse, it is considered to be set when attribute itself is parsed via
 // `parse_features!`.
 impl_feature! {

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -857,6 +857,8 @@ impl<'e> EnumSchema<'e> {
                             super::features::attributes::Examples,
                             super::features::attributes::Default,
                             super::features::attributes::Title,
+                            crate::component::features::attributes::EnumVarnames,
+                            crate::component::features::attributes::EnumDescriptions,
                             crate::component::features::attributes::Deprecated,
                             As
                         ))

--- a/utoipa-gen/src/component/schema/enums.rs
+++ b/utoipa-gen/src/component/schema/enums.rs
@@ -2,7 +2,9 @@ use std::{borrow::Cow, ops::Deref};
 
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{punctuated::Punctuated, spanned::Spanned, token::Comma, Fields, TypePath, Variant};
+use syn::{
+    punctuated::Punctuated, spanned::Spanned, token::Comma, Fields, LitStr, TypePath, Variant,
+};
 
 use crate::{
     component::{
@@ -36,6 +38,8 @@ enum PlainEnumRepr<'p> {
 pub struct PlainEnum<'e> {
     pub root: &'e Root<'e>,
     enum_variant: PlainEnumRepr<'e>,
+    varnames: Option<EnumExtension<'e>>,
+    descriptions: Option<EnumExtension<'e>>,
     serde_enum_repr: SerdeEnumRepr,
     features: Vec<Feature>,
     pub description: Option<Description>,
@@ -118,12 +122,35 @@ impl<'e> PlainEnum<'e> {
             ),
         };
 
+        let varnames = pop_feature!(features => Feature::EnumVarnames(_)).map(|_| EnumExtension {
+            key: LitStr::new("x-enum-varnames", proc_macro2::Span::call_site()),
+            names: variants
+                .iter()
+                .map(|v| LitStr::new(&v.ident.to_string(), v.ident.span()))
+                .collect(),
+        });
+
+        let descriptions =
+            pop_feature!(features => Feature::EnumDescriptions(_)).map(|_| EnumExtension {
+                key: LitStr::new("x-enum-descriptions", proc_macro2::Span::call_site()),
+                names: variants
+                    .iter()
+                    .map(|v| {
+                        let doc =
+                            CommentAttributes::from_attributes(&v.attrs).as_formatted_string();
+                        LitStr::new(&doc, v.ident.span())
+                    })
+                    .collect(),
+            });
+
         Ok(Self {
             root,
             enum_variant,
             features,
             serde_enum_repr: container_rules.enum_repr,
             description,
+            varnames,
+            descriptions,
         })
     }
 
@@ -165,8 +192,14 @@ impl ToTokens for PlainEnum<'_> {
 
         match &self.serde_enum_repr {
             SerdeEnumRepr::ExternallyTagged => {
-                EnumSchema::<PlainSchema>::with_types(variants, schema_type, enum_type)
-                    .to_tokens(tokens);
+                EnumSchema::<PlainSchema>::with_types(
+                    variants,
+                    Roo::Ref(&self.varnames),
+                    Roo::Ref(&self.descriptions),
+                    schema_type,
+                    enum_type,
+                )
+                .to_tokens(tokens);
             }
             SerdeEnumRepr::InternallyTagged { tag } => {
                 let items = variants
@@ -182,6 +215,8 @@ impl ToTokens for PlainEnum<'_> {
                         .map(|item| {
                             EnumSchema::<PlainSchema>::with_types(
                                 Roo::Ref(item),
+                                Roo::Owned(None),
+                                Roo::Owned(None),
                                 Roo::Ref(schema_type),
                                 Roo::Ref(enum_type),
                             )
@@ -213,6 +248,8 @@ impl ToTokens for PlainEnum<'_> {
                             EnumSchema::<ObjectSchema>::adjacently_tagged(
                                 PlainSchema::new(
                                     item.deref(),
+                                    Roo::Owned(None),
+                                    Roo::Owned(None),
                                     Roo::Ref(schema_type),
                                     Roo::Ref(enum_type),
                                 ),
@@ -232,6 +269,23 @@ impl ToTokens for PlainEnum<'_> {
         };
 
         tokens.extend(self.features.to_token_stream());
+    }
+}
+
+#[cfg_attr(feature = "debug", derive(Debug))]
+struct EnumExtension<'p> {
+    key: LitStr,
+    names: Array<'p, LitStr>,
+}
+
+impl ToTokens for EnumExtension<'_> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let key = &self.key;
+        let names = &self.names;
+
+        tokens.extend(quote! {
+            .extension(#key, #names)
+        })
     }
 }
 
@@ -896,10 +950,12 @@ impl<'a> EnumSchema<PlainSchema> {
 
     fn with_types<T: ToTokens>(
         items: Roo<'a, Array<'a, T>>,
+        varnames: Roo<'a, Option<EnumExtension>>,
+        descriptions: Roo<'a, Option<EnumExtension>>,
         schema_type: Roo<'a, SchemaType<'a>>,
         enum_type: Roo<'a, TokenStream>,
     ) -> Self {
-        let plain_schema = PlainSchema::new(&items, schema_type, enum_type);
+        let plain_schema = PlainSchema::new(&items, varnames, descriptions, schema_type, enum_type);
 
         Self {
             content: Some(PlainSchema(quote! {
@@ -960,8 +1016,10 @@ impl PlainSchema {
         (Roo::Owned(schema_type), Roo::Owned(enum_type))
     }
 
-    fn new<'a, T: ToTokens>(
-        items: &[T],
+    fn new<'a>(
+        items: &[impl ToTokens],
+        varnames: Roo<'a, Option<EnumExtension>>,
+        descriptions: Roo<'a, Option<EnumExtension>>,
         schema_type: Roo<'a, SchemaType<'a>>,
         enum_type: Roo<'a, TokenStream>,
     ) -> Self {
@@ -969,10 +1027,14 @@ impl PlainSchema {
         let enum_type = enum_type.as_ref();
         let items = Array::Borrowed(items);
         let len = items.len();
+        let varnames = varnames.as_ref().as_ref().map(|v| v.to_token_stream());
+        let descriptions = descriptions.as_ref().as_ref().map(|v| v.to_token_stream());
 
         let plain_enum = quote! {
                 .schema_type(#schema_type)
                 .enum_values::<[#enum_type; #len], #enum_type>(Some(#items))
+                #varnames
+                #descriptions
         };
 
         Self(plain_enum.to_token_stream())
@@ -981,7 +1043,13 @@ impl PlainSchema {
     fn for_name<N: ToTokens>(name: N) -> Self {
         let (schema_type, enum_type) = Self::get_default_types();
         let name = &[name.to_token_stream()];
-        Self::new(name, schema_type, enum_type)
+        Self::new(
+            name,
+            Roo::Owned(None),
+            Roo::Owned(None),
+            schema_type,
+            enum_type,
+        )
     }
 }
 

--- a/utoipa-gen/src/component/schema/features.rs
+++ b/utoipa-gen/src/component/schema/features.rs
@@ -84,6 +84,8 @@ impl Parse for EnumFeatures {
             RenameAll,
             As,
             Deprecated,
+            crate::component::features::attributes::EnumVarnames,
+            crate::component::features::attributes::EnumDescriptions,
             Description,
             Bound
         )))

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -162,7 +162,7 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 ///   _`Value`_ will be rendered as any OpenAPI value (i.e. no `type` restriction).
 /// * `inline` If the type of this field implements [`ToSchema`][to_schema], then the schema definition
 ///   will be inlined. **warning:** Don't use this for recursive data types!
-///   
+///
 ///   **Note!**<br>Using `inline` with generic arguments might lead to incorrect spec generation.
 ///   This is due to the fact that during compilation we cannot know how to treat the generic
 ///   argument and there is difference whether it is a primitive type or another generic type.
@@ -288,6 +288,10 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 /// * `rename_all = ...` Supports same syntax as _serde_ _`rename_all`_ attribute. Will rename all
 ///   variants of the enum accordingly. If both _serde_ `rename_all` and _schema_ _`rename_all`_
 ///   are defined __serde__ will take precedence.
+/// * `enum_varnames` Can be used to add the common `"x-enum-varnames"` extension with the names used by
+///   the enum values in the code.
+/// * `enum_descriptions` Can be used to add the common `"x-enum-descriptions"` extension with each
+///    enum value's description (taken from its doc comment).
 /// * `as = ...` Can be used to define alternative path and name for the schema what will be used in
 ///   the OpenAPI. E.g _`as = path::to::Pet`_. This would make the schema appear in the generated
 ///   OpenAPI spec as _`path.to.Pet`_. This same name will be used throughout the OpenAPI generated

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3105,6 +3105,41 @@ fn derive_struct_inline_with_description() {
 }
 
 #[test]
+fn derive_enum_varnames() {
+    let value = api_doc! {
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "lowercase")]
+        #[schema(enum_varnames)]
+        enum ExitCode {
+            Error,
+            Ok,
+            Unknown,
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_enum_descriptions() {
+    let value = api_doc! {
+        #[derive(serde::Deserialize)]
+        #[schema(enum_descriptions)]
+        enum ExitCode {
+            /// There was an error
+            ///
+            /// Try turning it off and on again.
+            Error,
+            /// Success
+            Ok,
+            Unknown,
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
 fn schema_manual_impl() {
     #![allow(unused)]
 

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_enum_descriptions.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_enum_descriptions.snap
@@ -1,0 +1,17 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "enum": [
+    "Error",
+    "Ok",
+    "Unknown"
+  ],
+  "type": "string",
+  "x-enum-descriptions": [
+    "There was an error\n\nTry turning it off and on again.",
+    "Success",
+    ""
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_enum_varnames.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_enum_varnames.snap
@@ -1,0 +1,17 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "enum": [
+    "error",
+    "ok",
+    "unknown"
+  ],
+  "type": "string",
+  "x-enum-varnames": [
+    "Error",
+    "Ok",
+    "Unknown"
+  ]
+}

--- a/utoipa/src/openapi/content.rs
+++ b/utoipa/src/openapi/content.rs
@@ -121,4 +121,20 @@ impl ContentBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }

--- a/utoipa/src/openapi/encoding.rs
+++ b/utoipa/src/openapi/encoding.rs
@@ -91,4 +91,20 @@ impl EncodingBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }

--- a/utoipa/src/openapi/external_docs.rs
+++ b/utoipa/src/openapi/external_docs.rs
@@ -60,4 +60,20 @@ impl ExternalDocsBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }

--- a/utoipa/src/openapi/info.rs
+++ b/utoipa/src/openapi/info.rs
@@ -130,6 +130,22 @@ impl InfoBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }
 
 builder! {
@@ -192,6 +208,22 @@ impl ContactBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }
 
 builder! {
@@ -251,6 +283,22 @@ impl LicenseBuilder {
     /// Add openapi extensions (x-something) of the API.
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
     }
 
     /// Set identifier of the licence as [SPDX-Licenses][spdx_licence] expression for the API.

--- a/utoipa/src/openapi/link.rs
+++ b/utoipa/src/openapi/link.rs
@@ -140,4 +140,20 @@ impl LinkBuilder {
 
         self
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -174,6 +174,22 @@ impl PathsBuilder {
         set_value!(self extensions extensions)
     }
 
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
+
     /// Appends a [`Path`] to map of paths. Method must be called with one generic argument that
     /// implements [`trait@Path`] trait.
     ///
@@ -402,6 +418,22 @@ impl PathItemBuilder {
     /// Add openapi extensions (x-something) to this [`PathItem`].
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
     }
 }
 
@@ -665,6 +697,22 @@ impl OperationBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }
 
 builder! {
@@ -814,6 +862,22 @@ impl ParameterBuilder {
     /// Add openapi extensions (x-something) to the [`Parameter`].
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
     }
 }
 

--- a/utoipa/src/openapi/request_body.rs
+++ b/utoipa/src/openapi/request_body.rs
@@ -65,6 +65,22 @@ impl RequestBodyBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }
 
 /// Trait with convenience functions for documenting request bodies.

--- a/utoipa/src/openapi/response.rs
+++ b/utoipa/src/openapi/response.rs
@@ -81,6 +81,22 @@ impl ResponsesBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }
 
 impl From<Responses> for BTreeMap<String, RefOr<Response>> {
@@ -178,6 +194,22 @@ impl ResponseBuilder {
     /// Add openapi extensions (x-something) to the [`Header`].
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
     }
 
     /// Add link that can be followed from the response.

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -263,6 +263,22 @@ impl ComponentsBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }
 
 /// Is super type for [OpenAPI Schema Object][schemas]. Schema is reusable resource what can be
@@ -536,6 +552,22 @@ impl OneOfBuilder {
         set_value!(self extensions extensions)
     }
 
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
+
     to_array_builder!();
 }
 
@@ -713,6 +745,22 @@ impl AllOfBuilder {
         set_value!(self extensions extensions)
     }
 
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
+
     to_array_builder!();
 }
 
@@ -878,6 +926,22 @@ impl AnyOfBuilder {
     /// Add openapi extensions (`x-something`) for [`AnyOf`].
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
     }
 
     to_array_builder!();
@@ -1275,6 +1339,22 @@ impl ObjectBuilder {
     /// Add openapi extensions (`x-something`) for [`Object`].
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
     }
 
     /// Set of change [`Object::content_encoding`]. Typically left empty but could be `base64` for
@@ -1842,6 +1922,22 @@ impl ArrayBuilder {
     /// Add openapi extensions (`x-something`) for [`Array`].
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
     }
 
     to_array_builder!();

--- a/utoipa/src/openapi/server.rs
+++ b/utoipa/src/openapi/server.rs
@@ -154,6 +154,22 @@ impl ServerBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }
 
 builder! {
@@ -208,6 +224,22 @@ impl ServerVariableBuilder {
     /// Add openapi extensions (x-something) of the API.
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
     }
 }
 

--- a/utoipa/src/openapi/tag.rs
+++ b/utoipa/src/openapi/tag.rs
@@ -65,4 +65,20 @@ impl TagBuilder {
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
     }
+
+    /// Add an extension (`x-something`) to the existing extensions
+    pub fn extension(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        if let Some(e) = self.extensions.as_mut() {
+            e
+        } else {
+            self.extensions.insert(Default::default())
+        }
+        .insert(key.into(), value.into());
+
+        self
+    }
 }


### PR DESCRIPTION
This addresses https://github.com/juhaku/utoipa/issues/1317.

`x-enum-varnames` and `x-enum-descriptions` are [commonly used extensions](https://openapi-generator.tech/docs/templating/#enum),
especially for enums with a numeric representation. This adds options to generate
both of those values, so an enum like this:

```rust
    #[schema(repr, enum_varnames, enum_descriptions)]
    #[repr(u8)]
    pub enum MyEnum {
        /// Value A
        A = 0,
        /// Value B
        B = 1,
        /// Value C
        C = 2,
    }
```

Will have a schema like this:

```json
{
  "type": "integer",
  "enum": [
    0,
    1,
    2
  ],
  "x-enum-varnames": [
    "A",
    "B",
    "C"
  ],
  "x-enum-descriptions": [
    "Value A",
    "Value B",
    "Value C"
  ]
}
```

(Note that this example uses the `#[schema(repr)]` syntax from [this PR](https://github.com/juhaku/utoipa/pull/1539), just because the `enum_varnames` feature makes most sense with a numerical enum. The two branches aren't dependent on each other though.)