### PR TITLE
Revert "ci: constrain brotli-decompressor to fix actix-web build"

### DIFF
--- a/examples/actix-web-multipart/Cargo.toml
+++ b/examples/actix-web-multipart/Cargo.toml
@@ -9,6 +9,5 @@ actix-multipart = "0.7"
 utoipa = { path = "../../utoipa", features = ["actix_extras"] }
 utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["actix-web"] }
 utoipa-actix-web = { path = "../../utoipa-actix-web" }
-brotli-decompressor = "5.0.3"
 
 [workspace]

--- a/examples/actix-web-multiple-api-docs-with-scopes/Cargo.toml
+++ b/examples/actix-web-multiple-api-docs-with-scopes/Cargo.toml
@@ -18,6 +18,5 @@ log = "0.4"
 futures = "0.3"
 utoipa = { path = "../../utoipa", features = ["actix_extras"] }
 utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["actix-web"] }
-brotli-decompressor = "5.0.3"
 
 [workspace]

--- a/examples/actix-web-scopes-binding/Cargo.toml
+++ b/examples/actix-web-scopes-binding/Cargo.toml
@@ -15,6 +15,5 @@ utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = [
     "actix-web",
 ] }
 utoipa-actix-web = { path = "../../utoipa-actix-web" }
-brotli-decompressor = "5.0.3"
 
 [workspace]

--- a/examples/generics-actix/Cargo.toml
+++ b/examples/generics-actix/Cargo.toml
@@ -17,6 +17,5 @@ geo-types = { version = "0.7", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 utoipa = { path = "../../utoipa", features = ["actix_extras", "non_strict_integers"] }
 utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["actix-web"] }
-brotli-decompressor = "5.0.3"
 
 [workspace]

--- a/examples/raw-json-actix/Cargo.toml
+++ b/examples/raw-json-actix/Cargo.toml
@@ -16,6 +16,5 @@ env_logger = "0.10.0"
 serde_json = "1.0"
 utoipa = { path = "../../utoipa", features = ["actix_extras"] }
 utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["actix-web"] }
-brotli-decompressor = "5.0.3"
 
 [workspace]

--- a/examples/simple-x-extensions/Cargo.toml
+++ b/examples/simple-x-extensions/Cargo.toml
@@ -8,6 +8,5 @@ edition = "2021"
 actix-web = "4"
 env_logger = "0"
 utoipa = { path = "../../utoipa", features = [ "yaml" ] }
-brotli-decompressor = "5.0.3"
 
 [workspace]

--- a/examples/todo-actix/Cargo.toml
+++ b/examples/todo-actix/Cargo.toml
@@ -22,6 +22,5 @@ utoipa-redoc = { path = "../../utoipa-redoc", features = ["actix-web"] }
 utoipa-rapidoc = { path = "../../utoipa-rapidoc", features = ["actix-web"] }
 utoipa-scalar = { path = "../../utoipa-scalar", features = ["actix-web"] }
 utoipa-actix-web = { path = "../../utoipa-actix-web" }
-brotli-decompressor = "5.0.3"
 
 [workspace]

--- a/utoipa-actix-web/Cargo.toml
+++ b/utoipa-actix-web/Cargo.toml
@@ -24,7 +24,6 @@ utoipa = { path = "../utoipa", version = "5", features = [
 ] }
 actix-web = { version = "4", default-features = false, features = ["macros"] }
 serde = "1"
-brotli-decompressor = "5.0.3"
 
 [package.metadata.docs.rs]
 features = []

--- a/utoipa-rapidoc/Cargo.toml
+++ b/utoipa-rapidoc/Cargo.toml
@@ -29,7 +29,6 @@ axum = { version = "0.8.4", default-features = false, features = [
 
 [dev-dependencies]
 utoipa-rapidoc = { path = ".", features = ["actix-web", "axum", "rocket"] }
-brotli-decompressor = "5.0.3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/utoipa-redoc/Cargo.toml
+++ b/utoipa-redoc/Cargo.toml
@@ -27,7 +27,6 @@ axum = { version = "0.8.4", default-features = false, optional = true }
 
 [dev-dependencies]
 utoipa-redoc = { path = ".", features = ["actix-web", "axum", "rocket"] }
-brotli-decompressor = "5.0.3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/utoipa-scalar/Cargo.toml
+++ b/utoipa-scalar/Cargo.toml
@@ -27,7 +27,6 @@ axum = { version = "0.8.4", default-features = false, optional = true }
 
 [dev-dependencies]
 utoipa-scalar = { path = ".", features = ["actix-web", "axum", "rocket"] }
-brotli-decompressor = "5.0.3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }

--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -42,7 +42,6 @@ similar = "2.7"
 tokio = { version = "1", features = ["macros"] }
 tower = "0.5"
 utoipa-swagger-ui = { path = ".", features = ["actix-web", "axum", "rocket"] }
-brotli-decompressor = "5.0.3"
 
 [package.metadata.docs.rs]
 features = ["actix-web", "axum", "rocket", "vendored", "cache"]


### PR DESCRIPTION
brotli 8.0.4 resolves the alloc-no-stdlib version conflict that broke actix-web builds, so the brotli-decompressor 5.0.3 workaround is no longer needed.