### PR TITLE
fix: simplify utoipa-gen feature gates to fix jiff_0_2

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 * Avoid degenerate `oneOf` for `Option<_>` with `nullable = false` and `default`/`title`/`description` (https://github.com/juhaku/utoipa/pull/1380)
+* Fix `jiff` type detection when only the `jiff_0_2` feature is enabled (https://github.com/juhaku/utoipa/pull/1575)
 
 ## 5.5.0 - May 5 2026
 

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -13,7 +13,7 @@ pub enum SchemaTypeInner {
     Object,
     /// Indicates string type of content.
     String,
-    /// Indicates integer type of content.    
+    /// Indicates integer type of content.
     Integer,
     /// Indicates floating point number type of content.
     Number,
@@ -70,34 +70,7 @@ impl SchemaType<'_> {
         };
         let name = &*last_segment.ident.to_string();
 
-        #[cfg(not(any(
-            feature = "chrono",
-            feature = "decimal",
-            feature = "decimal_float",
-            feature = "bigdecimal",
-            feature = "bigdecimal_float",
-            feature = "rocket_extras",
-            feature = "uuid",
-            feature = "ulid",
-            feature = "url",
-            feature = "time",
-        )))]
-        {
-            is_primitive(name)
-        }
-
-        #[cfg(any(
-            feature = "chrono",
-            feature = "decimal",
-            feature = "decimal_float",
-            feature = "bigdecimal",
-            feature = "bigdecimal_float",
-            feature = "rocket_extras",
-            feature = "uuid",
-            feature = "ulid",
-            feature = "url",
-            feature = "time",
-        ))]
+        #[allow(unused_mut, reason = "mut is used in conditional compilation")]
         {
             let mut primitive = is_primitive(name);
 


### PR DESCRIPTION
Enabling the "jiff_0_2" feature on its own would not correctly enable the more
elaborate is_primitive branch because it was mistakenly omitted from the feature gate list.
Rather than merely fixing the feature gate list, this commit simplifies the
logic to make such a mistake impossible in the future.
