### PR TITLE
Add quote_diagnostics! and quote_diagnostics_spanned! macros

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+* Add quote_diagnostics! and quote_diagnostics_spanned! macros (https://github.com/juhaku/utoipa/pull/1553)
+
 ### Changed
 
 * Emit nullable_item last for OneOfBuilder (https://github.com/juhaku/utoipa/pull/1299)

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -12,11 +12,12 @@ use syn::{
 
 use crate::doc_comment::CommentAttributes;
 use crate::schema_type::{KnownFormat, PrimitiveType, SchemaTypeInner};
-use crate::{
-    as_tokens_or_diagnostics, Array, AttributesExt, Diagnostics, GenericsExt, OptionExt,
-    ToTokensDiagnostics,
-};
+use crate::token_stream::quote_diagnostics_spanned;
 use crate::{schema_type::SchemaType, Deprecated};
+use crate::{
+    token_stream::{as_tokens_or_diagnostics, quote_diagnostics, ToTokensDiagnostics},
+    Array, AttributesExt, Diagnostics, GenericsExt, OptionExt,
+};
 
 use self::features::attributes::{Description, Nullable};
 use self::features::validation::Minimum;
@@ -946,7 +947,6 @@ impl ComponentSchema {
         let nullable: Option<Nullable> =
             pop_feature!(features => Feature::Nullable(_)).into_inner();
         let default = pop_feature!(features => Feature::Default(_));
-        let default_tokens = as_tokens_or_diagnostics!(&default);
         let deprecated = pop_feature!(features => Feature::Deprecated(_)).try_to_token_stream()?;
 
         let additional_properties = additional_properties
@@ -1006,14 +1006,14 @@ impl ComponentSchema {
         let schema_type =
             ComponentSchema::get_schema_type_override(nullable, SchemaTypeInner::Object);
 
-        tokens.extend(quote! {
+        tokens.extend(quote_diagnostics! {
             utoipa::openapi::ObjectBuilder::new()
                 #schema_type
                 #additional_properties
                 #description_stream
                 #deprecated
-                #default_tokens
-        });
+                @default
+        }?);
 
         example.to_tokens(tokens)
     }
@@ -1159,10 +1159,9 @@ impl ComponentSchema {
                     }
                 }
 
-                let schema_type_tokens = as_tokens_or_diagnostics!(&schema_type);
-                tokens.extend(quote! {
-                    utoipa::openapi::ObjectBuilder::new().schema_type(#schema_type_tokens)
-                });
+                tokens.extend(quote_diagnostics! {
+                    utoipa::openapi::ObjectBuilder::new().schema_type(@schema_type)
+                }?);
 
                 let format = KnownFormat::from_path(type_path)?;
                 if format.is_known_format() {
@@ -1238,9 +1237,7 @@ impl ComponentSchema {
                     object_schema_reference.name = quote! { String::from(#name_tokens) };
 
                     let default = pop_feature!(features => Feature::Default(_));
-                    let default_tokens = as_tokens_or_diagnostics!(&default);
                     let title = pop_feature!(features => Feature::Title(_));
-                    let title_tokens = as_tokens_or_diagnostics!(&title);
 
                     if is_inline {
                         let schema_type = SchemaType {
@@ -1292,14 +1289,14 @@ impl ComponentSchema {
                             || title.is_some()
                             || !description_tokens.is_empty()
                         {
-                            quote_spanned! {type_path.span()=>
+                            quote_diagnostics_spanned! {type_path.span()=>
                                 utoipa::openapi::schema::OneOfBuilder::new()
                                     .item(#items_tokens)
                                     #nullable_item
-                                #title_tokens
-                                #default_tokens
+                                @title
+                                @default
                                 #description_stream
-                            }
+                            }?
                         } else {
                             items_tokens
                         };
@@ -1359,16 +1356,16 @@ impl ComponentSchema {
                         // on schemas more over there is no way to distinct the `summary` from
                         // `description` of the ref. Should we consider supporting the summary?
                         let schema = if default.is_some() || nullable || title.is_some() {
-                            composed_or_ref(quote_spanned! {type_path.span()=>
+                            composed_or_ref(quote_diagnostics_spanned! {type_path.span()=>
                                 utoipa::openapi::schema::OneOfBuilder::new()
                                     .item(utoipa::openapi::schema::RefBuilder::new()
                                         #description_stream
                                         .ref_location_from_schema_name(#name_tokens)
                                     )
                                     #nullable_item
-                                    #title_tokens
-                                    #default_tokens
-                            })
+                                    @title
+                                    @default
+                            }?)
                         } else {
                             composed_or_ref(quote_spanned! {type_path.span()=>
                                 utoipa::openapi::schema::RefBuilder::new()
@@ -1602,7 +1599,6 @@ impl FlattenedMapSchema {
         let example = features.pop_by(|feature| matches!(feature, Feature::Example(_)));
         let nullable = pop_feature!(features => Feature::Nullable(_));
         let default = pop_feature!(features => Feature::Default(_));
-        let default_tokens = as_tokens_or_diagnostics!(&default);
 
         // Maps are treated as generic objects with no named properties and
         // additionalProperties denoting the type
@@ -1621,12 +1617,12 @@ impl FlattenedMapSchema {
         })?;
         let schema_tokens = schema_property.to_token_stream();
 
-        tokens.extend(quote! {
+        tokens.extend(quote_diagnostics! {
             #schema_tokens
                 #description
                 #deprecated
-                #default_tokens
-        });
+                @default
+        }?);
 
         example.to_tokens(&mut tokens)?;
         nullable.to_tokens(&mut tokens)?;

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -5,7 +5,9 @@ use quote::{quote, ToTokens};
 use syn::parse::ParseStream;
 
 use crate::{
-    as_tokens_or_diagnostics, schema_type::SchemaType, Diagnostics, OptionExt, ToTokensDiagnostics,
+    schema_type::SchemaType,
+    token_stream::{as_tokens_or_diagnostics, Diagnostics, ToTokensDiagnostics},
+    OptionExt,
 };
 
 use self::validators::{AboveZeroF64, AboveZeroUsize, IsNumber, IsString, IsVec, ValidatorChain};

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -26,7 +26,8 @@ use crate::{
     },
     doc_comment::CommentAttributes,
     parse_utils::LitBoolOrExprPath,
-    Array, Diagnostics, OptionExt, Required, ToTokensDiagnostics,
+    token_stream::{quote_diagnostics, Diagnostics, ToTokensDiagnostics},
+    Array, OptionExt, Required,
 };
 
 use super::{
@@ -380,8 +381,7 @@ impl Param {
 
         let schema_with = pop_feature!(param_features => Feature::SchemaWith(_));
         if let Some(schema_with) = schema_with {
-            let schema_with = crate::as_tokens_or_diagnostics!(&schema_with);
-            tokens.extend(quote! { .schema(Some(#schema_with)).build() });
+            tokens.extend(quote_diagnostics! { .schema(Some(@schema_with)).build() }?);
         } else {
             let description =
                 CommentAttributes::from_attributes(&field.attrs).as_formatted_string();

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -8,14 +8,14 @@ use syn::{
 };
 
 use crate::{
-    as_tokens_or_diagnostics,
     component::features::{
         attributes::{Rename, Title, ValueType},
         validation::Pattern,
     },
     doc_comment::CommentAttributes,
     parse_utils::LitBoolOrExprPath,
-    Array, AttributesExt, Diagnostics, OptionExt, ToTokensDiagnostics,
+    token_stream::{as_tokens_or_diagnostics, quote_diagnostics, ToTokensDiagnostics},
+    Array, AttributesExt, Diagnostics, OptionExt,
 };
 
 use self::{
@@ -495,17 +495,16 @@ impl NamedStructSchema {
 
             for (options, _, _, field) in flatten_fields {
                 let NamedStructFieldOptions { property, .. } = options;
-                let property_schema = as_tokens_or_diagnostics!(property);
 
                 match property {
                     Property::Schema(_) | Property::SchemaWith(_) => {
-                        flattened_tokens.extend(quote! { .item(#property_schema) })
+                        flattened_tokens.extend(quote_diagnostics! { .item(@property) }?)
                     }
                     Property::FlattenedMap(_) => {
                         match flattened_map_field {
                             None => {
                                 object_tokens.extend(
-                                    quote! { .additional_properties(Some(#property_schema)) },
+                                    quote_diagnostics! { .additional_properties(Some(@property)) }?,
                                 );
                                 flattened_map_field = Some(field);
                             }

--- a/utoipa-gen/src/component/schema/enums.rs
+++ b/utoipa-gen/src/component/schema/enums.rs
@@ -21,7 +21,8 @@ use crate::{
     },
     doc_comment::CommentAttributes,
     schema_type::SchemaType,
-    Array, AttributesExt, Diagnostics, ToTokensDiagnostics,
+    token_stream::{Diagnostics, ToTokensDiagnostics},
+    Array, AttributesExt,
 };
 
 use super::{features, serde, NamedStructSchema, Root, UnnamedStructSchema};

--- a/utoipa-gen/src/ext.rs
+++ b/utoipa-gen/src/ext.rs
@@ -9,7 +9,7 @@ use syn::{punctuated::Punctuated, token::Comma, ItemFn};
 use crate::component::{ComponentSchema, ComponentSchemaProps, Container, TypeTree};
 use crate::path::media_type::MediaTypePathExt;
 use crate::path::{HttpMethod, PathTypeTree};
-use crate::{Diagnostics, ToTokensDiagnostics};
+use crate::token_stream::{Diagnostics, ToTokensDiagnostics};
 
 #[cfg(feature = "auto_into_responses")]
 pub mod auto_types;

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -20,13 +20,7 @@ compile_error!(
     "`actix_extras`, `axum_extras` and `rocket_extras` are mutually exclusive feature flags"
 );
 
-use std::{
-    borrow::{Borrow, Cow},
-    error::Error,
-    fmt::Display,
-    mem,
-    ops::Deref,
-};
+use std::{mem, ops::Deref};
 
 use component::schema::Schema;
 use doc_comment::CommentAttributes;
@@ -35,9 +29,9 @@ use component::into_params::IntoParams;
 use ext::{PathOperationResolver, PathOperations, PathResolver};
 use openapi::OpenApi;
 use proc_macro::TokenStream;
-use quote::{quote, quote_spanned, ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens, TokenStreamExt};
 
-use proc_macro2::{Group, Ident, Punct, Span, TokenStream as TokenStream2};
+use proc_macro2::{Group, Ident, Punct, TokenStream as TokenStream2};
 use syn::{
     bracketed,
     parse::{Parse, ParseStream},
@@ -54,6 +48,7 @@ mod path;
 mod schema_type;
 mod security_requirement;
 mod server;
+pub(crate) mod token_stream;
 
 use crate::path::{Path, PathAttr};
 
@@ -64,6 +59,7 @@ use self::{
     },
     openapi::parse_openapi_attrs,
     path::response::derive::{IntoResponses, ToResponse},
+    token_stream::{Diagnostics, ToTokensDiagnostics},
 };
 
 #[cfg(feature = "config")]
@@ -3455,170 +3451,6 @@ impl<'g> GenericsExt for &'g syn::Generics {
                     None
                 }
             })
-    }
-}
-
-trait ToTokensDiagnostics {
-    fn to_tokens(&self, tokens: &mut TokenStream2) -> Result<(), Diagnostics>;
-
-    #[allow(unused)]
-    fn into_token_stream(self) -> TokenStream2
-    where
-        Self: std::marker::Sized,
-    {
-        ToTokensDiagnostics::to_token_stream(&self)
-    }
-
-    fn to_token_stream(&self) -> TokenStream2 {
-        let mut tokens = TokenStream2::new();
-        match ToTokensDiagnostics::to_tokens(self, &mut tokens) {
-            Ok(_) => tokens,
-            Err(error_stream) => Into::<Diagnostics>::into(error_stream).into_token_stream(),
-        }
-    }
-
-    fn try_to_token_stream(&self) -> Result<TokenStream2, Diagnostics> {
-        let mut tokens = TokenStream2::new();
-        match ToTokensDiagnostics::to_tokens(self, &mut tokens) {
-            Ok(_) => Ok(tokens),
-            Err(diagnostics) => Err(diagnostics),
-        }
-    }
-}
-
-macro_rules! as_tokens_or_diagnostics {
-    ( $type:expr ) => {{
-        let mut _tokens = proc_macro2::TokenStream::new();
-        match crate::ToTokensDiagnostics::to_tokens($type, &mut _tokens) {
-            Ok(_) => _tokens,
-            Err(diagnostics) => return Err(diagnostics),
-        }
-    }};
-}
-
-use as_tokens_or_diagnostics;
-
-#[derive(Debug)]
-struct Diagnostics {
-    diagnostics: Vec<DiangosticsInner>,
-}
-
-#[derive(Debug)]
-struct DiangosticsInner {
-    span: Span,
-    message: Cow<'static, str>,
-    suggestions: Vec<Suggestion>,
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum Suggestion {
-    Help(Cow<'static, str>),
-    Note(Cow<'static, str>),
-}
-
-impl Display for Diagnostics {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.message())
-    }
-}
-
-impl Display for Suggestion {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Help(help) => {
-                let s: &str = help.borrow();
-                write!(f, "help = {}", s)
-            }
-            Self::Note(note) => {
-                let s: &str = note.borrow();
-                write!(f, "note = {}", s)
-            }
-        }
-    }
-}
-
-impl Diagnostics {
-    fn message(&self) -> Cow<'static, str> {
-        self.diagnostics
-            .first()
-            .as_ref()
-            .map(|diagnostics| diagnostics.message.clone())
-            .unwrap_or_else(|| Cow::Borrowed(""))
-    }
-
-    pub fn new<S: Into<Cow<'static, str>>>(message: S) -> Self {
-        Self::with_span(Span::call_site(), message)
-    }
-
-    pub fn with_span<S: Into<Cow<'static, str>>>(span: Span, message: S) -> Self {
-        Self {
-            diagnostics: vec![DiangosticsInner {
-                span,
-                message: message.into(),
-                suggestions: Vec::new(),
-            }],
-        }
-    }
-
-    pub fn help<S: Into<Cow<'static, str>>>(mut self, help: S) -> Self {
-        if let Some(diagnostics) = self.diagnostics.first_mut() {
-            diagnostics.suggestions.push(Suggestion::Help(help.into()));
-            diagnostics.suggestions.sort();
-        }
-
-        self
-    }
-
-    pub fn note<S: Into<Cow<'static, str>>>(mut self, note: S) -> Self {
-        if let Some(diagnostics) = self.diagnostics.first_mut() {
-            diagnostics.suggestions.push(Suggestion::Note(note.into()));
-            diagnostics.suggestions.sort();
-        }
-
-        self
-    }
-}
-
-impl From<syn::Error> for Diagnostics {
-    fn from(value: syn::Error) -> Self {
-        Self::with_span(value.span(), value.to_string())
-    }
-}
-
-impl ToTokens for Diagnostics {
-    fn to_tokens(&self, tokens: &mut TokenStream2) {
-        for diagnostics in &self.diagnostics {
-            let span = diagnostics.span;
-            let message: &str = diagnostics.message.borrow();
-
-            let suggestions = diagnostics
-                .suggestions
-                .iter()
-                .map(Suggestion::to_string)
-                .collect::<Vec<_>>()
-                .join("\n");
-
-            let diagnostics = if !suggestions.is_empty() {
-                Cow::Owned(format!("{message}\n\n{suggestions}"))
-            } else {
-                Cow::Borrowed(message)
-            };
-
-            tokens.extend(quote_spanned! {span=>
-                ::core::compile_error!(#diagnostics);
-            })
-        }
-    }
-}
-
-impl Error for Diagnostics {}
-
-impl FromIterator<Diagnostics> for Option<Diagnostics> {
-    fn from_iter<T: IntoIterator<Item = Diagnostics>>(iter: T) -> Self {
-        iter.into_iter().reduce(|mut acc, diagnostics| {
-            acc.diagnostics.extend(diagnostics.diagnostics);
-            acc
-        })
     }
 }
 

--- a/utoipa-gen/src/openapi.rs
+++ b/utoipa-gen/src/openapi.rs
@@ -18,7 +18,8 @@ use crate::{
     parse_utils,
     security_requirement::SecurityRequirementsAttr,
     server::Server,
-    Array, Diagnostics, ExternalDocs, ToTokensDiagnostics,
+    token_stream::{Diagnostics, ToTokensDiagnostics},
+    Array, ExternalDocs,
 };
 use crate::{path, OptionExt};
 

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -12,9 +12,8 @@ use syn::{Expr, ExprLit, Lit, LitStr};
 
 use crate::component::{features::attributes::Extensions, ComponentSchema, GenericType, TypeTree};
 use crate::server::Server;
-use crate::{
-    as_tokens_or_diagnostics, parse_utils, Deprecated, Diagnostics, OptionExt, ToTokensDiagnostics,
-};
+use crate::token_stream::quote_diagnostics;
+use crate::{parse_utils, token_stream::ToTokensDiagnostics, Deprecated, Diagnostics, OptionExt};
 use crate::{schema_type::SchemaType, security_requirement::SecurityRequirementsAttr, Array};
 
 use self::response::Response;
@@ -484,7 +483,6 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
             extensions: self.path_attr.extensions.as_ref(),
             servers: self.path_attr.servers.as_ref(),
         };
-        let operation = as_tokens_or_diagnostics!(&operation);
 
         fn to_schema_references(
             mut schemas: TokenStream2,
@@ -596,7 +594,7 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
             path_struct
         };
 
-        tokens.extend(quote! {
+        tokens.extend(quote_diagnostics! {
             impl<'t> utoipa::__dev::Tags<'t> for #impl_for {
                 fn tags() -> Vec<&'t str> {
                     #tags_list.into()
@@ -614,7 +612,7 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
                 fn operation() -> utoipa::openapi::path::Operation {
                     use utoipa::openapi::ToArray;
                     use std::iter::FromIterator;
-                    #operation.into()
+                    @operation.into()
                 }
             }
 
@@ -625,7 +623,7 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
                 }
             }
 
-        });
+        }?);
 
         Ok(())
     }
@@ -650,17 +648,15 @@ impl ToTokensDiagnostics for Operation<'_> {
         tokens.extend(quote! { utoipa::openapi::path::OperationBuilder::new() });
 
         if let Some(request_body) = self.request_body {
-            let request_body = as_tokens_or_diagnostics!(request_body);
-            tokens.extend(quote! {
-                .request_body(Some(#request_body))
-            })
+            tokens.extend(quote_diagnostics! {
+                .request_body(Some(@request_body))
+            }?)
         }
 
         let responses = Responses(self.responses);
-        let responses = as_tokens_or_diagnostics!(&responses);
-        tokens.extend(quote! {
-            .responses(#responses)
-        });
+        tokens.extend(quote_diagnostics! {
+            .responses(@responses)
+        }?);
         if let Some(security_requirements) = self.security {
             tokens.extend(quote! {
                 .securities(Some(#security_requirements))

--- a/utoipa-gen/src/path/handler.rs
+++ b/utoipa-gen/src/path/handler.rs
@@ -1,7 +1,6 @@
-use quote::quote;
 use syn::ItemFn;
 
-use crate::{as_tokens_or_diagnostics, ToTokensDiagnostics};
+use crate::token_stream::{quote_diagnostics, ToTokensDiagnostics};
 
 use super::Path;
 
@@ -13,11 +12,11 @@ pub struct Handler<'p> {
 impl<'p> ToTokensDiagnostics for Handler<'p> {
     fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) -> Result<(), crate::Diagnostics> {
         let ast_fn = &self.handler_fn;
-        let path = as_tokens_or_diagnostics!(&self.path);
-        tokens.extend(quote! {
-            #path
+        let path = &self.path;
+        tokens.extend(quote_diagnostics! {
+            @path
             #ast_fn
-        });
+        }?);
 
         Ok(())
     }

--- a/utoipa-gen/src/path/media_type.rs
+++ b/utoipa-gen/src/path/media_type.rs
@@ -12,7 +12,11 @@ use crate::component::features::attributes::{Extensions, Inline};
 use crate::component::features::Feature;
 use crate::component::{ComponentSchema, ComponentSchemaProps, Container, TypeTree, ValueType};
 use crate::ext::ExtSchema;
-use crate::{parse_utils, AnyValue, Array, Diagnostics, ToTokensDiagnostics};
+use crate::{
+    parse_utils,
+    token_stream::{Diagnostics, ToTokensDiagnostics},
+    AnyValue, Array,
+};
 
 use super::example::Example;
 use super::PathTypeTree;

--- a/utoipa-gen/src/path/parameter.rs
+++ b/utoipa-gen/src/path/parameter.rs
@@ -9,7 +9,6 @@ use syn::{
 };
 
 use crate::{
-    as_tokens_or_diagnostics,
     component::{
         self,
         features::{
@@ -26,7 +25,9 @@ use crate::{
         },
         ComponentSchema, Container, TypeTree,
     },
-    parse_utils, Diagnostics, Required, ToTokensDiagnostics,
+    parse_utils,
+    token_stream::{quote_diagnostics, Diagnostics, ToTokensDiagnostics},
+    Required,
 };
 
 use super::media_type::ParsedType;
@@ -94,8 +95,7 @@ impl ToTokensDiagnostics for Parameter<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostics> {
         match self {
             Parameter::Value(parameter) => {
-                let parameter = as_tokens_or_diagnostics!(parameter);
-                tokens.extend(quote! { .parameter(#parameter) });
+                tokens.extend(quote_diagnostics! { .parameter(@parameter) }?);
             }
             Parameter::IntoParamsIdent(IntoParamsIdentParameter {
                 path,

--- a/utoipa-gen/src/path/request_body.rs
+++ b/utoipa-gen/src/path/request_body.rs
@@ -5,7 +5,11 @@ use syn::token::Paren;
 use syn::{parse::Parse, Error, Token};
 
 use crate::component::{features::attributes::Extensions, ComponentSchema};
-use crate::{parse_utils, Diagnostics, Required, ToTokensDiagnostics};
+use crate::{
+    parse_utils,
+    token_stream::{Diagnostics, ToTokensDiagnostics},
+    Required,
+};
 
 use super::media_type::{MediaTypeAttr, Schema};
 use super::parse;

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -11,8 +11,12 @@ use syn::{
 };
 
 use crate::{
-    component::ComponentSchema, features::attributes::Extensions, parse_utils,
-    path::media_type::Schema, AnyValue, Diagnostics, ToTokensDiagnostics,
+    component::ComponentSchema,
+    features::attributes::Extensions,
+    parse_utils,
+    path::media_type::Schema,
+    token_stream::{quote_diagnostics, Diagnostics, ToTokensDiagnostics},
+    AnyValue,
 };
 
 use self::{header::Header, link::LinkTuple};
@@ -455,10 +459,9 @@ impl ToTokensDiagnostics for ResponseTuple<'_> {
 
                 for header in &value.headers {
                     let name = &header.name;
-                    let header = crate::as_tokens_or_diagnostics!(header);
-                    tokens.extend(quote! {
-                        .header(#name, #header)
-                    })
+                    tokens.extend(quote_diagnostics! {
+                        .header(#name, @header)
+                    }?)
                 }
 
                 for LinkTuple(name, link) in &value.links {
@@ -762,8 +765,7 @@ impl ToTokensDiagnostics for Responses<'_> {
                     }
                     Response::Tuple(response) => {
                         let code = &response.status_code;
-                        let response = crate::as_tokens_or_diagnostics!(response);
-                        Ok(quote! { .response(#code, #response) })
+                        Ok(quote_diagnostics! { .response(#code, @response) }?)
                     }
                 })
                 .collect::<Result<Vec<_>, Diagnostics>>()?

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -15,9 +15,8 @@ use syn::{
 use crate::component::schema::{EnumSchema, NamedStructSchema, Root};
 use crate::doc_comment::CommentAttributes;
 use crate::path::media_type::{DefaultSchema, MediaTypeAttr, ParsedType, Schema};
-use crate::{
-    as_tokens_or_diagnostics, parse_utils, Array, Diagnostics, OptionExt, ToTokensDiagnostics,
-};
+use crate::token_stream::quote_diagnostics;
+use crate::{parse_utils, token_stream::ToTokensDiagnostics, Array, Diagnostics, OptionExt};
 
 use super::{
     DeriveIntoResponsesValue, DeriveResponseValue, DeriveToResponseValue, ResponseTuple,
@@ -85,7 +84,7 @@ impl ToTokensDiagnostics for ToResponse<'_> {
         let lifetime = &self.lifetime;
         let ident = &self.ident;
         let name = ident.to_string();
-        let response = as_tokens_or_diagnostics!(&self.response);
+        let response = &self.response;
 
         let mut to_response_generics = self.generics.clone();
         to_response_generics
@@ -95,13 +94,13 @@ impl ToTokensDiagnostics for ToResponse<'_> {
             )));
         let (to_response_impl_generics, _, _) = to_response_generics.split_for_impl();
 
-        tokens.extend(quote! {
+        tokens.extend(quote_diagnostics! {
             impl #to_response_impl_generics utoipa::ToResponse <#lifetime> for #ident #ty_generics #where_clause {
                 fn response() -> (& #lifetime str, utoipa::openapi::RefOr<utoipa::openapi::response::Response>) {
-                    (#name, #response.into())
+                    (#name, @response.into())
                 }
             }
-        });
+        }?);
 
         Ok(())
     }
@@ -122,9 +121,8 @@ impl ToTokensDiagnostics for IntoResponses {
                     let response =
                         NamedStructResponse::new(&self.attributes, &self.ident, &fields.named)?.0;
                     let status = &response.status_code;
-                    let response_tokens = as_tokens_or_diagnostics!(&response);
 
-                    Array::from_iter(iter::once(quote!((#status, #response_tokens))))
+                    Array::from_iter(iter::once(quote_diagnostics!((#status, @response))?))
                 }
                 Fields::Unnamed(fields) => {
                     let field = fields
@@ -136,16 +134,14 @@ impl ToTokensDiagnostics for IntoResponses {
                     let response =
                         UnnamedStructResponse::new(&self.attributes, &field.ty, &field.attrs)?.0;
                     let status = &response.status_code;
-                    let response_tokens = as_tokens_or_diagnostics!(&response);
 
-                    Array::from_iter(iter::once(quote!((#status, #response_tokens))))
+                    Array::from_iter(iter::once(quote_diagnostics!((#status, @response))?))
                 }
                 Fields::Unit => {
                     let response = UnitStructResponse::new(&self.attributes)?.0;
                     let status = &response.status_code;
-                    let response_tokens = as_tokens_or_diagnostics!(&response);
 
-                    Array::from_iter(iter::once(quote!((#status, #response_tokens))))
+                    Array::from_iter(iter::once(quote_diagnostics!((#status, @response))?))
                 }
             },
             Data::Enum(enum_value) => enum_value
@@ -175,8 +171,7 @@ impl ToTokensDiagnostics for IntoResponses {
                 .iter()
                 .map(|response| {
                     let status = &response.status_code;
-                    let response_tokens = as_tokens_or_diagnostics!(response);
-                    Ok(quote!((#status, utoipa::openapi::RefOr::from(#response_tokens))))
+                    quote_diagnostics!((#status, utoipa::openapi::RefOr::from(@response)))
                 })
                 .collect::<Result<Array<TokenStream>, Diagnostics>>()?,
             Data::Union(_) => {
@@ -190,7 +185,7 @@ impl ToTokensDiagnostics for IntoResponses {
         let ident = &self.ident;
         let (impl_generics, ty_generics, where_clause) = self.generics.split_for_impl();
 
-        let responses = if responses.len() > 0 {
+        let responses = if !responses.is_empty() {
             Some(quote!( .responses_from_iter(#responses)))
         } else {
             None

--- a/utoipa-gen/src/path/response/header.rs
+++ b/utoipa-gen/src/path/response/header.rs
@@ -6,7 +6,10 @@ use syn::{Error, Generics, Ident, LitStr, Token};
 use crate::component::features::attributes::Inline;
 use crate::component::{ComponentSchema, Container, TypeTree};
 use crate::path::media_type::ParsedType;
-use crate::{parse_utils, Diagnostics, ToTokensDiagnostics};
+use crate::{
+    parse_utils,
+    token_stream::{Diagnostics, ToTokensDiagnostics},
+};
 
 /// Parsed representation of response header defined in `#[utoipa::path(..)]` attribute.
 ///

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -3,7 +3,7 @@ use quote::{quote, ToTokens};
 use syn::spanned::Spanned;
 use syn::{parse::Parse, Error, Ident, LitStr, Path};
 
-use crate::{Diagnostics, ToTokensDiagnostics};
+use crate::token_stream::{Diagnostics, ToTokensDiagnostics};
 
 /// Represents data type of [`Schema`].
 #[cfg_attr(feature = "debug", derive(Debug))]

--- a/utoipa-gen/src/token_stream.rs
+++ b/utoipa-gen/src/token_stream.rs
@@ -329,3 +329,74 @@ impl FromIterator<Diagnostics> for Option<Diagnostics> {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Entity;
+
+    impl ToTokensDiagnostics for Entity {
+        fn to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostics> {
+            tokens.extend(quote::quote! { entity });
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn quote_diagnostics_with_curly_braces() {
+        let entity = Entity;
+        let result: Result<proc_macro2::TokenStream, crate::Diagnostics> = quote_diagnostics! {
+            ( @entity )
+        };
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn quote_diagnostics_with_curly_brackets() {
+        let entity = Entity;
+        let result: Result<proc_macro2::TokenStream, crate::Diagnostics> = quote_diagnostics! {
+            { @entity }
+        };
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn quote_diagnostics_with_brackets() {
+        let entity = Entity;
+        let result: Result<proc_macro2::TokenStream, crate::Diagnostics> = quote_diagnostics! {
+            [ @entity ]
+        };
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn quote_diagnostics_spanned_with_curly_braces() {
+        let span = Span::call_site();
+        let entity = Entity;
+        let result: Result<proc_macro2::TokenStream, crate::Diagnostics> = quote_diagnostics_spanned! {
+            span => ( @entity )
+        };
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn quote_diagnostics_spanned_with_curly_brackets() {
+        let span = Span::call_site();
+        let entity = Entity;
+        let result: Result<proc_macro2::TokenStream, crate::Diagnostics> = quote_diagnostics_spanned! {
+            span => { @entity }
+        };
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn quote_diagnostics_spanned_with_brackets() {
+        let span = Span::call_site();
+        let entity = Entity;
+        let result: Result<proc_macro2::TokenStream, crate::Diagnostics> = quote_diagnostics_spanned! {
+            span => [ @entity ]
+        };
+        assert!(result.is_ok());
+    }
+}

--- a/utoipa-gen/src/token_stream.rs
+++ b/utoipa-gen/src/token_stream.rs
@@ -185,7 +185,7 @@ macro_rules! quote_diagnostics_spanned {
         $out.extend(quote::quote_spanned!($span => $($prev)*));
 
         let mut group = proc_macro2::TokenStream::new();
-        $crate::quote_diagnostics_spanned!( %qd group $span; [ ] [ $($inner)* ]);
+        $crate::token_stream::quote_diagnostics_spanned!( %qd group $span; [ ] [ $($inner)* ]);
         $out.extend(quote::quote_spanned!{$span =>  { #group } });
 
         $crate::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);

--- a/utoipa-gen/src/token_stream.rs
+++ b/utoipa-gen/src/token_stream.rs
@@ -175,7 +175,7 @@ macro_rules! quote_diagnostics_spanned {
         $out.extend(quote::quote_spanned!($span => $($prev)*));
 
         let mut group = proc_macro2::TokenStream::new();
-        $crate::quote_diagnostics_spanned!( %qd group $span; [ ] [ $($inner)* ]);
+        $crate::token_stream::quote_diagnostics_spanned!( %qd group $span; [ ] [ $($inner)* ]);
         $out.extend(quote::quote_spanned!{$span =>  [ #group ] });
 
         $crate::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);

--- a/utoipa-gen/src/token_stream.rs
+++ b/utoipa-gen/src/token_stream.rs
@@ -188,7 +188,7 @@ macro_rules! quote_diagnostics_spanned {
         $crate::token_stream::quote_diagnostics_spanned!( %qd group $span; [ ] [ $($inner)* ]);
         $out.extend(quote::quote_spanned!{$span =>  { #group } });
 
-        $crate::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);
+        $crate::token_stream::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);
     };
     (%qd $out:ident $span:expr; [$($prev:tt)*] [$first:tt $($rest:tt)*]) => {
         $crate::token_stream::quote_diagnostics_spanned!( %qd $out $span; [ $($prev)* $first ] [ $($rest)* ]);

--- a/utoipa-gen/src/token_stream.rs
+++ b/utoipa-gen/src/token_stream.rs
@@ -178,7 +178,7 @@ macro_rules! quote_diagnostics_spanned {
         $crate::token_stream::quote_diagnostics_spanned!( %qd group $span; [ ] [ $($inner)* ]);
         $out.extend(quote::quote_spanned!{$span =>  [ #group ] });
 
-        $crate::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);
+        $crate::token_stream::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);
     };
     // inner {}
     (%qd $out:ident $span:expr; [$($prev:tt)*] [{ $($inner:tt)* } $($rest:tt)*]) => {

--- a/utoipa-gen/src/token_stream.rs
+++ b/utoipa-gen/src/token_stream.rs
@@ -1,0 +1,331 @@
+use proc_macro2::{Span, TokenStream};
+use quote::{quote_spanned, ToTokens};
+use std::borrow::Borrow;
+use std::borrow::Cow;
+use std::error::Error;
+use std::fmt::Display;
+
+pub trait ToTokensDiagnostics {
+    fn to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostics>;
+
+    #[allow(unused)]
+    fn into_token_stream(self) -> TokenStream
+    where
+        Self: std::marker::Sized,
+    {
+        ToTokensDiagnostics::to_token_stream(&self)
+    }
+
+    fn to_token_stream(&self) -> TokenStream {
+        let mut tokens = TokenStream::new();
+        match ToTokensDiagnostics::to_tokens(self, &mut tokens) {
+            Ok(_) => tokens,
+            Err(error_stream) => Into::<Diagnostics>::into(error_stream).into_token_stream(),
+        }
+    }
+
+    fn try_to_token_stream(&self) -> Result<TokenStream, Diagnostics> {
+        let mut tokens = TokenStream::new();
+        match ToTokensDiagnostics::to_tokens(self, &mut tokens) {
+            Ok(_) => Ok(tokens),
+            Err(diagnostics) => Err(diagnostics),
+        }
+    }
+}
+
+impl<T: ToTokensDiagnostics> ToTokensDiagnostics for &'_ T {
+    fn to_tokens(&self, tokens: &mut TokenStream) -> Result<(), Diagnostics> {
+        T::to_tokens(self, tokens)
+    }
+}
+
+macro_rules! as_tokens_or_diagnostics {
+    ( $type:expr ) => {{
+        let mut _tokens = proc_macro2::TokenStream::new();
+        match crate::token_stream::ToTokensDiagnostics::to_tokens($type, &mut _tokens) {
+            Ok(_) => _tokens,
+            Err(diagnostics) => return Err(diagnostics),
+        }
+    }};
+}
+
+pub(crate) use as_tokens_or_diagnostics;
+
+/// A [`quote::quote!`] style macro that additionally supports interpolating types that
+/// implement [`ToTokensDiagnostics`].
+///
+/// Works identically to [`quote!`][quote]` **except**:
+/// - Returns [`Result<proc_macro2::TokenStream, Diagnostics>`] instead of[`proc_macro2::TokenStream`].
+/// - Supports a `@ident` sigil for values whose type implements [`ToTokensDiagnostics`]. The  macro
+///   calls [`ToTokensDiagnostics::to_tokens`] internally and propagates any [`Diagnostics`]  error
+///   via early return.
+/// - Regular `#ident` interpolation continues to work as in `quote!` for types that implement
+///   [`quote::ToTokens`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// # use quote::quote;
+/// // Before — manual pre-conversion required
+/// let request_body = as_tokens_or_diagnostics!(request_body);
+/// let responses = as_tokens_or_diagnostics!(&responses);
+/// tokens.extend(quote! {
+///     .request_body(Some(#request_body))
+///     .responses(#responses)
+/// });
+///
+/// // After — inline via @sigil, ? propagates Diagnostics
+/// tokens.extend(quote_diagnostics! {
+///     .request_body(Some(@request_body))
+///     .responses(@responses)
+/// }?);
+/// ```
+/// [quote](https://docs.rs/quote/latest/quote/macro.quote.html).
+macro_rules! quote_diagnostics {
+    // flush
+    (%qd $out:ident [$($prev:tt)*] []) => {
+        $out.extend(quote::quote!($($prev)*));
+    };
+    // match @diagnostics
+    (%qd $out:ident [$($prev:tt)*] [ @ $var:ident $($rest:tt)*] ) => {
+        $out.extend(quote::quote!($($prev)*));
+        let tokens = $crate::token_stream::as_tokens_or_diagnostics!(&$var);
+        $out.extend(tokens);
+        $crate::token_stream::quote_diagnostics!( %qd $out [ ] [ $($rest)* ]);
+    };
+    // inner ()
+    (%qd $out:ident [$($prev:tt)*] [($($inner:tt)*) $($rest:tt)*]) => {
+        $out.extend(quote::quote!($($prev)*));
+
+        let mut group = proc_macro2::TokenStream::new();
+        $crate::token_stream::quote_diagnostics!( %qd group [ ] [ $($inner)* ]);
+        $out.extend(quote::quote!{ ( #group ) });
+
+        $crate::token_stream::quote_diagnostics!( %qd $out [ ] [ $($rest)* ]);
+    };
+    // inner []
+    (%qd $out:ident [$($prev:tt)*] [[ $($inner:tt)* ] $($rest:tt)*]) => {
+        $out.extend(quote::quote!($($prev)*));
+
+        let mut group = proc_macro2::TokenStream::new();
+        $crate::token_stream::quote_diagnostics!( %qd group [ ] [ $($inner)* ]);
+        $out.extend(quote::quote!{ [ #group ] });
+
+        $crate::token_stream::quote_diagnostics!( %qd $out [ ] [ $($rest)* ]);
+    };
+    // inner {}
+    (%qd $out:ident [$($prev:tt)*] [{ $($inner:tt)* } $($rest:tt)*]) => {
+        $out.extend(quote::quote!($($prev)*));
+
+        let mut group = proc_macro2::TokenStream::new();
+        $crate::token_stream::quote_diagnostics!( %qd group [ ] [ $($inner)* ]);
+        $out.extend(quote::quote!{ { #group } });
+
+        $crate::token_stream::quote_diagnostics!( %qd $out [ ] [ $($rest)* ]);
+    };
+    (%qd $out:ident [$($prev:tt)*] [$first:tt $($rest:tt)*]) => {
+        $crate::token_stream::quote_diagnostics!( %qd $out [ $($prev)* $first ] [ $($rest)* ]);
+    };
+    // begin
+    ( $($tt:tt)* ) => {
+        (|| -> Result<proc_macro2::TokenStream, crate::Diagnostics> {
+            let mut tokens = proc_macro2::TokenStream::new();
+            $crate::token_stream::quote_diagnostics!( %qd tokens [ ] [ $($tt)* ]);
+
+            Ok(tokens)
+        })()
+    };
+}
+
+pub(crate) use quote_diagnostics;
+
+/// A [`quote::quote_spanned!`] style macro that additionally supports interpolating types that
+/// implement [`ToTokensDiagnostics`].
+///
+/// Behaves identically to [`quote_diagnostics`] but accepts a [`Span`] as the first argument
+/// followed by `=>`, applying the span to the all emitted tokens. Returns
+/// [`Result<proc_macro2::TokenStream, Diagnostics>`].
+///
+/// Use the `@ident` sigil to interpolate values whose type implements [`ToTokensDiagnostics`].
+/// Regular `#ident` interpolation works as in [`quote::quote_spanned!`].
+macro_rules! quote_diagnostics_spanned {
+    // flush
+    (%qd $out:ident $span:expr; [$($prev:tt)*] []) => {
+        $out.extend(quote::quote_spanned!($span => $($prev)*));
+    };
+    // match @diagnostics
+    (%qd $out:ident $span:expr; [$($prev:tt)*] [ @ $var:ident $($rest:tt)*] ) => {
+        $out.extend(quote::quote_spanned!($span => $($prev)*));
+        let tokens = $crate::token_stream::as_tokens_or_diagnostics!(&$var);
+        $out.extend(tokens);
+        $crate::token_stream::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);
+    };
+    // inner ()
+    (%qd $out:ident $span:expr; [$($prev:tt)*] [($($inner:tt)*) $($rest:tt)*]) => {
+        $out.extend(quote::quote_spanned!($span => $($prev)*));
+
+        let mut group = proc_macro2::TokenStream::new();
+        $crate::token_stream::quote_diagnostics_spanned!( %qd group $span; [ ] [ $($inner)* ]);
+        $out.extend(quote::quote_spanned!{ $span => ( #group ) });
+
+        $crate::token_stream::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);
+    };
+    // inner []
+    (%qd $out:ident $span:expr; [$($prev:tt)*] [[ $($inner:tt)* ] $($rest:tt)*]) => {
+        $out.extend(quote::quote_spanned!($span => $($prev)*));
+
+        let mut group = proc_macro2::TokenStream::new();
+        $crate::quote_diagnostics_spanned!( %qd group $span; [ ] [ $($inner)* ]);
+        $out.extend(quote::quote_spanned!{$span =>  [ #group ] });
+
+        $crate::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);
+    };
+    // inner {}
+    (%qd $out:ident $span:expr; [$($prev:tt)*] [{ $($inner:tt)* } $($rest:tt)*]) => {
+        $out.extend(quote::quote_spanned!($span => $($prev)*));
+
+        let mut group = proc_macro2::TokenStream::new();
+        $crate::quote_diagnostics_spanned!( %qd group $span; [ ] [ $($inner)* ]);
+        $out.extend(quote::quote_spanned!{$span =>  { #group } });
+
+        $crate::quote_diagnostics_spanned!( %qd $out $span; [ ] [ $($rest)* ]);
+    };
+    (%qd $out:ident $span:expr; [$($prev:tt)*] [$first:tt $($rest:tt)*]) => {
+        $crate::token_stream::quote_diagnostics_spanned!( %qd $out $span; [ $($prev)* $first ] [ $($rest)* ]);
+    };
+    // begin
+    ( $span:expr => $($tt:tt)* ) => {
+        (|| -> Result<proc_macro2::TokenStream, crate::Diagnostics> {
+            let mut tokens = proc_macro2::TokenStream::new();
+            $crate::token_stream::quote_diagnostics_spanned!( %qd tokens $span; [ ] [ $($tt)* ]);
+
+            Ok(tokens)
+        })()
+    };
+}
+
+pub(crate) use quote_diagnostics_spanned;
+
+#[derive(Debug)]
+pub struct Diagnostics {
+    diagnostics: Vec<DiangosticsInner>,
+}
+
+#[derive(Debug)]
+pub struct DiangosticsInner {
+    span: Span,
+    message: Cow<'static, str>,
+    suggestions: Vec<Suggestion>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Suggestion {
+    Help(Cow<'static, str>),
+    Note(Cow<'static, str>),
+}
+
+impl Display for Diagnostics {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message())
+    }
+}
+
+impl Display for Suggestion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Help(help) => {
+                let s: &str = help.borrow();
+                write!(f, "help = {}", s)
+            }
+            Self::Note(note) => {
+                let s: &str = note.borrow();
+                write!(f, "note = {}", s)
+            }
+        }
+    }
+}
+
+impl Diagnostics {
+    fn message(&self) -> Cow<'static, str> {
+        self.diagnostics
+            .first()
+            .as_ref()
+            .map(|diagnostics| diagnostics.message.clone())
+            .unwrap_or_else(|| Cow::Borrowed(""))
+    }
+
+    pub fn new<S: Into<Cow<'static, str>>>(message: S) -> Self {
+        Self::with_span(Span::call_site(), message)
+    }
+
+    pub fn with_span<S: Into<Cow<'static, str>>>(span: Span, message: S) -> Self {
+        Self {
+            diagnostics: vec![DiangosticsInner {
+                span,
+                message: message.into(),
+                suggestions: Vec::new(),
+            }],
+        }
+    }
+
+    pub fn help<S: Into<Cow<'static, str>>>(mut self, help: S) -> Self {
+        if let Some(diagnostics) = self.diagnostics.first_mut() {
+            diagnostics.suggestions.push(Suggestion::Help(help.into()));
+            diagnostics.suggestions.sort();
+        }
+
+        self
+    }
+
+    pub fn note<S: Into<Cow<'static, str>>>(mut self, note: S) -> Self {
+        if let Some(diagnostics) = self.diagnostics.first_mut() {
+            diagnostics.suggestions.push(Suggestion::Note(note.into()));
+            diagnostics.suggestions.sort();
+        }
+
+        self
+    }
+}
+
+impl From<syn::Error> for Diagnostics {
+    fn from(value: syn::Error) -> Self {
+        Self::with_span(value.span(), value.to_string())
+    }
+}
+
+impl ToTokens for Diagnostics {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        for diagnostics in &self.diagnostics {
+            let span = diagnostics.span;
+            let message: &str = diagnostics.message.borrow();
+
+            let suggestions = diagnostics
+                .suggestions
+                .iter()
+                .map(Suggestion::to_string)
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let diagnostics = if !suggestions.is_empty() {
+                Cow::Owned(format!("{message}\n\n{suggestions}"))
+            } else {
+                Cow::Borrowed(message)
+            };
+
+            tokens.extend(quote_spanned! {span=>
+                ::core::compile_error!(#diagnostics);
+            })
+        }
+    }
+}
+
+impl Error for Diagnostics {}
+
+impl FromIterator<Diagnostics> for Option<Diagnostics> {
+    fn from_iter<T: IntoIterator<Item = Diagnostics>>(iter: T) -> Self {
+        iter.into_iter().reduce(|mut acc, diagnostics| {
+            acc.diagnostics.extend(diagnostics.diagnostics);
+            acc
+        })
+    }
+}


### PR DESCRIPTION
Working with types that implement `ToTokensDiagnostics` inside `quote!` required an awkward two-step: first convert to tokens with `as_tokens_or_diagnostics!` to get a plain `TokenStream`, then interpolate that temporary variable into `quote!`. Every `ToTokensDiagnostics` value needed its own let binding purely to satisfy `quote!`'s requirement that interpolated values implement `ToTokens`. This scattered the actual intent across multiple lines and was unnecessary boilerplate.

The new `quote_diagnostics!` macro accepts the same syntax as `quote`! but introduces the `@` sigil for inline interpolation of `ToTokensDiagnostics` values. The macro handles the `to_tokens_diagnostics` call internally and propagates any `Diagnostics` error via early return. The result is a `Result<TokenStream, Diagnostics>` which composes naturally with `?` at the call site.

### Before:
```rust
let request_body = as_tokens_or_diagnostics!(request_body);
let responses = as_tokens_or_diagnostics!(&responses);
tokens.extend(quote! {
    .request_body(Some(#request_body))
    .responses(#responses)
});
```

### After:
```rust
tokens.extend(quote_diagnostics! {
    .request_body(Some(@request_body))
    .responses(@responses)
}?);
```

`quote_diagnostics_spanned!` mirrors the same improvement for span-aware emission, accepting the same span => ... prefix as `quote_spanned!`.

Regular `#ident` interpolation for `ToTokens` types continues to work unchanged in both macros.