### PR TITLE
feat: added support for num types + dev tools fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ Cargo.lock
 .vscode
 target
 .nvim
-
+# bacon + nextest
+.pending-snap
+.*.pending-snap
+**/.*.pending-snap

--- a/bacon.toml
+++ b/bacon.toml
@@ -5,4 +5,5 @@ command = ["just", "test"]
 env.CARGO_COMMAND = "nextest run --hide-progress-bar --failure-output final"
 need_stdout = true
 allow_warnings = true
+on_change_strategy = "kill_then_restart"
 analyzer = "nextest"

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,8 @@
+ignore = ["**/*.pending-snap"]
+
+[jobs.nextest-just]
+command = ["just", "test"]
+env.CARGO_COMMAND = "nextest run --hide-progress-bar --failure-output final"
+need_stdout = true
+allow_warnings = true
+analyzer = "nextest"

--- a/justfile
+++ b/justfile
@@ -21,6 +21,7 @@ test *crates='utoipa utoipa-gen utoipa-swagger-ui utoipa-redoc utoipa-rapidoc ut
 
         if [[ "$crate" == "utoipa" ]]; then
             $cargo $cargo_command -p utoipa --features openapi_extensions,preserve_order,preserve_path_order,debug,macros
+            $cargo $cargo_command -p utoipa --features openapi_extensions,preserve_order,preserve_path_order,debug,macros,non_strict_integers
         elif [[ "$crate" == "utoipa-gen" ]]; then
             $cargo $cargo_command -p utoipa-gen --features utoipa/actix_extras,chrono,decimal,utoipa/uuid,uuid,utoipa/ulid,ulid,utoipa/url,url,utoipa/time,time,jiff_0_2,utoipa/repr,utoipa/smallvec,smallvec,rc_schema,utoipa/rc_schema,utoipa/macros
             $cargo $cargo_command -p utoipa-gen --test schema_derive_test --features decimal_float,utoipa/macros
@@ -126,3 +127,6 @@ validate-examples:
     done
 
     echo "All examples are valid!"
+
+watch-test *crates='utoipa utoipa-gen utoipa-swagger-ui utoipa-axum utoipa-actix-web utoipa-rapidoc':
+    bacon nextest-just -- {{ crates }}

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use features::validation::ExclusiveMinimum;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::punctuated::Punctuated;
@@ -1120,14 +1121,21 @@ impl ComponentSchema {
                     path: Cow::Borrowed(type_path),
                     nullable,
                 };
