### PR TITLE
feat!: remove serde_norway, make yaml feature use yaml_serde

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,7 @@ and the `ipa` is _api_ reversed. Aaand... `ipa` is also an awesome type of beer 
 ## Crate Features
 
 - **`macros`** Enable `utoipa-gen` macros. **This is enabled by default.**
-- **`yaml`**: Enables **serde_norway** serialization of OpenAPI objects.
-- **`yaml_serde`**: Enables **serde_yaml** serialization of OpenAPI objects.
+- **`yaml`**: Enables **yaml_serde** serialization of OpenAPI objects.
 - **`actix_extras`**: Enhances [actix-web](https://github.com/actix/actix-web/) integration with being able to
   parse `path`, `path` and `query` parameters from actix web path attribute macros. See
   [docs](https://docs.rs/utoipa/latest/utoipa/attr.path.html#actix_extras-feature-support-for-actix-web) or [examples](./examples) for more details.

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -61,7 +61,7 @@ insta = { version = "1.47", features = ["json"] }
 debug = ["syn/extra-traits"]
 actix_extras = ["regex", "syn/extra-traits"]
 chrono = []
-yaml = []
+yaml = ["utoipa/yaml"]
 decimal = []
 decimal_float = []
 bigdecimal = []

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -8,9 +8,12 @@ to look into changes introduced to **`utoipa-gen`**.
 ### Added
 
 * Add `bigdecimal` and `bigdecimal_float` feature support for `BigDecimal` type (https://github.com/juhaku/utoipa/pull/1487)
-* Added feature `yaml_serde` for deserializing using the official yaml_serde crate (https://github.com/juhaku/utoipa/pull/1559)
 * Add support for `title` on `RefBuilder` (https://github.com/juhaku/utoipa/pull/1380)
 * Add support for `default` on `RefBuilder` (https://github.com/juhaku/utoipa/pull/1380)
+
+### Changed
+
+* **Breaking**: Removed `serde_norway` dependency. The `yaml` feature now uses `yaml_serde` and `OpenApi::to_yaml` returns `yaml_serde::Error` (https://github.com/juhaku/utoipa/issues/1565)
 
 ## 5.5.0 - May 5 2026
 

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -40,8 +40,7 @@ decimal_float = ["utoipa-gen?/decimal_float"]
 bigdecimal = ["utoipa-gen?/bigdecimal"]
 bigdecimal_float = ["utoipa-gen?/bigdecimal_float"]
 non_strict_integers = ["utoipa-gen?/non_strict_integers"]
-yaml = ["serde_norway", "utoipa-gen?/yaml"]
-yaml_serde = ["dep:yaml_serde", "utoipa-gen?/yaml"]
+yaml = ["dep:yaml_serde", "utoipa-gen?/yaml"]
 uuid = ["utoipa-gen?/uuid"]
 ulid = ["utoipa-gen?/ulid"]
 url = ["utoipa-gen?/url"]
@@ -63,7 +62,6 @@ auto_into_responses = ["utoipa-gen?/auto_into_responses"]
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
-serde_norway = {version = "0.9.42", optional = true}
 yaml_serde = { version = "0.10.4", optional = true }
 utoipa-gen = { version = "5.5.0", path = "../utoipa-gen", optional = true }
 indexmap = { version = "2", features = ["serde"] }

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -60,8 +60,7 @@
 //! # Crate Features
 //!
 //! * **`macros`** Enable `utoipa-gen` macros. **This is enabled by default.**
-//! * **`yaml`** Enables **serde_norway** serialization of OpenAPI objects.
-//! * **`yaml_serde`**: Enables **serde_yaml** serialization of OpenAPI objects.
+//! * **`yaml`** Enables **yaml_serde** serialization of OpenAPI objects.
 //! * **`actix_extras`** Enhances [actix-web](https://github.com/actix/actix-web/) integration with being able to
 //!   parse `path`, `path` and `query` parameters from actix web path attribute macros. See [actix extras support][actix_path] or
 //!   [examples](https://github.com/juhaku/utoipa/tree/master/examples) for more details.

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -163,17 +163,10 @@ impl OpenApi {
         serde_json::to_string_pretty(self)
     }
 
-    /// Converts this [`OpenApi`] to YAML String. This method essentially calls [`serde_norway::to_string`] method.
+    /// Converts this [`OpenApi`] to YAML String. This method essentially calls [`yaml_serde::to_string`].
     #[cfg(feature = "yaml")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "yaml")))]
-    pub fn to_yaml(&self) -> Result<String, serde_norway::Error> {
-        serde_norway::to_string(self)
-    }
-
-    /// Converts this [`OpenApi`] to YAML String. This method essentially calls [`yaml_serde::to_string`].
-    #[cfg(feature = "yaml_serde")]
-    #[cfg_attr(doc_cfg, doc(cfg(feature = "yaml")))]
-    pub fn to_yaml_serde(&self) -> Result<String, yaml_serde::Error> {
+    pub fn to_yaml(&self) -> Result<String, yaml_serde::Error> {
         yaml_serde::to_string(self)
     }
 


### PR DESCRIPTION
BREAKING CHANGE: `yaml` feature now uses `yaml_serde` instead of `serde_norway`.

`OpenApi::to_yaml` returns `yaml_serde::Error`.

Removes the temporary `yaml_serde` feature and `to_yaml_serde`.

fixes #1565

Note: also changes `yaml = ["utoipa/yaml"]` as a small fix that makes the existing `stable_yaml` test actually runnable; it was previously broken when invoked with `--features yaml`.