### PR TITLE
Add yaml_serde feature for yaml deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also an awesome type of beer 
 
 - **`macros`** Enable `utoipa-gen` macros. **This is enabled by default.**
 - **`yaml`**: Enables **serde_norway** serialization of OpenAPI objects.
+- **`yaml_serde`**: Enables **serde_yaml** serialization of OpenAPI objects.
 - **`actix_extras`**: Enhances [actix-web](https://github.com/actix/actix-web/) integration with being able to
   parse `path`, `path` and `query` parameters from actix web path attribute macros. See
   [docs](https://docs.rs/utoipa/latest/utoipa/attr.path.html#actix_extras-feature-support-for-actix-web) or [examples](./examples) for more details.

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -7,7 +7,7 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Added
 
-* Added feature `yaml_serde` for deserializing using the official yaml_serde crate
+* Added feature `yaml_serde` for deserializing using the official yaml_serde crate (https://github.com/juhaku/utoipa/pull/1559)
 * Add support for `title` on `RefBuilder` (https://github.com/juhaku/utoipa/pull/1380)
 * Add support for `default` on `RefBuilder` (https://github.com/juhaku/utoipa/pull/1380)
 

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -7,6 +7,7 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Added
 
+* Added feature `yaml_serde` for deserializing using the official yaml_serde crate
 * Add support for `title` on `RefBuilder` (https://github.com/juhaku/utoipa/pull/1380)
 * Add support for `default` on `RefBuilder` (https://github.com/juhaku/utoipa/pull/1380)
 

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -39,6 +39,7 @@ decimal = ["utoipa-gen?/decimal"]
 decimal_float = ["utoipa-gen?/decimal_float"]
 non_strict_integers = ["utoipa-gen?/non_strict_integers"]
 yaml = ["serde_norway", "utoipa-gen?/yaml"]
+yaml_serde = ["dep:yaml_serde", "utoipa-gen?/yaml"]
 uuid = ["utoipa-gen?/uuid"]
 ulid = ["utoipa-gen?/ulid"]
 url = ["utoipa-gen?/url"]
@@ -61,6 +62,7 @@ auto_into_responses = ["utoipa-gen?/auto_into_responses"]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 serde_norway = {version = "0.9.42", optional = true}
+yaml_serde = { version = "0.10.4", optional = true }
 utoipa-gen = { version = "5.5.0", path = "../utoipa-gen", optional = true }
 indexmap = { version = "2", features = ["serde"] }
 

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -61,6 +61,7 @@
 //!
 //! * **`macros`** Enable `utoipa-gen` macros. **This is enabled by default.**
 //! * **`yaml`** Enables **serde_norway** serialization of OpenAPI objects.
+//! * **`yaml_serde`**: Enables **serde_yaml** serialization of OpenAPI objects.
 //! * **`actix_extras`** Enhances [actix-web](https://github.com/actix/actix-web/) integration with being able to
 //!   parse `path`, `path` and `query` parameters from actix web path attribute macros. See [actix extras support][actix_path] or
 //!   [examples](https://github.com/juhaku/utoipa/tree/master/examples) for more details.

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -173,7 +173,7 @@ impl OpenApi {
     /// Converts this [`OpenApi`] to YAML String. This method essentially calls [`yaml_serde::to_string`].
     #[cfg(feature = "yaml_serde")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "yaml")))]
-    pub fn to_yaml(&self) -> Result<String, yaml_serde::Error> {
+    pub fn to_yaml_serde(&self) -> Result<String, yaml_serde::Error> {
         yaml_serde::to_string(self)
     }
 

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -170,6 +170,13 @@ impl OpenApi {
         serde_norway::to_string(self)
     }
 
+    /// Converts this [`OpenApi`] to YAML String. This method essentially calls [`yaml_serde::to_string`].
+    #[cfg(feature = "yaml_serde")]
+    #[cfg_attr(doc_cfg, doc(cfg(feature = "yaml")))]
+    pub fn to_yaml(&self) -> Result<String, yaml_serde::Error> {
+        yaml_serde::to_string(self)
+    }
+
     /// Merge `other` [`OpenApi`] moving `self` and returning combined [`OpenApi`].
     ///
     /// In functionality wise this is exactly same as calling [`OpenApi::merge`] but but provides


### PR DESCRIPTION
The current `yaml` feature uses the `serde_norway`-crate, which was not updated since nearly 1.5 years. This commit introduces the new `yaml_serde`-feature, which provides nearly the same interface as serde_norway does, but with a crate that is more actively maintained and owned by the official yaml github organization.

The current implementation is about 90% done, but it does not (really) cover what happens if both yaml features are enabled since they both provide the same function but with a different signature. Depending on your preference, I can just make a cfg block that checks if both are enabled and emits a more helpful message or rename the function, depending on preference.