+
                 if schema_type.is_unsigned_integer() {
+                    let minimum : Feature = if schema_type.is_nonzero_unsigned_integer() {
+                        ExclusiveMinimum::new(0f64, type_path.span()).into()
+                    } else {
+                        Minimum::new(0f64, type_path.span()).into()
+                    };
+
                     // add default minimum feature only when there is no explicit minimum
                     // provided
                     if !features
                         .iter()
-                        .any(|feature| matches!(&feature, Feature::Minimum(_)))
+                        .any(|feature| matches!(&feature, Feature::Minimum(_) | Feature::ExclusiveMinimum(_)))
                     {
-                        features.push(Minimum::new(0f64, type_path.span()).into());
+                        features.push(minimum);
                     }
                 }
 

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1123,7 +1123,7 @@ impl ComponentSchema {
                 };
 
                 if schema_type.is_unsigned_integer() {
-                    let minimum : Feature = if schema_type.is_nonzero_unsigned_integer() {
+                    let minimum: Feature = if schema_type.is_nonzero_unsigned_integer() {
                         ExclusiveMinimum::new(0f64, type_path.span()).into()
                     } else {
                         Minimum::new(0f64, type_path.span()).into()
@@ -1131,10 +1131,9 @@ impl ComponentSchema {
 
                     // add default minimum feature only when there is no explicit minimum
                     // provided
-                    if !features
-                        .iter()
-                        .any(|feature| matches!(&feature, Feature::Minimum(_) | Feature::ExclusiveMinimum(_)))
-                    {
+                    if !features.iter().any(|feature| {
+                        matches!(&feature, Feature::Minimum(_) | Feature::ExclusiveMinimum(_))
+                    }) {
                         features.push(minimum);
                     }
                 }

--- a/utoipa-gen/src/component/features/validation.rs
+++ b/utoipa-gen/src/component/features/validation.rs
@@ -210,6 +210,18 @@ impl_feature! {
     pub struct ExclusiveMaximum(NumberValue, Ident);
 }
 
+impl ExclusiveMinimum {
+    pub fn new(value: f64, span: Span) -> Self {
+        Self(
+            NumberValue {
+                minus: value <= 0.0,
+                lit: Literal::f64_suffixed(value),
+            },
+            Ident::new("empty", span),
+        )
+    }
+}
+
 impl Validate for ExclusiveMaximum {
     fn validate(&self, validator: impl Validator) -> Option<Diagnostics> {
         match validator.is_valid() {

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -129,17 +129,36 @@ impl SchemaType<'_> {
     pub fn is_integer(&self) -> bool {
         matches!(
             &*self.last_segment_to_string(),
-            "i8" | "i16"
-                | "i32"
-                | "i64"
-                | "i128"
-                | "isize"
-                | "u8"
-                | "u16"
-                | "u32"
-                | "u64"
-                | "u128"
-                | "usize"
+            "i8" 
+            | "i16"
+            | "i32"
+            | "i64"
+            | "i128"
+            | "isize"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "u128"
+            | "usize"
+            | "NonZeroI8"
+            | "NonZeroI16"
+            | "NonZeroI32"
+            | "NonZeroI64"
+            | "NonZeroIsize"
+            | "NonZeroU8"
+            | "NonZeroU16"
+            | "NonZeroU32"
+            | "NonZeroU64"
+            | "NonZeroUsize"
+        )
+    }
+
+    pub fn is_nonzero_unsigned_integer(&self) -> bool {
+        matches!(
+            &*self.last_segment_to_string(),
+            "NonZeroU8" | "NonZeroU16" | "NonZeroU32" |
+            "NonZeroU64" | "NonZeroUsize"
         )
     }
 
@@ -147,6 +166,8 @@ impl SchemaType<'_> {
         matches!(
             &*self.last_segment_to_string(),
             "u8" | "u16" | "u32" | "u64" | "u128" | "usize"
+            | "NonZeroU8" | "NonZeroU16" | "NonZeroU32"
+            | "NonZeroU64" | "NonZeroUsize"
         )
     }
 
@@ -189,6 +210,16 @@ fn is_primitive(name: &str) -> bool {
             | "i128"
             | "f32"
             | "f64"
+            | "NonZeroI8"
+            | "NonZeroI16"
+            | "NonZeroI32"
+            | "NonZeroI64"
+            | "NonZeroIsize"
+            | "NonZeroU8"
+            | "NonZeroU16"
+            | "NonZeroU32"
+            | "NonZeroU64"
+            | "NonZeroUsize"
     )
 }
 
@@ -245,7 +276,10 @@ impl ToTokensDiagnostics for SchemaType<'_> {
             "bool" => schema_type_tokens(tokens, SchemaTypeInner::Boolean, self.nullable),
 
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize" => {
+            | "u128" | "usize" 
+            | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64"
+            | "NonZeroU128" | "NonZeroUsize" 
+            => {
                 schema_type_tokens(tokens, SchemaTypeInner::Integer, self.nullable)
             }
             "f32" | "f64" => schema_type_tokens(tokens, SchemaTypeInner::Number, self.nullable),
@@ -367,26 +401,28 @@ impl KnownFormat {
 
         let variant = match name {
             #[cfg(feature = "non_strict_integers")]
-            "i8" => Self::Int8,
+            "i8" | "NonZeroI8" => Self::Int8,
             #[cfg(feature = "non_strict_integers")]
-            "u8" => Self::UInt8,
+            "u8" | "NonZeroU8" => Self::UInt8,
             #[cfg(feature = "non_strict_integers")]
-            "i16" => Self::Int16,
+            "i16" | "NonZeroI16" => Self::Int16,
             #[cfg(feature = "non_strict_integers")]
-            "u16" => Self::UInt16,
+            "u16" | "NonZeroU16" => Self::UInt16,
             #[cfg(feature = "non_strict_integers")]
-            "u32" => Self::UInt32,
+            "u32" | "NonZeroU32" => Self::UInt32,
             #[cfg(feature = "non_strict_integers")]
-            "u64" => Self::UInt64,
+            "u64" | "NonZeroU64" => Self::UInt64,
 
             #[cfg(not(feature = "non_strict_integers"))]
-            "i8" | "i16" | "u8" | "u16" | "u32" => Self::Int32,
+            "i8" | "i16" | "u8" | "u16" | "u32" |
+            "NonZeroI8" | "NonZeroI16" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" 
+                => Self::Int32,
 
             #[cfg(not(feature = "non_strict_integers"))]
-            "u64" => Self::Int64,
+            "u64" | "NonZeroU64" => Self::Int64,
 
-            "i32" => Self::Int32,
-            "i64" => Self::Int64,
+            "i32" | "NonZeroI32" => Self::Int32,
+            "i64" | "NonZeroI64" => Self::Int64,
             "f32" => Self::Float,
             "f64" => Self::Double,
 
@@ -689,7 +725,10 @@ impl PrimitiveType {
             "bool" => syn::parse_quote!(#path),
 
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize" => syn::parse_quote!(#path),
+            | "u128" | "usize"
+            | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64"
+            | "NonZeroU128" | "NonZeroUsize" 
+            => syn::parse_quote!(#path),
             "f32" | "f64" => syn::parse_quote!(#path),
 
             #[cfg(feature = "chrono")]

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -129,45 +129,58 @@ impl SchemaType<'_> {
     pub fn is_integer(&self) -> bool {
         matches!(
             &*self.last_segment_to_string(),
-            "i8" 
-            | "i16"
-            | "i32"
-            | "i64"
-            | "i128"
-            | "isize"
-            | "u8"
-            | "u16"
-            | "u32"
-            | "u64"
-            | "u128"
-            | "usize"
-            | "NonZeroI8"
-            | "NonZeroI16"
-            | "NonZeroI32"
-            | "NonZeroI64"
-            | "NonZeroIsize"
-            | "NonZeroU8"
-            | "NonZeroU16"
-            | "NonZeroU32"
-            | "NonZeroU64"
-            | "NonZeroUsize"
+            "i8" | "i16"
+                | "i32"
+                | "i64"
+                | "i128"
+                | "isize"
+                | "u8"
+                | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "usize"
+                | "NonZeroI8"
+                | "NonZeroI16"
+                | "NonZeroI32"
+                | "NonZeroI64"
+                | "NonZeroI128"
+                | "NonZeroIsize"
+                | "NonZeroU8"
+                | "NonZeroU16"
+                | "NonZeroU32"
+                | "NonZeroU64"
+                | "NonZeroU128"
+                | "NonZeroUsize"
         )
     }
 
     pub fn is_nonzero_unsigned_integer(&self) -> bool {
         matches!(
             &*self.last_segment_to_string(),
-            "NonZeroU8" | "NonZeroU16" | "NonZeroU32" |
-            "NonZeroU64" | "NonZeroUsize"
+            "NonZeroU8"
+                | "NonZeroU16"
+                | "NonZeroU32"
+                | "NonZeroU64"
+                | "NonZeroU128"
+                | "NonZeroUsize"
         )
     }
 
     pub fn is_unsigned_integer(&self) -> bool {
         matches!(
             &*self.last_segment_to_string(),
-            "u8" | "u16" | "u32" | "u64" | "u128" | "usize"
-            | "NonZeroU8" | "NonZeroU16" | "NonZeroU32"
-            | "NonZeroU64" | "NonZeroUsize"
+            "u8" | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "usize"
+                | "NonZeroU8"
+                | "NonZeroU16"
+                | "NonZeroU32"
+                | "NonZeroU64"
+                | "NonZeroU128"
+                | "NonZeroUsize"
         )
     }
 
@@ -214,11 +227,13 @@ fn is_primitive(name: &str) -> bool {
             | "NonZeroI16"
             | "NonZeroI32"
             | "NonZeroI64"
+            | "NonZeroI128"
             | "NonZeroIsize"
             | "NonZeroU8"
             | "NonZeroU16"
             | "NonZeroU32"
             | "NonZeroU64"
+            | "NonZeroU128"
             | "NonZeroUsize"
     )
 }
@@ -276,10 +291,9 @@ impl ToTokensDiagnostics for SchemaType<'_> {
             "bool" => schema_type_tokens(tokens, SchemaTypeInner::Boolean, self.nullable),
 
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize" 
-            | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64"
-            | "NonZeroU128" | "NonZeroUsize" 
-            => {
+            | "u128" | "usize" | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64"
+            | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32"
+            | "NonZeroU64" | "NonZeroU128" | "NonZeroUsize" => {
                 schema_type_tokens(tokens, SchemaTypeInner::Integer, self.nullable)
             }
             "f32" | "f64" => schema_type_tokens(tokens, SchemaTypeInner::Number, self.nullable),
@@ -414,9 +428,8 @@ impl KnownFormat {
             "u64" | "NonZeroU64" => Self::UInt64,
 
             #[cfg(not(feature = "non_strict_integers"))]
-            "i8" | "i16" | "u8" | "u16" | "u32" |
-            "NonZeroI8" | "NonZeroI16" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" 
-                => Self::Int32,
+            "i8" | "i16" | "u8" | "u16" | "u32" | "NonZeroI8" | "NonZeroI16" | "NonZeroU8"
+            | "NonZeroU16" | "NonZeroU32" => Self::Int32,
 
             #[cfg(not(feature = "non_strict_integers"))]
             "u64" | "NonZeroU64" => Self::Int64,
@@ -725,10 +738,9 @@ impl PrimitiveType {
             "bool" => syn::parse_quote!(#path),
 
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize"
-            | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64"
-            | "NonZeroU128" | "NonZeroUsize" 
-            => syn::parse_quote!(#path),
+            | "u128" | "usize" | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64"
+            | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32"
+            | "NonZeroU64" | "NonZeroU128" | "NonZeroUsize" => syn::parse_quote!(#path),
             "f32" | "f64" => syn::parse_quote!(#path),
 
             #[cfg(feature = "chrono")]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1687,6 +1687,17 @@ mod tests {
         assert_compact_json_snapshot!(u16::schema(), @r#"{"type": "integer", "format": "uint16", "minimum": 0}"#);
         assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "uint32", "minimum": 0}"#);
         assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "uint64", "minimum": 0}"#);
+
+        assert_compact_json_snapshot!(NonZeroI8::schema(), @r#"{"type": "integer", "format": "int8"}"#);
+        assert_compact_json_snapshot!(NonZeroI16::schema(), @r#"{"type": "integer", "format": "int16"}"#);
+        assert_compact_json_snapshot!(NonZeroI32::schema(), @r#"{"type": "integer", "format": "int32"}"#);
+        assert_compact_json_snapshot!(NonZeroI64::schema(), @r#"{"type": "integer", "format": "int64"}"#);
+        assert_compact_json_snapshot!(NonZeroI128::schema(), @r#"{"type": "integer"}"#);
+        assert_compact_json_snapshot!(NonZeroIsize::schema(), @r#"{"type": "integer"}"#);
+        assert_compact_json_snapshot!(NonZeroU8::schema(), @r#"{"type": "integer", "format": "uint8", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU16::schema(), @r#"{"type": "integer", "format": "uint16", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU32::schema(), @r#"{"type": "integer", "format": "uint32", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU64::schema(), @r#"{"type": "integer", "format": "uint64", "exclusiveMinimum": 0}"#);
     }
 
     #[test]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -511,27 +511,9 @@ macro_rules! impl_to_schema {
 
 #[rustfmt::skip]
 impl_to_schema!(
-    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char
-);
-
-macro_rules! impl_to_schema_num_alias {
-    ( $( $ty:ident as $as:ident),* ) => {
-        $(
-        impl ToSchema for $ty {
-            fn name() -> std::borrow::Cow<'static, str> {
-                std::borrow::Cow::Borrowed(stringify!( $ty as $as ))
-            }
-        }
-        )*
-    };
-}
-
-#[rustfmt::skip]
-impl_to_schema_num_alias!(
-    NonZeroI8 as isize, NonZeroI16 as isize, NonZeroI32 as isize,
-    NonZeroI64 as isize, NonZeroIsize as isize,
-    NonZeroU8 as usize, NonZeroU16 as usize, NonZeroU32 as usize,
-    NonZeroU64 as usize, NonZeroUsize as usize
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
+    NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroIsize,
+    NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize 
 );
 
 impl ToSchema for &str {

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1368,35 +1368,25 @@ pub mod __dev {
     }
 
     macro_rules! impl_compose_schema {
-    ( $( $ty:ident $(as $as:ident)? ),* $(,)? ) => {
-        $(
+        ( $( $ty:ident ),* ) => {
+            $(
             impl ComposeSchema for $ty {
-                fn compose(
-                    _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>
-                ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-                    impl_compose_schema!(@schema $ty $(, $as)?).into()
+                fn compose(_: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                    schema!( $ty ).into()
                 }
             }
-        )*
-    };
-
-    (@schema $ty:ident) => {
-        schema!($ty)
-    };
-
-    (@schema $ty:ident, $as:ident) => {
-        schema!($as)
-    };
-}
+            )*
+        };
+    }
 
     use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
 
     #[rustfmt::skip]
     impl_compose_schema!(
         i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
-        NonZeroI8 as i8, NonZeroI16 as i16, NonZeroI32 as i32, NonZeroI64 as i64, 
-        NonZeroU8 as u8, NonZeroU16 as u16, NonZeroU32 as u32, NonZeroU64 as u64, 
-        NonZeroIsize as isize, NonZeroUsize as usize
+        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, 
+        NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, 
+        NonZeroIsize, NonZeroUsize
     );
 
     fn schema_or_compose<T: ComposeSchema>(

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -514,11 +514,32 @@ impl_to_schema!(
     i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char
 );
 
+macro_rules! impl_to_schema_num_alias {
+    ( $( $ty:ident as $as:ident),* ) => {
+        $(
+        impl ToSchema for $ty {
+            fn name() -> std::borrow::Cow<'static, str> {
+                std::borrow::Cow::Borrowed(stringify!( $ty as $as ))
+            }
+        }
+        )*
+    };
+}
+
+#[rustfmt::skip]
+impl_to_schema_num_alias!(
+    NonZeroI8 as isize, NonZeroI16 as isize, NonZeroI32 as isize,
+    NonZeroI64 as isize, NonZeroIsize as isize,
+    NonZeroU8 as usize, NonZeroU16 as usize, NonZeroU32 as usize,
+    NonZeroU64 as usize, NonZeroUsize as usize
+);
+
 impl ToSchema for &str {
     fn name() -> Cow<'static, str> {
         str::name()
     }
 }
+
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
@@ -1376,9 +1397,13 @@ pub mod __dev {
         };
     }
 
+    use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
+
     #[rustfmt::skip]
     impl_compose_schema!(
-        i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char
+        i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
+        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, 
+        NonZeroIsize, NonZeroUsize
     );
 
     fn schema_or_compose<T: ComposeSchema>(

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1368,24 +1368,35 @@ pub mod __dev {
     }
 
     macro_rules! impl_compose_schema {
-        ( $( $ty:ident ),* ) => {
-            $(
+    ( $( $ty:ident $(as $as:ident)? ),* $(,)? ) => {
+        $(
             impl ComposeSchema for $ty {
-                fn compose(_: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-                    schema!( $ty ).into()
+                fn compose(
+                    _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>
+                ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                    impl_compose_schema!(@schema $ty $(, $as)?).into()
                 }
             }
-            )*
-        };
-    }
+        )*
+    };
+
+    (@schema $ty:ident) => {
+        schema!($ty)
+    };
+
+    (@schema $ty:ident, $as:ident) => {
+        schema!($as)
+    };
+}
 
     use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
 
     #[rustfmt::skip]
     impl_compose_schema!(
         i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
-        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, 
-        NonZeroIsize, NonZeroUsize
+        NonZeroI8 as i8, NonZeroI16 as i16, NonZeroI32 as i32, NonZeroI64 as i64, 
+        NonZeroU8 as u8, NonZeroU16 as u16, NonZeroU32 as u32, NonZeroU64 as u64, 
+        NonZeroIsize as isize, NonZeroUsize as usize
     );
 
     fn schema_or_compose<T: ComposeSchema>(

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1263,6 +1263,28 @@ impl_from_for_number!(
     isize => Int, usize => UInt
 );
 
+macro_rules! impl_from_for_num_alias {
+    ( $( $ty:ident => $pat:ident $( as $as:ident )? ),* ) => {
+        $(
+        impl From<$ty> for Number {
+            fn from(value: $ty) -> Self {
+                Self::$pat(value.get() $( as $as )?)
+            }
+        }
+        )*
+    };
+}
+
+use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
+
+#[rustfmt::skip]
+impl_from_for_num_alias!(
+    NonZeroI8 => Int as isize, NonZeroI16 => Int as isize, NonZeroI32 => Int as isize,
+    NonZeroI64 => Int as isize, NonZeroIsize => Int as isize,
+    NonZeroU8 => UInt as usize, NonZeroU16 => UInt as usize, NonZeroU32 => UInt as usize,
+    NonZeroU64 => UInt as usize, NonZeroUsize => UInt as usize
+);
+
 /// Internal dev module used internally by utoipa-gen
 #[doc(hidden)]
 #[cfg(feature = "macros")]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -522,7 +522,6 @@ impl ToSchema for &str {
     }
 }
 
-
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
 impl<T: ToSchema> ToSchema for Option<T>
@@ -1278,14 +1277,17 @@ macro_rules! impl_from_for_num_alias {
     };
 }
 
-use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
+use std::num::{
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+};
 
 #[rustfmt::skip]
 impl_from_for_num_alias!(
     NonZeroI8 => Int as isize, NonZeroI16 => Int as isize, NonZeroI32 => Int as isize,
-    NonZeroI64 => Int as isize, NonZeroIsize => Int as isize,
+    NonZeroI64 => Int as isize, NonZeroI128 => Int as isize, NonZeroIsize => Int as isize,
     NonZeroU8 => UInt as usize, NonZeroU16 => UInt as usize, NonZeroU32 => UInt as usize,
-    NonZeroU64 => UInt as usize, NonZeroUsize => UInt as usize
+    NonZeroU64 => UInt as usize, NonZeroU128 => UInt as usize, NonZeroUsize => UInt as usize
 );
 
 /// Internal dev module used internally by utoipa-gen
@@ -1296,6 +1298,10 @@ pub mod __dev {
     use utoipa_gen::schema;
 
     use crate::{utoipa, OpenApi, PartialSchema};
+    use std::num::{
+        NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+        NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    };
 
     pub trait PathConfig {
         fn path() -> String;
@@ -1379,13 +1385,11 @@ pub mod __dev {
         };
     }
 
-    use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
-
     #[rustfmt::skip]
     impl_compose_schema!(
         i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
-        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, 
-        NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, 
+        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128,
+        NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, 
         NonZeroIsize, NonZeroUsize
     );
 
@@ -1657,6 +1661,17 @@ mod tests {
         assert_compact_json_snapshot!(u16::schema(), @r#"{"type": "integer", "format": "int32", "minimum": 0}"#);
         assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "int32", "minimum": 0}"#);
         assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "int64", "minimum": 0}"#);
+
+        assert_compact_json_snapshot!(NonZeroI8::schema(), @r#"{"type": "integer", "format": "int32"}"#);
+        assert_compact_json_snapshot!(NonZeroI16::schema(), @r#"{"type": "integer", "format": "int32"}"#);
+        assert_compact_json_snapshot!(NonZeroI32::schema(), @r#"{"type": "integer", "format": "int32"}"#);
+        assert_compact_json_snapshot!(NonZeroI64::schema(), @r#"{"type": "integer", "format": "int64"}"#);
+        assert_compact_json_snapshot!(NonZeroI128::schema(), @r#"{"type": "integer"}"#);
+        assert_compact_json_snapshot!(NonZeroIsize::schema(), @r#"{"type": "integer"}"#);
+        assert_compact_json_snapshot!(NonZeroU8::schema(), @r#"{"type": "integer", "format": "int32", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU16::schema(), @r#"{"type": "integer", "format": "int32", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU32::schema(), @r#"{"type": "integer", "format": "int32", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU64::schema(), @r#"{"type": "integer", "format": "int64", "exclusiveMinimum": 0}"#);
     }
 
     #[cfg(feature = "non_strict_integers")]
@@ -1670,8 +1685,8 @@ mod tests {
         assert_compact_json_snapshot!(isize::schema(), @r#"{"type": "integer"}"#);
         assert_compact_json_snapshot!(u8::schema(), @r#"{"type": "integer", "format": "uint8", "minimum": 0}"#);
         assert_compact_json_snapshot!(u16::schema(), @r#"{"type": "integer", "format": "uint16", "minimum": 0}"#);
-        assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "int32", "minimum": 0}"#);
-        assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "int64", "minimum": 0}"#);
+        assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "uint32", "minimum": 0}"#);
+        assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "uint64", "minimum": 0}"#);
     }
 
     #[test]

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -2093,18 +2093,22 @@ pub enum KnownFormat {
     /// 8 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[cfg_attr(feature = "non_strict_integers", serde(rename = "uint8"))]
     UInt8,
     /// 16 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[cfg_attr(feature = "non_strict_integers", serde(rename = "uint16"))]
     UInt16,
     /// 32 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[cfg_attr(feature = "non_strict_integers", serde(rename = "uint32"))]
     UInt32,
     /// 64 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[cfg_attr(feature = "non_strict_integers", serde(rename = "uint64"))]
     UInt64,
     /// floating point number.
     Float,


### PR DESCRIPTION
## Changes 
### Added support for 

```rust
std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
```
### Added `non_strict_integers` to test targets
It was failing on the master. Better to have it tested.

### Added `bacon + nextest` to configs
It's a better dev experience ;) 

## Why? 
Because these types are used by `typify`. And they are in the stdlib 

## Notes
* Similar to #1334 (didn't see that tbh), but includes NonZeroI* variants and dev tools fixes
* Includes same fixes as #1554 (again, didn't see that PR)