### PR TITLE
ci: stop installing nightly in `test (examples)` job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -126,12 +126,6 @@ jobs:
           toolchain: stable
           components: clippy, rustfmt
 
-      - name: Install nightly Rust
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly
-          components: clippy, rustfmt
-
       - uses: actions/cache@v3
         with:
           path: |


### PR DESCRIPTION
## Summary
- Removes the unused `Install nightly Rust` step from the `test-examples-compile` job.
- Restores green CI on `master` by ensuring `just validate-examples` runs under stable rustc.

## Why

The `test (examples)` job has been failing on every push to `master` since early May 2026 (see #1551). `dtolnay/rust-toolchain@master` runs `rustup default <toolchain>` after each install, so installing nightly *after* stable made nightly the default. `just validate-examples` then invoked plain `cargo`, compiling every example under the latest nightly rustc.

A recent nightly tightened how `rustc_*` attribute names are validated, which trips `rustix 0.37.28` (pulled in transitively by `tide 0.16` → `async-h1 2.3.4` → `async-io 1.13.0`):

```
error: attributes starting with `rustc` are reserved for use by the `rustc` compiler
  --> rustix-0.37.28/src/backend/linux_raw/io/errno.rs:28:25
   | #[cfg_attr(rustc_attrs, rustc_layout_scalar_valid_range_start(0xf001))]
error: could not compile `rustix` (lib) due to 4 previous errors
```

Stable rustc still accepts the gated attribute, so dropping the unused nightly install is the minimal fix and avoids reaching into the unmaintained `tide` dependency tree.

Nothing in the workflow or `just validate-examples` recipe needs nightly — the only nightly-only recipes (`coverage`, `doc`) prefix `cargo +nightly` explicitly.

## Test plan

- [x] Reproduced the failure locally: `cargo +nightly clippy --all-features --all-targets --workspace --quiet` inside `examples/todo-tide` fails with the rustix errors above.
- [x] Verified the fix locally: `just validate-examples` succeeds under `stable-x86_64-unknown-linux-gnu` (rustc 1.94.1), printing `All examples are valid!`.
- [x] Verified `cargo +stable clippy --all-features --all-targets --workspace` on `examples/todo-tide` returns warnings only, exit 0.

Closes #1551

---

**Disclosure:** Diagnosis and patch drafted with assistance from Anthropic Claude (Claude Code). All findings — log inspection, dependency-tree reverse lookup, local toolchain reproduction — were verified before submitting.