### PR TITLE
Fix unsigned integer known format serialization

### DIFF
--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1634,8 +1634,8 @@ mod tests {
         assert_compact_json_snapshot!(isize::schema(), @r#"{"type": "integer"}"#);
         assert_compact_json_snapshot!(u8::schema(), @r#"{"type": "integer", "format": "uint8", "minimum": 0}"#);
         assert_compact_json_snapshot!(u16::schema(), @r#"{"type": "integer", "format": "uint16", "minimum": 0}"#);
-        assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "int32", "minimum": 0}"#);
-        assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "int64", "minimum": 0}"#);
+        assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "uint32", "minimum": 0}"#);
+        assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "uint64", "minimum": 0}"#);
     }
 
     #[test]

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -2031,18 +2031,22 @@ pub enum KnownFormat {
     /// 8 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[serde(rename = "uint8")]
     UInt8,
     /// 16 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[serde(rename = "uint16")]
     UInt16,
     /// 32 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[serde(rename = "uint32")]
     UInt32,
     /// 64 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[serde(rename = "uint64")]
     UInt64,
     /// floating point number.
     Float,
@@ -2130,6 +2134,27 @@ mod tests {
 
     use super::*;
     use crate::openapi::*;
+
+    #[cfg(feature = "non_strict_integers")]
+    #[test]
+    fn serialize_unsigned_integer_known_formats() {
+        assert_eq!(
+            serde_json::to_value(KnownFormat::UInt8).unwrap(),
+            json!("uint8")
+        );
+        assert_eq!(
+            serde_json::to_value(KnownFormat::UInt16).unwrap(),
+            json!("uint16")
+        );
+        assert_eq!(
+            serde_json::to_value(KnownFormat::UInt32).unwrap(),
+            json!("uint32")
+        );
+        assert_eq!(
+            serde_json::to_value(KnownFormat::UInt64).unwrap(),
+            json!("uint64")
+        );
+    }
 
     #[test]
     fn create_schema_serializes_json() -> Result<(), serde_json::Error> {


### PR DESCRIPTION
## Summary
- serialize unsigned integer known formats as `uint8`, `uint16`, `uint32`, and `uint64`
- update non-strict integer schema snapshots for `u32` and `u64`
- add regression coverage for unsigned known format serialization

Closes #1527

## Verification
- `cargo test -p utoipa test_partial_schema_strict_integers`
- `cargo test -p utoipa test_partial_schema_non_strict_integers --features non_strict_integers`
- `cargo test -p utoipa serialize_unsigned_integer_known_formats --features non_strict_integers`
- `cargo fmt --all --check`
- `git diff --check`