### PR TITLE
Fix(utoipa-gen): Emit min_properties for MinProperties feature

### DIFF
--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -205,7 +205,7 @@ impl ToTokensDiagnostics for Feature {
                 quote! { .max_properties(Some(#max_properties)) }
             }
             Feature::MinProperties(min_properties) => {
-                quote! { .max_properties(Some(#min_properties)) }
+                quote! { .min_properties(Some(#min_properties)) }
             }
             Feature::SchemaWith(schema_with) => schema_with.to_token_stream(),
             Feature::Description(description) => quote! { .description(Some(#description)) },


### PR DESCRIPTION
Couldn't get "min properties" to work without this, fixes a typo. Emit min_properties for MinProperties in codegen.