### PR TITLE
feat(jsonschema): added support for $defs and const keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,7 @@ Cargo.lock
 .vscode
 target
 .nvim
-
+# bacon + nextest
+.pending-snap
+.*.pending-snap
+**/.*.pending-snap

--- a/bacon.toml
+++ b/bacon.toml
@@ -5,4 +5,5 @@ command = ["just", "test"]
 env.CARGO_COMMAND = "nextest run --hide-progress-bar --failure-output final"
 need_stdout = true
 allow_warnings = true
+on_change_strategy = "kill_then_restart"
 analyzer = "nextest"

--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,8 @@
+ignore = ["**/*.pending-snap"]
+
+[jobs.nextest-just]
+command = ["just", "test"]
+env.CARGO_COMMAND = "nextest run --hide-progress-bar --failure-output final"
+need_stdout = true
+allow_warnings = true
+analyzer = "nextest"

--- a/justfile
+++ b/justfile
@@ -21,6 +21,7 @@ test *crates='utoipa utoipa-gen utoipa-swagger-ui utoipa-redoc utoipa-rapidoc ut
 
         if [[ "$crate" == "utoipa" ]]; then
             $cargo $cargo_command -p utoipa --features openapi_extensions,preserve_order,preserve_path_order,debug,macros
+            $cargo $cargo_command -p utoipa --features openapi_extensions,preserve_order,preserve_path_order,debug,macros,non_strict_integers
         elif [[ "$crate" == "utoipa-gen" ]]; then
             $cargo $cargo_command -p utoipa-gen --features utoipa/actix_extras,chrono,decimal,utoipa/uuid,uuid,utoipa/ulid,ulid,utoipa/url,url,utoipa/time,time,jiff_0_2,utoipa/repr,utoipa/smallvec,smallvec,rc_schema,utoipa/rc_schema,utoipa/macros
             $cargo $cargo_command -p utoipa-gen --test schema_derive_test --features decimal_float,utoipa/macros
@@ -126,3 +127,6 @@ validate-examples:
     done
 
     echo "All examples are valid!"
+
+watch-test *crates='utoipa utoipa-gen utoipa-swagger-ui utoipa-axum utoipa-actix-web utoipa-rapidoc':
+    bacon nextest-just -- {{ crates }}

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 
+use features::validation::ExclusiveMinimum;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, quote_spanned, ToTokens};
 use syn::punctuated::Punctuated;
@@ -1120,14 +1121,21 @@ impl ComponentSchema {
                     path: Cow::Borrowed(type_path),
                     nullable,
                 };
+
                 if schema_type.is_unsigned_integer() {
+                    let minimum : Feature = if schema_type.is_nonzero_unsigned_integer() {
+                        ExclusiveMinimum::new(0f64, type_path.span()).into()
+                    } else {
+                        Minimum::new(0f64, type_path.span()).into()
+                    };
+
                     // add default minimum feature only when there is no explicit minimum
                     // provided
                     if !features
                         .iter()
-                        .any(|feature| matches!(&feature, Feature::Minimum(_)))
+                        .any(|feature| matches!(&feature, Feature::Minimum(_) | Feature::ExclusiveMinimum(_)))
                     {
-                        features.push(Minimum::new(0f64, type_path.span()).into());
+                        features.push(minimum);
                     }
                 }
 

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1123,7 +1123,7 @@ impl ComponentSchema {
                 };
 
                 if schema_type.is_unsigned_integer() {
-                    let minimum : Feature = if schema_type.is_nonzero_unsigned_integer() {
+                    let minimum: Feature = if schema_type.is_nonzero_unsigned_integer() {
                         ExclusiveMinimum::new(0f64, type_path.span()).into()
                     } else {
                         Minimum::new(0f64, type_path.span()).into()
@@ -1131,10 +1131,9 @@ impl ComponentSchema {
 
                     // add default minimum feature only when there is no explicit minimum
                     // provided
-                    if !features
-                        .iter()
-                        .any(|feature| matches!(&feature, Feature::Minimum(_) | Feature::ExclusiveMinimum(_)))
-                    {
+                    if !features.iter().any(|feature| {
+                        matches!(&feature, Feature::Minimum(_) | Feature::ExclusiveMinimum(_))
+                    }) {
                         features.push(minimum);
                     }
                 }

--- a/utoipa-gen/src/component/features/validation.rs
+++ b/utoipa-gen/src/component/features/validation.rs
@@ -210,6 +210,18 @@ impl_feature! {
     pub struct ExclusiveMaximum(NumberValue, Ident);
 }
 
+impl ExclusiveMinimum {
+    pub fn new(value: f64, span: Span) -> Self {
+        Self(
+            NumberValue {
+                minus: value <= 0.0,
+                lit: Literal::f64_suffixed(value),
+            },
+            Ident::new("empty", span),
+        )
+    }
+}
+
 impl Validate for ExclusiveMaximum {
     fn validate(&self, validator: impl Validator) -> Option<Diagnostics> {
         match validator.is_valid() {

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -129,17 +129,36 @@ impl SchemaType<'_> {
     pub fn is_integer(&self) -> bool {
         matches!(
             &*self.last_segment_to_string(),
-            "i8" | "i16"
-                | "i32"
-                | "i64"
-                | "i128"
-                | "isize"
-                | "u8"
-                | "u16"
-                | "u32"
-                | "u64"
-                | "u128"
-                | "usize"
+            "i8" 
+            | "i16"
+            | "i32"
+            | "i64"
+            | "i128"
+            | "isize"
+            | "u8"
+            | "u16"
+            | "u32"
+            | "u64"
+            | "u128"
+            | "usize"
+            | "NonZeroI8"
+            | "NonZeroI16"
+            | "NonZeroI32"
+            | "NonZeroI64"
+            | "NonZeroIsize"
+            | "NonZeroU8"
+            | "NonZeroU16"
+            | "NonZeroU32"
+            | "NonZeroU64"
+            | "NonZeroUsize"
+        )
+    }
+
+    pub fn is_nonzero_unsigned_integer(&self) -> bool {
+        matches!(
+            &*self.last_segment_to_string(),
+            "NonZeroU8" | "NonZeroU16" | "NonZeroU32" |
+            "NonZeroU64" | "NonZeroUsize"
         )
     }
 
@@ -147,6 +166,8 @@ impl SchemaType<'_> {
         matches!(
             &*self.last_segment_to_string(),
             "u8" | "u16" | "u32" | "u64" | "u128" | "usize"
+            | "NonZeroU8" | "NonZeroU16" | "NonZeroU32"
+            | "NonZeroU64" | "NonZeroUsize"
         )
     }
 
@@ -189,6 +210,16 @@ fn is_primitive(name: &str) -> bool {
             | "i128"
             | "f32"
             | "f64"
+            | "NonZeroI8"
+            | "NonZeroI16"
+            | "NonZeroI32"
+            | "NonZeroI64"
+            | "NonZeroIsize"
+            | "NonZeroU8"
+            | "NonZeroU16"
+            | "NonZeroU32"
+            | "NonZeroU64"
+            | "NonZeroUsize"
     )
 }
 
@@ -245,7 +276,10 @@ impl ToTokensDiagnostics for SchemaType<'_> {
             "bool" => schema_type_tokens(tokens, SchemaTypeInner::Boolean, self.nullable),
 
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize" => {
+            | "u128" | "usize" 
+            | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64"
+            | "NonZeroU128" | "NonZeroUsize" 
+            => {
                 schema_type_tokens(tokens, SchemaTypeInner::Integer, self.nullable)
             }
             "f32" | "f64" => schema_type_tokens(tokens, SchemaTypeInner::Number, self.nullable),
@@ -367,26 +401,28 @@ impl KnownFormat {
 
         let variant = match name {
             #[cfg(feature = "non_strict_integers")]
-            "i8" => Self::Int8,
+            "i8" | "NonZeroI8" => Self::Int8,
             #[cfg(feature = "non_strict_integers")]
-            "u8" => Self::UInt8,
+            "u8" | "NonZeroU8" => Self::UInt8,
             #[cfg(feature = "non_strict_integers")]
-            "i16" => Self::Int16,
+            "i16" | "NonZeroI16" => Self::Int16,
             #[cfg(feature = "non_strict_integers")]
-            "u16" => Self::UInt16,
+            "u16" | "NonZeroU16" => Self::UInt16,
             #[cfg(feature = "non_strict_integers")]
-            "u32" => Self::UInt32,
+            "u32" | "NonZeroU32" => Self::UInt32,
             #[cfg(feature = "non_strict_integers")]
-            "u64" => Self::UInt64,
+            "u64" | "NonZeroU64" => Self::UInt64,
 
             #[cfg(not(feature = "non_strict_integers"))]
-            "i8" | "i16" | "u8" | "u16" | "u32" => Self::Int32,
+            "i8" | "i16" | "u8" | "u16" | "u32" |
+            "NonZeroI8" | "NonZeroI16" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" 
+                => Self::Int32,
 
             #[cfg(not(feature = "non_strict_integers"))]
-            "u64" => Self::Int64,
+            "u64" | "NonZeroU64" => Self::Int64,
 
-            "i32" => Self::Int32,
-            "i64" => Self::Int64,
+            "i32" | "NonZeroI32" => Self::Int32,
+            "i64" | "NonZeroI64" => Self::Int64,
             "f32" => Self::Float,
             "f64" => Self::Double,
 
@@ -689,7 +725,10 @@ impl PrimitiveType {
             "bool" => syn::parse_quote!(#path),
 
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize" => syn::parse_quote!(#path),
+            | "u128" | "usize"
+            | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64"
+            | "NonZeroU128" | "NonZeroUsize" 
+            => syn::parse_quote!(#path),
             "f32" | "f64" => syn::parse_quote!(#path),
 
             #[cfg(feature = "chrono")]

--- a/utoipa-gen/src/schema_type.rs
+++ b/utoipa-gen/src/schema_type.rs
@@ -129,45 +129,58 @@ impl SchemaType<'_> {
     pub fn is_integer(&self) -> bool {
         matches!(
             &*self.last_segment_to_string(),
-            "i8" 
-            | "i16"
-            | "i32"
-            | "i64"
-            | "i128"
-            | "isize"
-            | "u8"
-            | "u16"
-            | "u32"
-            | "u64"
-            | "u128"
-            | "usize"
-            | "NonZeroI8"
-            | "NonZeroI16"
-            | "NonZeroI32"
-            | "NonZeroI64"
-            | "NonZeroIsize"
-            | "NonZeroU8"
-            | "NonZeroU16"
-            | "NonZeroU32"
-            | "NonZeroU64"
-            | "NonZeroUsize"
+            "i8" | "i16"
+                | "i32"
+                | "i64"
+                | "i128"
+                | "isize"
+                | "u8"
+                | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "usize"
+                | "NonZeroI8"
+                | "NonZeroI16"
+                | "NonZeroI32"
+                | "NonZeroI64"
+                | "NonZeroI128"
+                | "NonZeroIsize"
+                | "NonZeroU8"
+                | "NonZeroU16"
+                | "NonZeroU32"
+                | "NonZeroU64"
+                | "NonZeroU128"
+                | "NonZeroUsize"
         )
     }
 
     pub fn is_nonzero_unsigned_integer(&self) -> bool {
         matches!(
             &*self.last_segment_to_string(),
-            "NonZeroU8" | "NonZeroU16" | "NonZeroU32" |
-            "NonZeroU64" | "NonZeroUsize"
+            "NonZeroU8"
+                | "NonZeroU16"
+                | "NonZeroU32"
+                | "NonZeroU64"
+                | "NonZeroU128"
+                | "NonZeroUsize"
         )
     }
 
     pub fn is_unsigned_integer(&self) -> bool {
         matches!(
             &*self.last_segment_to_string(),
-            "u8" | "u16" | "u32" | "u64" | "u128" | "usize"
-            | "NonZeroU8" | "NonZeroU16" | "NonZeroU32"
-            | "NonZeroU64" | "NonZeroUsize"
+            "u8" | "u16"
+                | "u32"
+                | "u64"
+                | "u128"
+                | "usize"
+                | "NonZeroU8"
+                | "NonZeroU16"
+                | "NonZeroU32"
+                | "NonZeroU64"
+                | "NonZeroU128"
+                | "NonZeroUsize"
         )
     }
 
@@ -214,11 +227,13 @@ fn is_primitive(name: &str) -> bool {
             | "NonZeroI16"
             | "NonZeroI32"
             | "NonZeroI64"
+            | "NonZeroI128"
             | "NonZeroIsize"
             | "NonZeroU8"
             | "NonZeroU16"
             | "NonZeroU32"
             | "NonZeroU64"
+            | "NonZeroU128"
             | "NonZeroUsize"
     )
 }
@@ -276,10 +291,9 @@ impl ToTokensDiagnostics for SchemaType<'_> {
             "bool" => schema_type_tokens(tokens, SchemaTypeInner::Boolean, self.nullable),
 
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize" 
-            | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64"
-            | "NonZeroU128" | "NonZeroUsize" 
-            => {
+            | "u128" | "usize" | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64"
+            | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32"
+            | "NonZeroU64" | "NonZeroU128" | "NonZeroUsize" => {
                 schema_type_tokens(tokens, SchemaTypeInner::Integer, self.nullable)
             }
             "f32" | "f64" => schema_type_tokens(tokens, SchemaTypeInner::Number, self.nullable),
@@ -414,9 +428,8 @@ impl KnownFormat {
             "u64" | "NonZeroU64" => Self::UInt64,
 
             #[cfg(not(feature = "non_strict_integers"))]
-            "i8" | "i16" | "u8" | "u16" | "u32" |
-            "NonZeroI8" | "NonZeroI16" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" 
-                => Self::Int32,
+            "i8" | "i16" | "u8" | "u16" | "u32" | "NonZeroI8" | "NonZeroI16" | "NonZeroU8"
+            | "NonZeroU16" | "NonZeroU32" => Self::Int32,
 
             #[cfg(not(feature = "non_strict_integers"))]
             "u64" | "NonZeroU64" => Self::Int64,
@@ -725,10 +738,9 @@ impl PrimitiveType {
             "bool" => syn::parse_quote!(#path),
 
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize"
-            | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64" | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32" | "NonZeroU64"
-            | "NonZeroU128" | "NonZeroUsize" 
-            => syn::parse_quote!(#path),
+            | "u128" | "usize" | "NonZeroI8" | "NonZeroI16" | "NonZeroI32" | "NonZeroI64"
+            | "NonZeroI128" | "NonZeroIsize" | "NonZeroU8" | "NonZeroU16" | "NonZeroU32"
+            | "NonZeroU64" | "NonZeroU128" | "NonZeroUsize" => syn::parse_quote!(#path),
             "f32" | "f64" => syn::parse_quote!(#path),
 
             #[cfg(feature = "chrono")]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1687,6 +1687,17 @@ mod tests {
         assert_compact_json_snapshot!(u16::schema(), @r#"{"type": "integer", "format": "uint16", "minimum": 0}"#);
         assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "uint32", "minimum": 0}"#);
         assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "uint64", "minimum": 0}"#);
+
+        assert_compact_json_snapshot!(NonZeroI8::schema(), @r#"{"type": "integer", "format": "int8"}"#);
+        assert_compact_json_snapshot!(NonZeroI16::schema(), @r#"{"type": "integer", "format": "int16"}"#);
+        assert_compact_json_snapshot!(NonZeroI32::schema(), @r#"{"type": "integer", "format": "int32"}"#);
+        assert_compact_json_snapshot!(NonZeroI64::schema(), @r#"{"type": "integer", "format": "int64"}"#);
+        assert_compact_json_snapshot!(NonZeroI128::schema(), @r#"{"type": "integer"}"#);
+        assert_compact_json_snapshot!(NonZeroIsize::schema(), @r#"{"type": "integer"}"#);
+        assert_compact_json_snapshot!(NonZeroU8::schema(), @r#"{"type": "integer", "format": "uint8", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU16::schema(), @r#"{"type": "integer", "format": "uint16", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU32::schema(), @r#"{"type": "integer", "format": "uint32", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU64::schema(), @r#"{"type": "integer", "format": "uint64", "exclusiveMinimum": 0}"#);
     }
 
     #[test]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -511,27 +511,9 @@ macro_rules! impl_to_schema {
 
 #[rustfmt::skip]
 impl_to_schema!(
-    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char
-);
-
-macro_rules! impl_to_schema_num_alias {
-    ( $( $ty:ident as $as:ident),* ) => {
-        $(
-        impl ToSchema for $ty {
-            fn name() -> std::borrow::Cow<'static, str> {
-                std::borrow::Cow::Borrowed(stringify!( $ty as $as ))
-            }
-        }
-        )*
-    };
-}
-
-#[rustfmt::skip]
-impl_to_schema_num_alias!(
-    NonZeroI8 as isize, NonZeroI16 as isize, NonZeroI32 as isize,
-    NonZeroI64 as isize, NonZeroIsize as isize,
-    NonZeroU8 as usize, NonZeroU16 as usize, NonZeroU32 as usize,
-    NonZeroU64 as usize, NonZeroUsize as usize
+    i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
+    NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroIsize,
+    NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize 
 );
 
 impl ToSchema for &str {

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1368,35 +1368,25 @@ pub mod __dev {
     }
 
     macro_rules! impl_compose_schema {
-    ( $( $ty:ident $(as $as:ident)? ),* $(,)? ) => {
-        $(
+        ( $( $ty:ident ),* ) => {
+            $(
             impl ComposeSchema for $ty {
-                fn compose(
-                    _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>
-                ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-                    impl_compose_schema!(@schema $ty $(, $as)?).into()
+                fn compose(_: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                    schema!( $ty ).into()
                 }
             }
-        )*
-    };
-
-    (@schema $ty:ident) => {
-        schema!($ty)
-    };
-
-    (@schema $ty:ident, $as:ident) => {
-        schema!($as)
-    };
-}
+            )*
+        };
+    }
 
     use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
 
     #[rustfmt::skip]
     impl_compose_schema!(
         i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
-        NonZeroI8 as i8, NonZeroI16 as i16, NonZeroI32 as i32, NonZeroI64 as i64, 
-        NonZeroU8 as u8, NonZeroU16 as u16, NonZeroU32 as u32, NonZeroU64 as u64, 
-        NonZeroIsize as isize, NonZeroUsize as usize
+        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, 
+        NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, 
+        NonZeroIsize, NonZeroUsize
     );
 
     fn schema_or_compose<T: ComposeSchema>(

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -514,11 +514,32 @@ impl_to_schema!(
     i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char
 );
 
+macro_rules! impl_to_schema_num_alias {
+    ( $( $ty:ident as $as:ident),* ) => {
+        $(
+        impl ToSchema for $ty {
+            fn name() -> std::borrow::Cow<'static, str> {
+                std::borrow::Cow::Borrowed(stringify!( $ty as $as ))
+            }
+        }
+        )*
+    };
+}
+
+#[rustfmt::skip]
+impl_to_schema_num_alias!(
+    NonZeroI8 as isize, NonZeroI16 as isize, NonZeroI32 as isize,
+    NonZeroI64 as isize, NonZeroIsize as isize,
+    NonZeroU8 as usize, NonZeroU16 as usize, NonZeroU32 as usize,
+    NonZeroU64 as usize, NonZeroUsize as usize
+);
+
 impl ToSchema for &str {
     fn name() -> Cow<'static, str> {
         str::name()
     }
 }
+
 
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
@@ -1376,9 +1397,13 @@ pub mod __dev {
         };
     }
 
+    use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
+
     #[rustfmt::skip]
     impl_compose_schema!(
-        i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char
+        i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
+        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, 
+        NonZeroIsize, NonZeroUsize
     );
 
     fn schema_or_compose<T: ComposeSchema>(

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1368,24 +1368,35 @@ pub mod __dev {
     }
 
     macro_rules! impl_compose_schema {
-        ( $( $ty:ident ),* ) => {
-            $(
+    ( $( $ty:ident $(as $as:ident)? ),* $(,)? ) => {
+        $(
             impl ComposeSchema for $ty {
-                fn compose(_: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
-                    schema!( $ty ).into()
+                fn compose(
+                    _: Vec<utoipa::openapi::RefOr<utoipa::openapi::schema::Schema>>
+                ) -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+                    impl_compose_schema!(@schema $ty $(, $as)?).into()
                 }
             }
-            )*
-        };
-    }
+        )*
+    };
+
+    (@schema $ty:ident) => {
+        schema!($ty)
+    };
+
+    (@schema $ty:ident, $as:ident) => {
+        schema!($as)
+    };
+}
 
     use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
 
     #[rustfmt::skip]
     impl_compose_schema!(
         i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
-        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, 
-        NonZeroIsize, NonZeroUsize
+        NonZeroI8 as i8, NonZeroI16 as i16, NonZeroI32 as i32, NonZeroI64 as i64, 
+        NonZeroU8 as u8, NonZeroU16 as u16, NonZeroU32 as u32, NonZeroU64 as u64, 
+        NonZeroIsize as isize, NonZeroUsize as usize
     );
 
     fn schema_or_compose<T: ComposeSchema>(

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -1263,6 +1263,28 @@ impl_from_for_number!(
     isize => Int, usize => UInt
 );
 
+macro_rules! impl_from_for_num_alias {
+    ( $( $ty:ident => $pat:ident $( as $as:ident )? ),* ) => {
+        $(
+        impl From<$ty> for Number {
+            fn from(value: $ty) -> Self {
+                Self::$pat(value.get() $( as $as )?)
+            }
+        }
+        )*
+    };
+}
+
+use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
+
+#[rustfmt::skip]
+impl_from_for_num_alias!(
+    NonZeroI8 => Int as isize, NonZeroI16 => Int as isize, NonZeroI32 => Int as isize,
+    NonZeroI64 => Int as isize, NonZeroIsize => Int as isize,
+    NonZeroU8 => UInt as usize, NonZeroU16 => UInt as usize, NonZeroU32 => UInt as usize,
+    NonZeroU64 => UInt as usize, NonZeroUsize => UInt as usize
+);
+
 /// Internal dev module used internally by utoipa-gen
 #[doc(hidden)]
 #[cfg(feature = "macros")]

--- a/utoipa/src/lib.rs
+++ b/utoipa/src/lib.rs
@@ -522,7 +522,6 @@ impl ToSchema for &str {
     }
 }
 
-
 #[cfg(feature = "macros")]
 #[cfg_attr(doc_cfg, doc(cfg(feature = "macros")))]
 impl<T: ToSchema> ToSchema for Option<T>
@@ -1278,14 +1277,17 @@ macro_rules! impl_from_for_num_alias {
     };
 }
 
-use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
+use std::num::{
+    NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+    NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+};
 
 #[rustfmt::skip]
 impl_from_for_num_alias!(
     NonZeroI8 => Int as isize, NonZeroI16 => Int as isize, NonZeroI32 => Int as isize,
-    NonZeroI64 => Int as isize, NonZeroIsize => Int as isize,
+    NonZeroI64 => Int as isize, NonZeroI128 => Int as isize, NonZeroIsize => Int as isize,
     NonZeroU8 => UInt as usize, NonZeroU16 => UInt as usize, NonZeroU32 => UInt as usize,
-    NonZeroU64 => UInt as usize, NonZeroUsize => UInt as usize
+    NonZeroU64 => UInt as usize, NonZeroU128 => UInt as usize, NonZeroUsize => UInt as usize
 );
 
 /// Internal dev module used internally by utoipa-gen
@@ -1296,6 +1298,10 @@ pub mod __dev {
     use utoipa_gen::schema;
 
     use crate::{utoipa, OpenApi, PartialSchema};
+    use std::num::{
+        NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
+        NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU8, NonZeroUsize,
+    };
 
     pub trait PathConfig {
         fn path() -> String;
@@ -1379,13 +1385,11 @@ pub mod __dev {
         };
     }
 
-    use std::num::{NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroIsize, NonZeroUsize};
-
     #[rustfmt::skip]
     impl_compose_schema!(
         i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, bool, f32, f64, String, str, char,
-        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, 
-        NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, 
+        NonZeroI8, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI128,
+        NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroU128, 
         NonZeroIsize, NonZeroUsize
     );
 
@@ -1657,6 +1661,17 @@ mod tests {
         assert_compact_json_snapshot!(u16::schema(), @r#"{"type": "integer", "format": "int32", "minimum": 0}"#);
         assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "int32", "minimum": 0}"#);
         assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "int64", "minimum": 0}"#);
+
+        assert_compact_json_snapshot!(NonZeroI8::schema(), @r#"{"type": "integer", "format": "int32"}"#);
+        assert_compact_json_snapshot!(NonZeroI16::schema(), @r#"{"type": "integer", "format": "int32"}"#);
+        assert_compact_json_snapshot!(NonZeroI32::schema(), @r#"{"type": "integer", "format": "int32"}"#);
+        assert_compact_json_snapshot!(NonZeroI64::schema(), @r#"{"type": "integer", "format": "int64"}"#);
+        assert_compact_json_snapshot!(NonZeroI128::schema(), @r#"{"type": "integer"}"#);
+        assert_compact_json_snapshot!(NonZeroIsize::schema(), @r#"{"type": "integer"}"#);
+        assert_compact_json_snapshot!(NonZeroU8::schema(), @r#"{"type": "integer", "format": "int32", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU16::schema(), @r#"{"type": "integer", "format": "int32", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU32::schema(), @r#"{"type": "integer", "format": "int32", "exclusiveMinimum": 0}"#);
+        assert_compact_json_snapshot!(NonZeroU64::schema(), @r#"{"type": "integer", "format": "int64", "exclusiveMinimum": 0}"#);
     }
 
     #[cfg(feature = "non_strict_integers")]
@@ -1670,8 +1685,8 @@ mod tests {
         assert_compact_json_snapshot!(isize::schema(), @r#"{"type": "integer"}"#);
         assert_compact_json_snapshot!(u8::schema(), @r#"{"type": "integer", "format": "uint8", "minimum": 0}"#);
         assert_compact_json_snapshot!(u16::schema(), @r#"{"type": "integer", "format": "uint16", "minimum": 0}"#);
-        assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "int32", "minimum": 0}"#);
-        assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "int64", "minimum": 0}"#);
+        assert_compact_json_snapshot!(u32::schema(), @r#"{"type": "integer", "format": "uint32", "minimum": 0}"#);
+        assert_compact_json_snapshot!(u64::schema(), @r#"{"type": "integer", "format": "uint64", "minimum": 0}"#);
     }
 
     #[test]

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -25,6 +25,7 @@ pub use self::{
 };
 
 pub mod content;
+pub mod defs;
 pub mod encoding;
 pub mod example;
 pub mod extensions;

--- a/utoipa/src/openapi/defs.rs
+++ b/utoipa/src/openapi/defs.rs
@@ -140,7 +140,7 @@ impl Schema {
     /// Used to replace /#defs/ with openapi /components/schemas/<schema-name>
     /// for schema (recursively)
     ///
-    /// See also: [`RefOr::root_defs_to_openapi_schemas`]
+    /// See also: [`RefOr::refs_to_openapi_format`]
     ///
     /// e.g.
     /// ```json
@@ -367,7 +367,7 @@ impl OpenApi {
     /// Used to replace /#defs/ with openapi /components/schemas/<schema-name>
     /// for all components schemas (recursively)
     ///
-    /// See also: [`RefOr::root_defs_to_openapi_schemas`]
+    /// See also: [`RefOr::refs_to_openapi_format`]
     ///
     /// e.g.
     /// ```json
@@ -419,7 +419,7 @@ impl RefOr<Schema> {
     ///    "$ref": /#components/schemas/<schema-name>/a/b"
     /// }
     /// ```
-    pub fn root_defs_to_openapi_schemas<SN: AsRef<str>>(
+    pub fn refs_to_openapi_format<SN: AsRef<str>>(
         &mut self,
         schema_name: Option<SN>,
     ) -> &mut Self {
@@ -717,14 +717,14 @@ pub mod test {
     }
 
     #[test]
-    fn root_defs_to_openapi_schemas_simple_ref() {
+    fn refs_to_openapi_format_simple_ref() {
         let mut simple_ref: RefOr<Schema> = RefOr::Ref(
             RefBuilder::new()
                 .ref_location("/#defs/MyStruct".into())
                 .into(),
         );
 
-        simple_ref.replace_defs_with_openapi_schemas(Option::<&str>::None);
+        simple_ref.refs_to_openapi_format(Option::<&str>::None);
 
         match simple_ref {
             RefOr::Ref(x) => assert_eq!(x.ref_location, "/#components/schemas/MyStruct"),
@@ -733,7 +733,7 @@ pub mod test {
     }
 
     #[test]
-    fn root_defs_to_openapi_schemas_on_schema() {
+    fn refs_to_openapi_format_on_schema() {
         let simple_ref: RefOr<Schema> = RefOr::Ref(
             RefBuilder::new()
                 .ref_location("/#defs/MyStruct".into())
@@ -762,7 +762,7 @@ pub mod test {
     }
 
     #[test]
-    fn root_defs_to_openapi_schemas() {
+    fn refs_to_openapi_format_on_openapi() {
         let simple_ref: RefOr<Schema> = RefOr::Ref(
             RefBuilder::new()
                 .ref_location("/#defs/MyStruct".into())

--- a/utoipa/src/openapi/defs.rs
+++ b/utoipa/src/openapi/defs.rs
@@ -8,7 +8,11 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::{builder, OpenApi, RefOr, Schema};
+use super::{
+    builder,
+    schema::{AdditionalProperties, AnyOf},
+    AllOf, Array, Components, Object, OneOf, OpenApi, RefOr, Schema,
+};
 
 builder! {
     DefsBuilder;
@@ -135,7 +139,9 @@ impl Schema {
 }
 
 impl OpenApi {
-    /// Used to extract defs from the direct openapi components schemas as the schemas
+    /// Used to extract defs from the direct openapi components schemas as the schemas.
+    ///
+    /// It keeps original defs unchanged.
     ///
     /// e.g.
     ///
@@ -237,8 +243,9 @@ impl OpenApi {
     /// }
     /// ```
     pub fn extract_components_from_schemas_def(&mut self) -> &mut Self {
-        let mut additional_schemas: Vec<(String, RefOr<Schema>)> = Vec::new();
         if let Some(components) = &mut self.components {
+            let mut additional_schemas: Vec<(String, RefOr<Schema>)> = Vec::new();
+
             for schema in components
                 .schemas
                 .values()
@@ -261,10 +268,11 @@ impl OpenApi {
 
         self
     }
-}
 
-impl<T> RefOr<T> {
-    /// Used to replace /#defs/ with openapi /components/schemas
+    /// Used to replace /#defs/ with openapi /components/schemas/<schema-name>
+    /// for all components schemas (recursively)
+    ///
+    /// See also: [`RefOr::root_defs_to_openapi_schemas`]
     ///
     /// e.g.
     /// ```json
@@ -277,19 +285,211 @@ impl<T> RefOr<T> {
     ///
     /// ```json
     /// {
-    ///    "$ref": /#components/schemas/a/b"
+    ///    "$ref": /#components/schemas/<schema-name>/a/b"
     /// }
     /// ```
-    pub fn root_defs_to_openapi_schemas(&mut self) -> &mut Self {
+    pub fn refs_to_openapi_format<SN: AsRef<str>>(&mut self, schema_name: Option<SN>) -> &mut Self {
+        if let Some(components) = &mut self.components {
+            for schema in components.schemas.values_mut() {
+                match &schema_name {
+                    Some(schema_name) => {
+                        schema.replace_defs_with_openapi_schemas(Some(schema_name.as_ref()))
+                    }
+                    None => schema.replace_defs_with_openapi_schemas(None),
+                };
+            }
+        }
+
+        self
+    }
+}
+
+const DEFS_PREFIX: &str = "/#defs/";
+const COMPONENTS_PREFIX: &str = "/#components/schemas/";
+
+impl RefOr<Schema> {
+    /// Used to replace /#defs/ with openapi /components/schemas/<schema-name>
+    ///
+    /// e.g.
+    /// ```json
+    /// {
+    ///    "$ref": "/#defs/a/b
+    /// }
+    /// ```
+    ///
+    /// becomes
+    ///
+    /// ```json
+    /// {
+    ///    "$ref": /#components/schemas/<schema-name>/a/b"
+    /// }
+    /// ```
+    pub fn root_defs_to_openapi_schemas<SN: AsRef<str>>(
+        &mut self,
+        schema_name: Option<SN>,
+    ) -> &mut Self {
+        // map caused some compiler errors due to ownership
+        match schema_name {
+            Some(schema_name) => self.replace_defs_with_openapi_schemas(Some(schema_name.as_ref())),
+            None => self.replace_defs_with_openapi_schemas(None),
+        };
+        self
+    }
+}
+
+trait RefRootDefsReplace {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self;
+}
+
+impl RefRootDefsReplace for RefOr<Schema> {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
         match self {
+            // use non recursive version for the ref itself
             RefOr::Ref(ref_) => {
-                if ref_.ref_location.starts_with("/#defs/") {
-                    ref_.ref_location =
-                        ref_.ref_location
-                            .replacen("/#defs/", "#/components/schemas/", 1);
+                if ref_.ref_location.starts_with(DEFS_PREFIX) {
+                    let replacement = schema_name
+                        .map(|schema| format!("{COMPONENTS_PREFIX}{schema}/"))
+                        .unwrap_or(COMPONENTS_PREFIX.into());
+
+                    ref_.ref_location = ref_.ref_location.replacen(DEFS_PREFIX, &replacement, 1);
                 }
             }
-            RefOr::T(_) => {}
+
+            // any schema should use recursive version
+            RefOr::T(t) => {
+                t.replace_defs_with_openapi_schemas(schema_name);
+            }
+        }
+
+        self
+    }
+}
+
+impl RefRootDefsReplace for Components {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
+        for schema in &mut self.schemas {
+            schema.1.replace_defs_with_openapi_schemas(schema_name);
+        }
+
+        self
+    }
+}
+
+impl RefRootDefsReplace for Defs {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
+        for (_, schema) in self.iter_mut() {
+            schema.replace_defs_with_openapi_schemas(schema_name);
+        }
+
+        self
+    }
+}
+
+impl RefRootDefsReplace for Schema {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
+        match self {
+            Schema::Const(_) => {}
+            Schema::Array(array) => {
+                array.replace_defs_with_openapi_schemas(schema_name);
+            }
+            Schema::Object(object) => {
+                object.replace_defs_with_openapi_schemas(schema_name);
+            }
+            Schema::OneOf(one_of) => {
+                one_of.replace_defs_with_openapi_schemas(schema_name);
+            }
+            Schema::AllOf(all_of) => {
+                all_of.replace_defs_with_openapi_schemas(schema_name);
+            }
+            Schema::AnyOf(any_of) => {
+                any_of.replace_defs_with_openapi_schemas(schema_name);
+            }
+        }
+
+        self
+    }
+}
+
+impl RefRootDefsReplace for Array {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
+        self.defs.replace_defs_with_openapi_schemas(schema_name);
+        for item in &mut self.prefix_items {
+            item.replace_defs_with_openapi_schemas(schema_name);
+        }
+
+        match &mut self.items {
+            super::schema::ArrayItems::RefOrSchema(ref_or) => {
+                ref_or.replace_defs_with_openapi_schemas(schema_name);
+            }
+            super::schema::ArrayItems::False => {}
+        }
+
+        self
+    }
+}
+
+impl RefRootDefsReplace for AdditionalProperties<Schema> {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
+        match self {
+            AdditionalProperties::RefOr(ref_or) => {
+                ref_or.replace_defs_with_openapi_schemas(schema_name);
+            }
+            AdditionalProperties::FreeForm(_) => {}
+        }
+
+        self
+    }
+}
+
+impl RefRootDefsReplace for Object {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
+        self.defs.replace_defs_with_openapi_schemas(schema_name);
+
+        for property in self.properties.values_mut() {
+            property.replace_defs_with_openapi_schemas(schema_name);
+        }
+
+        if let Some(additional_properties) = &mut self.additional_properties {
+            additional_properties.replace_defs_with_openapi_schemas(schema_name);
+        }
+
+        if let Some(property_names) = &mut self.property_names {
+            property_names.replace_defs_with_openapi_schemas(schema_name);
+        }
+
+        self
+    }
+}
+
+impl RefRootDefsReplace for OneOf {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
+        self.defs.replace_defs_with_openapi_schemas(schema_name);
+
+        for item in &mut self.items {
+            item.replace_defs_with_openapi_schemas(schema_name);
+        }
+
+        self
+    }
+}
+
+impl RefRootDefsReplace for AllOf {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
+        self.defs.replace_defs_with_openapi_schemas(schema_name);
+
+        for item in &mut self.items {
+            item.replace_defs_with_openapi_schemas(schema_name);
+        }
+
+        self
+    }
+}
+impl RefRootDefsReplace for AnyOf {
+    fn replace_defs_with_openapi_schemas(&mut self, schema_name: Option<&str>) -> &mut Self {
+        self.defs.replace_defs_with_openapi_schemas(schema_name);
+
+        for item in &mut self.items {
+            item.replace_defs_with_openapi_schemas(schema_name);
         }
 
         self
@@ -301,8 +501,8 @@ impl<T> RefOr<T> {
 pub mod test {
     use super::*;
     use crate::openapi::{
-        schema::{SchemaType, Type},
-        ComponentsBuilder, ObjectBuilder, OpenApiBuilder,
+        schema::{AnyOfBuilder, ArrayItems, RefBuilder, SchemaType, Type},
+        AllOfBuilder, ArrayBuilder, ComponentsBuilder, ObjectBuilder, OneOfBuilder, OpenApiBuilder,
     };
 
     const BASIC: &str = r##"
@@ -391,13 +591,127 @@ pub mod test {
     fn additional_schemas_extraction() {
         let defs = serde_json::from_str(BASIC).unwrap();
 
-        let mut openapi = OpenApiBuilder::new().components(Some(
-            ComponentsBuilder::new()
-                .schema("MySchema", ObjectBuilder::new().defs(defs))
-                .build(),
-        )).build();
+        let mut openapi = OpenApiBuilder::new()
+            .components(Some(
+                ComponentsBuilder::new()
+                    .schema("MySchema", ObjectBuilder::new().defs(defs))
+                    .build(),
+            ))
+            .build();
 
         openapi.extract_components_from_schemas_def();
-        assert_eq!(openapi.components.unwrap().schemas.len(), 3);
+
+        // defs should be promoted to components
+        assert_eq!(openapi.components.as_ref().unwrap().schemas.len(), 3);
+
+        let my_schema = openapi
+            .components
+            .unwrap()
+            .schemas
+            .iter()
+            .find(|x| x.0 == "MySchema")
+            .map(|x| match x.1 {
+                RefOr::T(schema) => schema,
+                _ => panic!("It should be schema"),
+            })
+            .unwrap()
+            .clone();
+
+        // old defs should be kept intact
+        assert_eq!(my_schema.defs().map(|defs| defs.len()), Some(2));
+    }
+
+    #[test]
+    fn root_defs_to_openapi_schemas() {
+        let simple_ref: RefOr<Schema> = RefOr::Ref(
+            RefBuilder::new()
+                .ref_location("/#defs/MyStruct".into())
+                .into(),
+        );
+
+        let defsobj_with_ref = ObjectBuilder::new()
+            .title("BaseDefsObj".into())
+            .property("base", simple_ref.clone());
+        let defs = DefsBuilder::new().def("DefObj", defsobj_with_ref).build();
+
+        let any_of_with_ref = AnyOfBuilder::new()
+            .title("AnyOf".into())
+            .item(simple_ref.clone())
+            .defs(defs.clone())
+            .build();
+
+        let one_of_with_ref = OneOfBuilder::new()
+            .title("OneOf".into())
+            .item(simple_ref.clone())
+            .defs(defs.clone())
+            .build();
+
+        let all_of_with_ref = AllOfBuilder::new()
+            .title("AllOf".into())
+            .item(simple_ref.clone())
+            .defs(defs.clone())
+            .build();
+
+        let object_with_ref = ObjectBuilder::new()
+            .schema_type(SchemaType::Type(Type::Object))
+            .title(Some("Obj"))
+            .property("prop", simple_ref.clone())
+            .additional_properties(Some(AdditionalProperties::RefOr(simple_ref.clone())))
+            .property_names(Some(any_of_with_ref.clone()))
+            .defs(defs.clone());
+
+        let array_with_ref = ArrayBuilder::new()
+            .schema_type(SchemaType::Type(Type::Array))
+            .title(Some("AraryWithRef"))
+            .items(ArrayItems::RefOrSchema(Box::new(simple_ref.clone())));
+
+        let openapi = OpenApiBuilder::new()
+            .components(Some(
+                ComponentsBuilder::new()
+                    .schema("AnyOfRef", RefOr::T(any_of_with_ref.into()))
+                    .schema("OneOffRef", RefOr::T(one_of_with_ref.into()))
+                    .schema("AllOffRef", RefOr::T(all_of_with_ref.into()))
+                    .schema("ObjectRef", RefOr::T(object_with_ref.into()))
+                    .schema("ArrayRef", RefOr::T(array_with_ref.into()))
+                    .build(),
+            ))
+            .build();
+
+        let stringified = serde_json::to_string_pretty(&openapi).unwrap();
+        let initial_defs_ref_count = stringified.matches(DEFS_PREFIX).count();
+        let non_suffixed_stringified = serde_json::to_string_pretty(
+            openapi.clone().refs_to_openapi_format(Option::<&str>::None),
+        )
+        .unwrap();
+
+        assert_eq!(
+            non_suffixed_stringified.matches(DEFS_PREFIX).count(),
+            0,
+            "No original {DEFS_PREFIX} should be present"
+        );
+
+        assert_eq!(
+            initial_defs_ref_count,
+            non_suffixed_stringified.matches(COMPONENTS_PREFIX).count(),
+            "All occurences of {DEFS_PREFIX} should be replaced with {COMPONENTS_PREFIX}\nSchema: {non_suffixed_stringified}"
+        );
+
+        let suffix = "MySuffixSchema";
+        let suffixed_stringified =
+            serde_json::to_string_pretty(openapi.clone().refs_to_openapi_format(Some(suffix)))
+                .unwrap();
+
+        assert_eq!(
+            suffixed_stringified.matches(DEFS_PREFIX).count(),
+            0,
+            "No original {DEFS_PREFIX} should be present"
+        );
+
+        let suffixed = format!("{COMPONENTS_PREFIX}{suffix}/");
+        assert_eq!(
+            initial_defs_ref_count,
+            suffixed_stringified.matches(&suffixed).count(),
+            "All occurences of {DEFS_PREFIX} should be replaced with {suffixed}\nSchema: {suffixed_stringified}"
+        );
     }
 }

--- a/utoipa/src/openapi/defs.rs
+++ b/utoipa/src/openapi/defs.rs
@@ -1,0 +1,130 @@
+//! Implements [`$defs` keyword from json schema][defs]
+//!
+//! [defs]: https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs
+use std::{
+    collections::BTreeMap,
+    ops::{Deref, DerefMut},
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::Schema;
+
+/// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON Schemas
+/// into a more general schema. The keyword does not directly affect the validation result.
+///
+/// This keyword's value MUST be an object. Each member value of this object MUST be a valid
+/// JSON Schema.
+///
+/// As an example, here is a schema describing an array of positive integers, where the
+/// positive integer constraint is a subschema in "$defs":
+/// ```
+/// {
+///     "type": "array",
+///     "items": { "$ref": "#/$defs/positiveInteger" },
+///     "$defs": {
+///         "positiveInteger": {
+///             "type": "integer",
+///             "exclusiveMinimum": 0
+///         }
+///     }
+/// }
+/// ```
+#[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct Defs(
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
+    BTreeMap<String, Schema>,
+);
+
+/// Builder for the [`Defs`]
+pub struct DefsBuilder(BTreeMap<String, Schema>);
+
+impl DefsBuilder {
+    /// Extend `$defs`
+    ///
+    /// Read more:
+    /// <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
+    pub fn defs<T: IntoIterator<Item = (String, Schema)>>(mut self, defs: T) -> Self {
+        self.0.extend(defs);
+        self
+    }
+
+    /// Add field describing `const` value
+    ///
+    /// Read more:
+    /// <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
+    pub fn def<K: Into<String>, V: Into<Schema>>(mut self, key: K, value: V) -> Self {
+        self.0.insert(key.into(), value.into());
+        self
+    }
+}
+
+impl Defs {
+    /// Get internal iterator
+    pub fn iter(&self) -> std::collections::btree_map::Iter<String, Schema> {
+        self.0.iter()
+    }
+
+    /// Get internal iterator (mutable)
+    pub fn iter_mut(&mut self) -> std::collections::btree_map::IterMut<String, Schema> {
+        self.0.iter_mut()
+    }
+}
+
+impl<K, V> FromIterator<(K, V)> for Defs
+where
+    K: Into<String>,
+    V: Into<Schema>,
+{
+    fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
+        let iter = iter.into_iter().map(|(k, v)| (k.into(), v.into()));
+        let defs = BTreeMap::from_iter(iter);
+        Self(defs)
+    }
+}
+
+impl From<Defs> for BTreeMap<String, Schema> {
+    fn from(value: Defs) -> Self {
+        value.0
+    }
+}
+
+impl Deref for Defs {
+    type Target = BTreeMap<String, Schema>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Defs {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl IntoIterator for Defs {
+    type Item = (String, Schema);
+
+    type IntoIter = std::collections::btree_map::IntoIter<String, Schema>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl Schema {
+
+    /// Retrive [`$defs`] keyword for the [`Schema`]
+    pub fn defs(&self) -> Option<&Defs> {
+        match self {
+            Schema::Const(_) => None,
+            Schema::Array(array) => Some(&array.defs),
+            Schema::Object(object) => Some(&object.defs),
+            Schema::OneOf(one_of) => Some(&one_of.defs),
+            Schema::AllOf(all_of) => Some(&all_of.defs),
+            Schema::AnyOf(any_of) => Some(&any_of.defs),
+        }
+    }
+}

--- a/utoipa/src/openapi/defs.rs
+++ b/utoipa/src/openapi/defs.rs
@@ -136,6 +136,32 @@ impl Schema {
             Schema::AnyOf(any_of) => Some(&any_of.defs),
         }
     }
+
+    /// Used to replace /#defs/ with openapi /components/schemas/<schema-name>
+    /// for schema (recursively)
+    ///
+    /// See also: [`RefOr::root_defs_to_openapi_schemas`]
+    ///
+    /// e.g.
+    /// ```json
+    /// {
+    ///    "$ref": "/#defs/a/b
+    /// }
+    /// ```
+    ///
+    /// becomes
+    ///
+    /// ```json
+    /// {
+    ///    "$ref": /#components/schemas/<schema-name>/a/b"
+    /// }
+    /// ```
+    pub fn refs_to_openapi_format<SN: AsRef<str>>(&mut self, schema_name: Option<SN>) -> &mut Self {
+        match schema_name {
+            Some(schema_name) => self.replace_defs_with_openapi_schemas(Some(schema_name.as_ref())),
+            None => self.replace_defs_with_openapi_schemas(None),
+        }
+    }
 }
 
 impl OpenApi {
@@ -622,6 +648,51 @@ pub mod test {
     }
 
     #[test]
+    fn root_defs_to_openapi_schemas_simple_ref() {
+        let mut simple_ref: RefOr<Schema> = RefOr::Ref(
+            RefBuilder::new()
+                .ref_location("/#defs/MyStruct".into())
+                .into(),
+        );
+
+        simple_ref.replace_defs_with_openapi_schemas(Option::<&str>::None);
+
+        match simple_ref {
+            RefOr::Ref(x) => assert_eq!(x.ref_location, "/#components/schemas/MyStruct"),
+            RefOr::T(_) => unreachable!(),
+        }
+    }
+
+    #[test]
+    fn root_defs_to_openapi_schemas_on_schema() {
+        let simple_ref: RefOr<Schema> = RefOr::Ref(
+            RefBuilder::new()
+                .ref_location("/#defs/MyStruct".into())
+                .into(),
+        );
+
+        let mut any_of_with_ref: Schema =
+            AnyOfBuilder::new().item(simple_ref.clone()).build().into();
+
+        any_of_with_ref
+            .refs_to_openapi_format(Option::<&str>::None)
+            // dual+ calls should not be a problem
+            .refs_to_openapi_format(Some("dummy"))
+            .refs_to_openapi_format(Some("magic-dummy"));
+
+        let items = match any_of_with_ref {
+            Schema::AnyOf(any_of) => any_of.items,
+            _ => unreachable!(),
+        };
+
+        assert_eq!(items.len(), 1);
+        match items.first().unwrap() {
+            RefOr::Ref(ref_) => assert_eq!(ref_.ref_location, "/#components/schemas/MyStruct"),
+            RefOr::T(_) => unreachable!(),
+        }
+    }
+
+    #[test]
     fn root_defs_to_openapi_schemas() {
         let simple_ref: RefOr<Schema> = RefOr::Ref(
             RefBuilder::new()
@@ -697,9 +768,14 @@ pub mod test {
         );
 
         let suffix = "MySuffixSchema";
-        let suffixed_stringified =
-            serde_json::to_string_pretty(openapi.clone().refs_to_openapi_format(Some(suffix)))
-                .unwrap();
+        let suffixed_stringified = serde_json::to_string_pretty(
+            openapi
+                .clone()
+                .refs_to_openapi_format(Some(suffix))
+                // dual calls should not cause any issues
+                .refs_to_openapi_format(Some("dummy")),
+        )
+        .unwrap();
 
         assert_eq!(
             suffixed_stringified.matches(DEFS_PREFIX).count(),

--- a/utoipa/src/openapi/defs.rs
+++ b/utoipa/src/openapi/defs.rs
@@ -164,6 +164,76 @@ impl Schema {
     }
 }
 
+impl Schema {
+    /// Extract other json schemas from the root $defs
+    ///
+    /// Example for:
+    ///
+    /// ```json
+    ///  "MySchema": {
+    ///    "type": "object",
+    ///    "$defs": {
+    ///      "address": {
+    ///        "type": "object",
+    ///        "required": [
+    ///          "street",
+    ///          "city"
+    ///        ],
+    ///        "properties": {
+    ///          "city": {
+    ///            "$ref": "#/$defs/nonEmptyString"
+    ///          },
+    ///          "street": {
+    ///            "$ref": "#/$defs/nonEmptyString"
+    ///          }
+    ///        }
+    ///      },
+    ///      "nonEmptyString": {
+    ///        "type": "string",
+    ///        "minLength": 1
+    ///      }
+    ///    }
+    ///  }
+    /// ````
+    ///
+    /// you get:
+    ///
+    /// ```json
+    ///   "address": {
+    ///     "type": "object",
+    ///     "required": [
+    ///       "street",
+    ///       "city"
+    ///     ],
+    ///     "properties": {
+    ///       "city": {
+    ///         "$ref": "#/$defs/nonEmptyString"
+    ///       },
+    ///       "street": {
+    ///         "$ref": "#/$defs/nonEmptyString"
+    ///       }
+    ///     }
+    ///   },
+    /// ```
+    ///
+    /// and
+    ///
+    /// ```json
+    ///   "nonEmptyString": {
+    ///     "type": "string",
+    ///     "minLength": 1
+    ///   }
+    /// ```
+    pub fn retrive_schemas_from_defs(&self) -> BTreeMap<&str, &Schema> {
+        let mut result = BTreeMap::new();
+        if let Some(defs) = self.defs() {
+            result.extend(defs.iter().map(|(key, value)| (key.as_str(), value)))
+        }
+
+        result
+    }
+}
+
 impl OpenApi {
     /// Used to extract defs from the direct openapi components schemas as the schemas.
     ///
@@ -280,13 +350,12 @@ impl OpenApi {
                     _ => None,
                 })
             {
-                if let Some(defs) = schema.defs() {
-                    additional_schemas.extend(
-                        defs.iter()
-                            // .cloned() did not work here
-                            .map(|(key, value)| (key.clone(), RefOr::T(value.clone()))),
-                    )
-                }
+                additional_schemas.extend(
+                    schema
+                        .retrive_schemas_from_defs()
+                        .into_iter()
+                        .map(|(key, schema)| (key.to_string(), RefOr::T(schema.clone()))),
+                )
             }
 
             components.schemas.extend(additional_schemas);

--- a/utoipa/src/openapi/defs.rs
+++ b/utoipa/src/openapi/defs.rs
@@ -8,45 +8,51 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::Schema;
+use super::{builder, Schema};
 
-/// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON Schemas
-/// into a more general schema. The keyword does not directly affect the validation result.
-///
-/// This keyword's value MUST be an object. Each member value of this object MUST be a valid
-/// JSON Schema.
-///
-/// As an example, here is a schema describing an array of positive integers, where the
-/// positive integer constraint is a subschema in "$defs":
-/// ```
-/// {
-///     "type": "array",
-///     "items": { "$ref": "#/$defs/positiveInteger" },
-///     "$defs": {
-///         "positiveInteger": {
-///             "type": "integer",
-///             "exclusiveMinimum": 0
-///         }
-///     }
-/// }
-/// ```
-#[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
-#[cfg_attr(feature = "debug", derive(Debug))]
-pub struct Defs(
-    #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
-    BTreeMap<String, Schema>,
-);
+builder! {
+    DefsBuilder;
 
-/// Builder for the [`Defs`]
-pub struct DefsBuilder(BTreeMap<String, Schema>);
+    /// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON Schemas
+    /// into a more general schema. The keyword does not directly affect the validation result.
+    ///
+    /// This keyword's value MUST be an object. Each member value of this object MUST be a valid
+    /// JSON Schema.
+    ///
+    /// As an example, here is a schema describing an array of positive integers, where the
+    /// positive integer constraint is a subschema in "$defs":
+    /// ```
+    /// {
+    ///     "type": "array",
+    ///     "items": { "$ref": "#/$defs/positiveInteger" },
+    ///     "$defs": {
+    ///         "positiveInteger": {
+    ///             "type": "integer",
+    ///             "exclusiveMinimum": 0
+    ///         }
+    ///     }
+    /// }
+    /// ```
+
+    #[derive(Serialize, Deserialize, Default, Clone, PartialEq)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct Defs {
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "$defs")]
+        defs: BTreeMap<String, Schema>,
+    }
+}
 
 impl DefsBuilder {
     /// Extend `$defs`
     ///
     /// Read more:
     /// <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
-    pub fn defs<T: IntoIterator<Item = (String, Schema)>>(mut self, defs: T) -> Self {
-        self.0.extend(defs);
+    pub fn defs<K: Into<String>, V: Into<Schema>, T: IntoIterator<Item = (K, V)>>(
+        mut self,
+        defs: T,
+    ) -> Self {
+        self.defs
+            .extend(defs.into_iter().map(|(k, v)| (k.into(), v.into())));
         self
     }
 
@@ -55,7 +61,7 @@ impl DefsBuilder {
     /// Read more:
     /// <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
     pub fn def<K: Into<String>, V: Into<Schema>>(mut self, key: K, value: V) -> Self {
-        self.0.insert(key.into(), value.into());
+        self.defs.insert(key.into(), value.into());
         self
     }
 }
@@ -63,12 +69,12 @@ impl DefsBuilder {
 impl Defs {
     /// Get internal iterator
     pub fn iter(&self) -> std::collections::btree_map::Iter<String, Schema> {
-        self.0.iter()
+        self.defs.iter()
     }
 
     /// Get internal iterator (mutable)
     pub fn iter_mut(&mut self) -> std::collections::btree_map::IterMut<String, Schema> {
-        self.0.iter_mut()
+        self.defs.iter_mut()
     }
 }
 
@@ -80,13 +86,13 @@ where
     fn from_iter<T: IntoIterator<Item = (K, V)>>(iter: T) -> Self {
         let iter = iter.into_iter().map(|(k, v)| (k.into(), v.into()));
         let defs = BTreeMap::from_iter(iter);
-        Self(defs)
+        Self { defs }
     }
 }
 
 impl From<Defs> for BTreeMap<String, Schema> {
     fn from(value: Defs) -> Self {
-        value.0
+        value.defs
     }
 }
 
@@ -94,13 +100,13 @@ impl Deref for Defs {
     type Target = BTreeMap<String, Schema>;
 
     fn deref(&self) -> &Self::Target {
-        &self.0
+        &self.defs
     }
 }
 
 impl DerefMut for Defs {
     fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
+        &mut self.defs
     }
 }
 
@@ -110,12 +116,11 @@ impl IntoIterator for Defs {
     type IntoIter = std::collections::btree_map::IntoIter<String, Schema>;
 
     fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
+        self.defs.into_iter()
     }
 }
 
 impl Schema {
-
     /// Retrive [`$defs`] keyword for the [`Schema`]
     pub fn defs(&self) -> Option<&Defs> {
         match self {
@@ -126,5 +131,98 @@ impl Schema {
             Schema::AllOf(all_of) => Some(&all_of.defs),
             Schema::AnyOf(any_of) => Some(&any_of.defs),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(missing_docs)]
+pub mod test {
+    use super::*;
+    use crate::openapi::{
+        schema::{SchemaType, Type},
+        ObjectBuilder,
+    };
+
+    const BASIC: &str = r##"
+    {
+        "$defs": {
+            "nonEmptyString": {
+              "type": "string",
+              "minLength": 1
+            },
+            "address": {
+              "type": "object",
+              "properties": {
+                "street": {
+                  "$ref": "#/$defs/nonEmptyString"
+                },
+                "city": {
+                  "$ref": "#/$defs/nonEmptyString"
+                }
+              },
+              "required": ["street", "city"]
+            }
+        }
+    }
+    "##;
+
+    #[test]
+    fn basic_defs() {
+        assert!(serde_json::from_str::<Defs>(BASIC).is_ok());
+    }
+
+    #[test]
+    fn test_builder() {
+        let defs: Defs = DefsBuilder::new()
+            .def(
+                "MySchema",
+                ObjectBuilder::new().schema_type(SchemaType::Type(Type::String)),
+            )
+            .defs([
+                (
+                    "OtherSchema",
+                    ObjectBuilder::new().schema_type(SchemaType::Type(Type::Integer)),
+                ),
+                (
+                    "ThirdSchema",
+                    ObjectBuilder::new().schema_type(SchemaType::Type(Type::Number)),
+                ),
+            ])
+            .def(
+                "FourthSchema",
+                ObjectBuilder::new().schema_type(SchemaType::Type(Type::Array)),
+            )
+            .into();
+
+        let expected_str = r#"
+        {
+            "$defs": {
+                "MySchema": {
+                    "type": "string"
+                },
+                "OtherSchema": {
+                    "type": "integer"
+                },
+                "ThirdSchema": {
+                    "type": "number"
+                },
+                "FourthSchema": {
+                    "type": "array"
+                }
+            }
+        }
+        "#;
+
+        let final_defs = serde_json::to_string_pretty(&defs).unwrap();
+        println!("--------------------------");
+        println!("{final_defs}");
+
+        let expected : Defs = serde_json::from_str(expected_str).unwrap();
+        let final_expected = serde_json::to_string_pretty(&expected).unwrap();
+        println!("{final_expected}");
+        println!("--------------------------");
+
+        assert_eq!(final_defs, final_expected);
+
     }
 }

--- a/utoipa/src/openapi/defs.rs
+++ b/utoipa/src/openapi/defs.rs
@@ -14,6 +14,10 @@ use super::{
     AllOf, Array, Components, Object, OneOf, OpenApi, RefOr, Schema,
 };
 
+
+const DEFS_PREFIX: &str = "#/$defs/";
+const COMPONENTS_PREFIX: &str = "#/components/schemas/";
+
 builder! {
     DefsBuilder;
 
@@ -137,7 +141,7 @@ impl Schema {
         }
     }
 
-    /// Used to replace /#defs/ with openapi /components/schemas/<schema-name>
+    /// Used to replace #/$defs/ with openapi /components/schemas/<schema-name>
     /// for schema (recursively)
     ///
     /// See also: [`RefOr::refs_to_openapi_format`]
@@ -145,7 +149,7 @@ impl Schema {
     /// e.g.
     /// ```json
     /// {
-    ///    "$ref": "/#defs/a/b
+    ///    "$ref": "#/$defs/a/b
     /// }
     /// ```
     ///
@@ -153,7 +157,7 @@ impl Schema {
     ///
     /// ```json
     /// {
-    ///    "$ref": /#components/schemas/<schema-name>/a/b"
+    ///    "$ref": #/components/schemas/<schema-name>/a/b"
     /// }
     /// ```
     pub fn refs_to_openapi_format<SN: AsRef<str>>(&mut self, schema_name: Option<SN>) -> &mut Self {
@@ -364,7 +368,7 @@ impl OpenApi {
         self
     }
 
-    /// Used to replace /#defs/ with openapi /components/schemas/<schema-name>
+    /// Used to replace #/$defs/ with openapi /components/schemas/<schema-name>
     /// for all components schemas (recursively)
     ///
     /// See also: [`RefOr::refs_to_openapi_format`]
@@ -372,7 +376,7 @@ impl OpenApi {
     /// e.g.
     /// ```json
     /// {
-    ///    "$ref": "/#defs/a/b
+    ///    "$ref": "#/$defs/a/b
     /// }
     /// ```
     ///
@@ -380,7 +384,7 @@ impl OpenApi {
     ///
     /// ```json
     /// {
-    ///    "$ref": /#components/schemas/<schema-name>/a/b"
+    ///    "$ref": #/components/schemas/<schema-name>/a/b"
     /// }
     /// ```
     pub fn refs_to_openapi_format<SN: AsRef<str>>(&mut self, schema_name: Option<SN>) -> &mut Self {
@@ -399,16 +403,13 @@ impl OpenApi {
     }
 }
 
-const DEFS_PREFIX: &str = "/#defs/";
-const COMPONENTS_PREFIX: &str = "/#components/schemas/";
-
 impl RefOr<Schema> {
-    /// Used to replace /#defs/ with openapi /components/schemas/<schema-name>
+    /// Used to replace #/$defs/ with openapi /components/schemas/<schema-name>
     ///
     /// e.g.
     /// ```json
     /// {
-    ///    "$ref": "/#defs/a/b
+    ///    "$ref": "#/$defs/a/b
     /// }
     /// ```
     ///
@@ -416,7 +417,7 @@ impl RefOr<Schema> {
     ///
     /// ```json
     /// {
-    ///    "$ref": /#components/schemas/<schema-name>/a/b"
+    ///    "$ref": #/components/schemas/<schema-name>/a/b"
     /// }
     /// ```
     pub fn refs_to_openapi_format<SN: AsRef<str>>(
@@ -720,14 +721,14 @@ pub mod test {
     fn refs_to_openapi_format_simple_ref() {
         let mut simple_ref: RefOr<Schema> = RefOr::Ref(
             RefBuilder::new()
-                .ref_location("/#defs/MyStruct".into())
+                .ref_location("#/$defs/MyStruct".into())
                 .into(),
         );
 
         simple_ref.refs_to_openapi_format(Option::<&str>::None);
 
         match simple_ref {
-            RefOr::Ref(x) => assert_eq!(x.ref_location, "/#components/schemas/MyStruct"),
+            RefOr::Ref(x) => assert_eq!(x.ref_location, "#/components/schemas/MyStruct"),
             RefOr::T(_) => unreachable!(),
         }
     }
@@ -736,7 +737,7 @@ pub mod test {
     fn refs_to_openapi_format_on_schema() {
         let simple_ref: RefOr<Schema> = RefOr::Ref(
             RefBuilder::new()
-                .ref_location("/#defs/MyStruct".into())
+                .ref_location("#/$defs/MyStruct".into())
                 .into(),
         );
 
@@ -756,7 +757,7 @@ pub mod test {
 
         assert_eq!(items.len(), 1);
         match items.first().unwrap() {
-            RefOr::Ref(ref_) => assert_eq!(ref_.ref_location, "/#components/schemas/MyStruct"),
+            RefOr::Ref(ref_) => assert_eq!(ref_.ref_location, "#/components/schemas/MyStruct"),
             RefOr::T(_) => unreachable!(),
         }
     }
@@ -765,7 +766,7 @@ pub mod test {
     fn refs_to_openapi_format_on_openapi() {
         let simple_ref: RefOr<Schema> = RefOr::Ref(
             RefBuilder::new()
-                .ref_location("/#defs/MyStruct".into())
+                .ref_location("#/$defs/MyStruct".into())
                 .into(),
         );
 

--- a/utoipa/src/openapi/defs.rs
+++ b/utoipa/src/openapi/defs.rs
@@ -8,7 +8,7 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use super::{builder, Schema};
+use super::{builder, OpenApi, RefOr, Schema};
 
 builder! {
     DefsBuilder;
@@ -134,13 +134,175 @@ impl Schema {
     }
 }
 
+impl OpenApi {
+    /// Used to extract defs from the direct openapi components schemas as the schemas
+    ///
+    /// e.g.
+    ///
+    /// ```json
+    /// {
+    ///   "openapi": "3.1.0",
+    ///   "info": {
+    ///     "title": "",
+    ///     "version": ""
+    ///   },
+    ///   "paths": {},
+    ///   "components": {
+    ///     "schemas": {
+    ///       "MySchema": {
+    ///         "type": "object",
+    ///         "$defs": {
+    ///           "address": {
+    ///             "type": "object",
+    ///             "required": [
+    ///               "street",
+    ///               "city"
+    ///             ],
+    ///             "properties": {
+    ///               "city": {
+    ///                 "$ref": "#/$defs/nonEmptyString"
+    ///               },
+    ///               "street": {
+    ///                 "$ref": "#/$defs/nonEmptyString"
+    ///               }
+    ///             }
+    ///           },
+    ///           "nonEmptyString": {
+    ///             "type": "string",
+    ///             "minLength": 1
+    ///           }
+    ///         }
+    ///       }
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// becomes
+    /// ```json
+    ///{
+    ///   "openapi": "3.1.0",
+    ///   "info": {
+    ///     "title": "",
+    ///     "version": ""
+    ///   },
+    ///   "paths": {},
+    ///   "components": {
+    ///     "schemas": {
+    ///       "MySchema": {
+    ///         "type": "object",
+    ///         "$defs": {
+    ///           "address": {
+    ///             "type": "object",
+    ///             "required": [
+    ///               "street",
+    ///               "city"
+    ///             ],
+    ///             "properties": {
+    ///               "city": {
+    ///                 "$ref": "#/$defs/nonEmptyString"
+    ///               },
+    ///               "street": {
+    ///                 "$ref": "#/$defs/nonEmptyString"
+    ///               }
+    ///             }
+    ///           },
+    ///           "nonEmptyString": {
+    ///             "type": "string",
+    ///             "minLength": 1
+    ///           }
+    ///         }
+    ///       },
+    ///       "address": {
+    ///         "type": "object",
+    ///         "required": [
+    ///           "street",
+    ///           "city"
+    ///         ],
+    ///         "properties": {
+    ///           "city": {
+    ///             "$ref": "#/$defs/nonEmptyString"
+    ///           },
+    ///           "street": {
+    ///             "$ref": "#/$defs/nonEmptyString"
+    ///           }
+    ///         }
+    ///       },
+    ///       "nonEmptyString": {
+    ///         "type": "string",
+    ///         "minLength": 1
+    ///       }
+    ///     }
+    ///   }
+    /// }
+    /// ```
+    pub fn extract_components_from_schemas_def(&mut self) -> &mut Self {
+        let mut additional_schemas: Vec<(String, RefOr<Schema>)> = Vec::new();
+        if let Some(components) = &mut self.components {
+            for schema in components
+                .schemas
+                .values()
+                .filter_map(|schema| match schema {
+                    RefOr::T(t) => Some(t),
+                    _ => None,
+                })
+            {
+                if let Some(defs) = schema.defs() {
+                    additional_schemas.extend(
+                        defs.iter()
+                            // .cloned() did not work here
+                            .map(|(key, value)| (key.clone(), RefOr::T(value.clone()))),
+                    )
+                }
+            }
+
+            components.schemas.extend(additional_schemas);
+        }
+
+        self
+    }
+}
+
+impl<T> RefOr<T> {
+    /// Used to replace /#defs/ with openapi /components/schemas
+    ///
+    /// e.g.
+    /// ```json
+    /// {
+    ///    "$ref": "/#defs/a/b
+    /// }
+    /// ```
+    ///
+    /// becomes
+    ///
+    /// ```json
+    /// {
+    ///    "$ref": /#components/schemas/a/b"
+    /// }
+    /// ```
+    pub fn root_defs_to_openapi_schemas(&mut self) -> &mut Self {
+        match self {
+            RefOr::Ref(ref_) => {
+                if ref_.ref_location.starts_with("/#defs/") {
+                    ref_.ref_location =
+                        ref_.ref_location
+                            .replacen("/#defs/", "#/components/schemas/", 1);
+                }
+            }
+            RefOr::T(_) => {}
+        }
+
+        self
+    }
+}
+
 #[cfg(test)]
 #[allow(missing_docs)]
 pub mod test {
     use super::*;
     use crate::openapi::{
         schema::{SchemaType, Type},
-        ObjectBuilder,
+        ComponentsBuilder, ObjectBuilder, OpenApiBuilder,
     };
 
     const BASIC: &str = r##"
@@ -217,12 +379,25 @@ pub mod test {
         println!("--------------------------");
         println!("{final_defs}");
 
-        let expected : Defs = serde_json::from_str(expected_str).unwrap();
+        let expected: Defs = serde_json::from_str(expected_str).unwrap();
         let final_expected = serde_json::to_string_pretty(&expected).unwrap();
         println!("{final_expected}");
         println!("--------------------------");
 
         assert_eq!(final_defs, final_expected);
+    }
 
+    #[test]
+    fn additional_schemas_extraction() {
+        let defs = serde_json::from_str(BASIC).unwrap();
+
+        let mut openapi = OpenApiBuilder::new().components(Some(
+            ComponentsBuilder::new()
+                .schema("MySchema", ObjectBuilder::new().defs(defs))
+                .build(),
+        )).build();
+
+        openapi.extract_components_from_schemas_def();
+        assert_eq!(openapi.components.unwrap().schemas.len(), 3);
     }
 }

--- a/utoipa/src/openapi/defs.rs
+++ b/utoipa/src/openapi/defs.rs
@@ -25,7 +25,7 @@ builder! {
     ///
     /// As an example, here is a schema describing an array of positive integers, where the
     /// positive integer constraint is a subschema in "$defs":
-    /// ```
+    /// ```json
     /// {
     ///     "type": "array",
     ///     "items": { "$ref": "#/$defs/positiveInteger" },

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -82,6 +82,16 @@ builder! {
         /// Optional extensions "x-something".
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
         pub extensions: Option<Extensions>,
+
+        /// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON
+        /// Schemas into a more general schema. The keyword does not directly affect the validation
+        /// result.
+        ///
+        ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
+        ///
+        /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
+        pub defs: BTreeMap<String, Schema>,
     }
 }
 
@@ -522,6 +532,16 @@ builder! {
         /// Declares the schema as "write only".
         #[serde(rename = "writeOnly", skip_serializing_if = "Option::is_none")]
         pub write_only: Option<bool>,
+
+        /// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON
+        /// Schemas into a more general schema. The keyword does not directly affect the validation
+        /// result.
+        ///
+        ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
+        ///
+        /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
+        pub defs: BTreeMap<String, Schema>,
     }
 }
 
@@ -567,6 +587,7 @@ impl Default for OneOf {
             extensions: Default::default(),
             read_only: Default::default(),
             write_only: Default::default(),
+            defs: Default::default()
         }
     }
 }
@@ -711,6 +732,16 @@ builder! {
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
         pub extensions: Option<Extensions>,
+
+        /// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON
+        /// Schemas into a more general schema. The keyword does not directly affect the validation
+        /// result.
+        ///
+        ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
+        ///
+        /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
+        pub defs: BTreeMap<String, Schema>,
     }
 }
 
@@ -754,6 +785,7 @@ impl Default for AllOf {
             examples: Default::default(),
             discriminator: Default::default(),
             extensions: Default::default(),
+            defs: Default::default()
         }
     }
 }
@@ -810,6 +842,11 @@ impl AllOfBuilder {
     /// Add openapi extensions (`x-something`) for [`AllOf`].
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Set definitons for the object [`Object::defs`].
+    pub fn defs<S: Into<BTreeMap<String, Schema>>>(mut self, defs: S) -> Self {
+        set_value!(self defs defs.into())
     }
 
     to_array_builder!();
@@ -884,6 +921,16 @@ builder! {
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
         pub extensions: Option<Extensions>,
+
+        /// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON
+        /// Schemas into a more general schema. The keyword does not directly affect the validation
+        /// result.
+        ///
+        ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
+        ///
+        /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
+        pub defs: BTreeMap<String, Schema>,
     }
 }
 
@@ -926,6 +973,7 @@ impl Default for AnyOf {
             examples: Default::default(),
             discriminator: Default::default(),
             extensions: Default::default(),
+            defs: Default::default()
         }
     }
 }
@@ -977,6 +1025,11 @@ impl AnyOfBuilder {
     /// Add openapi extensions (`x-something`) for [`AnyOf`].
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Set definitons for the object [`Object::defs`].
+    pub fn defs<S: Into<BTreeMap<String, Schema>>>(mut self, defs: S) -> Self {
+        set_value!(self defs defs.into())
     }
 
     to_array_builder!();
@@ -1167,7 +1220,9 @@ builder! {
         #[serde(skip_serializing_if = "String::is_empty", default)]
         pub content_media_type: String,
 
-        /// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON Schemas into a more general schema. The keyword does not directly affect the validation result.
+        /// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON
+        /// Schemas into a more general schema. The keyword does not directly affect the validation
+        /// result.
         ///
         ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
         ///
@@ -1831,6 +1886,16 @@ builder! {
         /// Optional extensions `x-something`.
         #[serde(skip_serializing_if = "Option::is_none", flatten)]
         pub extensions: Option<Extensions>,
+
+        /// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON
+        /// Schemas into a more general schema. The keyword does not directly affect the validation
+        /// result.
+        ///
+        ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
+        ///
+        /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
+        pub defs: BTreeMap<String, Schema>,
     }
 }
 
@@ -1853,6 +1918,7 @@ impl Default for Array {
             extensions: Default::default(),
             content_encoding: Default::default(),
             content_media_type: Default::default(),
+            defs: Default::default(),
         }
     }
 }
@@ -1996,6 +2062,11 @@ impl ArrayBuilder {
     /// Add openapi extensions (`x-something`) for [`Array`].
     pub fn extensions(mut self, extensions: Option<Extensions>) -> Self {
         set_value!(self extensions extensions)
+    }
+
+    /// Set definitons for the object [`Object::defs`].
+    pub fn defs<S: Into<BTreeMap<String, Schema>>>(mut self, defs: S) -> Self {
+        set_value!(self defs defs.into())
     }
 
     to_array_builder!();

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -270,10 +270,21 @@ impl ComponentsBuilder {
 ///
 /// [schemas]: https://spec.openapis.org/oas/latest.html#schema-object
 #[non_exhaustive]
+#[allow(clippy::large_enum_variant)]
 #[derive(Serialize, Deserialize, Clone, PartialEq)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 #[serde(untagged, rename_all = "camelCase")]
 pub enum Schema {
+    /// The value of this keyword MAY be of any type, including null.
+    /// Use of this keyword is functionally equivalent to an "enum" (Section 6.1.2) with a single value.
+    ///
+    /// An instance validates successfully against this keyword if its value is equal to the value of the keyword.
+    ///
+    /// Form more see:
+    /// * <https://json-schema.org/draft/2020-12/json-schema-validation#name-const>
+    /// * <https://spec.openapis.org/oas/v3.2.0.html#annotated-enumerations>
+    Const(Const),
+
     /// Defines array schema from another schema. Typically used with
     /// [`Schema::Object`]. Slice and Vec types are translated to [`Schema::Array`] types.
     Array(Array),
@@ -296,6 +307,24 @@ pub enum Schema {
     ///
     /// [composite]: https://spec.openapis.org/oas/latest.html#components-object
     AnyOf(AnyOf),
+}
+
+/// The value of this keyword MAY be of any type, including null.
+/// Use of this keyword is functionally equivalent to an "enum" (Section 6.1.2) with a single value.
+///
+/// An instance validates successfully against this keyword if its value is equal to the value of the keyword.
+///
+/// Form more see:
+/// * <https://json-schema.org/draft/2020-12/json-schema-validation#name-const>
+/// * <https://spec.openapis.org/oas/v3.2.0.html#annotated-enumerations>
+#[non_exhaustive]
+#[derive(Serialize, Deserialize, Clone, PartialEq)]
+#[cfg_attr(feature = "debug", derive(Debug))]
+pub struct Const {
+    #[serde(rename = "const")]
+    const_: Value,
+    #[serde(flatten, default)]
+    annotations: BTreeMap<String, String>,
 }
 
 impl Default for Schema {
@@ -2535,6 +2564,54 @@ mod tests {
             serialized_components,
             serde_json::to_string(&deserialized_components).unwrap()
         )
+    }
+
+    #[test]
+    fn serialize_deserialize_const_keyword() {
+
+        let basic_json = r#"{
+            "const": { "my-complex-key": [1, 2], "x": null, "v": {} },
+            "annotation": "my-annotation",
+            "other": "other",
+            "type": "object"
+        }"#;
+
+        let basic_deserialized: RefOr<Schema> = serde_json::from_str(basic_json).unwrap();
+        assert!(matches!(basic_deserialized, RefOr::T(Schema::Const(_))));
+
+        let deserialized_unwrapped = if let RefOr::T(Schema::Const(const_)) = basic_deserialized {
+            const_
+        } else {
+            unreachable!();
+        };
+
+        assert!(matches!(deserialized_unwrapped.const_, Value::Object(_)));
+        assert_eq!(deserialized_unwrapped.annotations.len(), 3);
+
+        for const_value in [
+            Const {
+                const_: Value::String("Test".into()),
+                annotations: BTreeMap::from([("title".into(), "test".into())]),
+            },
+            Const {
+                const_: Value::String("Test".into()),
+                annotations: BTreeMap::from([("type".into(), "string".into())]),
+            },
+        ] {
+            let const_keyword = RefOr::T(Schema::Const(const_value));
+
+            let json_str = serde_json::to_string(&const_keyword).expect("");
+            println!("----------------------------");
+            println!("{json_str}");
+
+            let deserialized: RefOr<Schema> = serde_json::from_str(&json_str).expect("");
+
+            let json_de_str = serde_json::to_string(&deserialized).expect("");
+            println!("----------------------------");
+            println!("{json_de_str}");
+
+            assert_eq!(json_str, json_de_str);
+        }
     }
 
     #[test]

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -309,24 +309,6 @@ pub enum Schema {
     AnyOf(AnyOf),
 }
 
-/// The value of this keyword MAY be of any type, including null.
-/// Use of this keyword is functionally equivalent to an "enum" (Section 6.1.2) with a single value.
-///
-/// An instance validates successfully against this keyword if its value is equal to the value of the keyword.
-///
-/// Form more see:
-/// * <https://json-schema.org/draft/2020-12/json-schema-validation#name-const>
-/// * <https://spec.openapis.org/oas/v3.2.0.html#annotated-enumerations>
-#[non_exhaustive]
-#[derive(Serialize, Deserialize, Clone, PartialEq)]
-#[cfg_attr(feature = "debug", derive(Debug))]
-pub struct Const {
-    #[serde(rename = "const")]
-    const_: Value,
-    #[serde(flatten, default)]
-    annotations: BTreeMap<String, String>,
-}
-
 impl Default for Schema {
     fn default() -> Self {
         Schema::Object(Object::default())
@@ -408,6 +390,74 @@ impl Discriminator {
             ),
             ..Default::default()
         }
+    }
+}
+
+builder! {
+
+    ConstBuilder;
+
+    /// The value of this keyword MAY be of any type, including null.
+    /// Use of this keyword is functionally equivalent to an "enum" (Section 6.1.2) with a single value.
+    ///
+    /// An instance validates successfully against this keyword if its value is equal to the value of the keyword.
+    ///
+    /// Form more see:
+    /// * <https://json-schema.org/draft/2020-12/json-schema-validation#name-const>
+    /// * <https://spec.openapis.org/oas/v3.2.0.html#annotated-enumerations>
+    #[non_exhaustive]
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Default)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct Const {
+        #[serde(rename = "const")]
+        const_: Value,
+        #[serde(flatten, default)]
+        annotations: BTreeMap<String, String>,
+    }
+}
+
+impl Const {
+    /// Construct a new [`Const`] component.
+    pub fn new(value: Value) -> Self {
+        Self {
+            const_: value,
+            ..Default::default()
+        }
+    }
+
+    /// Construct a new [`Const`] with provided annotations. Annotations describe `const` value
+    pub fn with_annotations(value: Value, annotations: BTreeMap<String, String>) -> Self {
+        Self {
+            const_: value,
+            annotations,
+        }
+    }
+}
+
+impl ConstBuilder {
+    /// Set `const` keyword
+    ///
+    /// Read more: 
+    /// * <https://json-schema.org/draft/2020-12/json-schema-validation#name-const>
+    /// * <https://spec.openapis.org/oas/v3.2.0.html#annotated-enumerations>
+    pub fn const_<T: Into<Value>>(mut self, value: T) -> Self {
+        set_value!(self const_ value.into())
+    }
+
+    /// Extend fields describing `const` value
+    ///
+    /// Read more: <https://spec.openapis.org/oas/v3.2.0.html#annotated-enumerations>
+    pub fn annotations<T: IntoIterator<Item = (String, String)>>(mut self, annotations: T) -> Self {
+        self.annotations.extend(annotations);
+        self
+    }
+
+    /// Add field describing `const` value
+    ///
+    /// Read more: <https://spec.openapis.org/oas/v3.2.0.html#annotated-enumerations>
+    pub fn annotation<K: Into<String>, V: Into<String>>(mut self, key: K, value: V) -> Self {
+        self.annotations.insert(key.into(), value.into());
+        self
     }
 }
 
@@ -2581,7 +2631,6 @@ mod tests {
 
     #[test]
     fn serialize_deserialize_const_keyword() {
-
         let basic_json = r#"{
             "const": { "my-complex-key": [1, 2], "x": null, "v": {} },
             "annotation": "my-annotation",

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -7,6 +7,7 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use super::defs::Defs;
 use super::extensions::Extensions;
 use super::RefOr;
 use super::{builder, security::SecurityScheme, set_value, xml::Xml, Deprecated, Response};
@@ -90,8 +91,8 @@ builder! {
         ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
         ///
         /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
-        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
-        pub defs: BTreeMap<String, Schema>,
+        #[serde(flatten)]
+        pub defs: Defs,
     }
 }
 
@@ -404,7 +405,6 @@ impl Discriminator {
 }
 
 builder! {
-
     ConstBuilder;
 
     /// The value of this keyword MAY be of any type, including null.
@@ -560,8 +560,8 @@ builder! {
         ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
         ///
         /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
-        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
-        pub defs: BTreeMap<String, Schema>,
+        #[serde(flatten)]
+        pub defs: Defs,
     }
 }
 
@@ -760,8 +760,8 @@ builder! {
         ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
         ///
         /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
-        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
-        pub defs: BTreeMap<String, Schema>,
+        #[serde(flatten)]
+        pub defs: Defs,
     }
 }
 
@@ -865,8 +865,8 @@ impl AllOfBuilder {
     }
 
     /// Set definitons for the object [`Object::defs`].
-    pub fn defs<S: Into<BTreeMap<String, Schema>>>(mut self, defs: S) -> Self {
-        set_value!(self defs defs.into())
+    pub fn defs(mut self, defs: Defs) -> Self {
+        set_value!(self defs defs)
     }
 
     to_array_builder!();
@@ -949,8 +949,8 @@ builder! {
         ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
         ///
         /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
-        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
-        pub defs: BTreeMap<String, Schema>,
+        #[serde(flatten)]
+        pub defs: Defs,
     }
 }
 
@@ -1048,8 +1048,8 @@ impl AnyOfBuilder {
     }
 
     /// Set definitons for the object [`Object::defs`].
-    pub fn defs<S: Into<BTreeMap<String, Schema>>>(mut self, defs: S) -> Self {
-        set_value!(self defs defs.into())
+    pub fn defs(mut self, defs: Defs) -> Self {
+        set_value!(self defs defs)
     }
 
     to_array_builder!();
@@ -1247,8 +1247,8 @@ builder! {
         ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
         ///
         /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
-        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
-        pub defs: BTreeMap<String, Schema>,
+        #[serde(flatten)]
+        pub defs: Defs,
     }
 }
 
@@ -1472,8 +1472,8 @@ impl ObjectBuilder {
     }
 
     /// Set definitons for the object [`Object::defs`].
-    pub fn defs<S: Into<BTreeMap<String, Schema>>>(mut self, defs: S) -> Self {
-        set_value!(self defs defs.into())
+    pub fn defs(mut self, defs: Defs) -> Self {
+        set_value!(self defs defs)
     }
 
     to_array_builder!();
@@ -1914,8 +1914,8 @@ builder! {
         ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
         ///
         /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
-        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
-        pub defs: BTreeMap<String, Schema>,
+        #[serde(flatten)]
+        pub defs: Defs,
     }
 }
 
@@ -2085,8 +2085,8 @@ impl ArrayBuilder {
     }
 
     /// Set definitons for the object [`Object::defs`].
-    pub fn defs<S: Into<BTreeMap<String, Schema>>>(mut self, defs: S) -> Self {
-        set_value!(self defs defs.into())
+    pub fn defs(mut self, defs: Defs) -> Self {
+        set_value!(self defs defs)
     }
 
     to_array_builder!();
@@ -3161,5 +3161,12 @@ mod tests {
 
         let value = serde_json::to_value(&json_value).unwrap();
         assert_eq!(value.get("x-some-extension"), Some(&expected));
+    }
+
+    #[test]
+    fn object_with_defs() {
+        let expected = json!("value");
+        let json_value = ObjectBuilder::new().defs(Defs::default()).build();
+        //TODO
     }
 }

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -2093,18 +2093,22 @@ pub enum KnownFormat {
     /// 8 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[cfg_attr(feature = "non_strict_integers", serde(rename = "uint8"))]
     UInt8,
     /// 16 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[cfg_attr(feature = "non_strict_integers", serde(rename = "uint16"))]
     UInt16,
     /// 32 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[cfg_attr(feature = "non_strict_integers", serde(rename = "uint32"))]
     UInt32,
     /// 64 bit unsigned integer.
     #[cfg(feature = "non_strict_integers")]
     #[cfg_attr(doc_cfg, doc(cfg(feature = "non_strict_integers")))]
+    #[cfg_attr(feature = "non_strict_integers", serde(rename = "uint64"))]
     UInt64,
     /// floating point number.
     Float,

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -676,6 +676,11 @@ impl OneOfBuilder {
         set_value!(self write_only Some(write_only))
     }
 
+    /// Set definitons for the object [`Object::defs`].
+    pub fn defs(mut self, defs: Defs) -> Self {
+        set_value!(self defs defs)
+    }
+
     to_array_builder!();
 }
 
@@ -904,6 +909,11 @@ builder! {
     #[derive(Serialize, Deserialize, Clone, PartialEq)]
     #[cfg_attr(feature = "debug", derive(Debug))]
     pub struct AnyOf {
+
+        /// Changes the [`AnyOf`] title.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub title: Option<String>,
+
         /// Components of _AnyOf component.
         #[serde(rename = "anyOf")]
         pub items: Vec<RefOr<Schema>>,
@@ -985,6 +995,7 @@ impl AnyOf {
 impl Default for AnyOf {
     fn default() -> Self {
         Self {
+            title: Default::default(),
             items: Default::default(),
             schema_type: SchemaType::AnyValue,
             description: Default::default(),
@@ -999,6 +1010,11 @@ impl Default for AnyOf {
 }
 
 impl AnyOfBuilder {
+    /// Add or change the title of the [`AnyOf`].
+    pub fn title<I: Into<String>>(mut self, title: Option<I>) -> Self {
+        set_value!(self title title.map(|title| title.into()))
+    }
+
     /// Adds a given [`Schema`] to [`AnyOf`] [Composite Object][composite].
     ///
     /// [composite]: https://spec.openapis.org/oas/latest.html#components-object

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -447,7 +447,7 @@ impl Const {
 impl ConstBuilder {
     /// Set `const` keyword
     ///
-    /// Read more: 
+    /// Read more:
     /// * <https://json-schema.org/draft/2020-12/json-schema-validation#name-const>
     /// * <https://spec.openapis.org/oas/v3.2.0.html#annotated-enumerations>
     pub fn const_<T: Into<Value>>(mut self, value: T) -> Self {
@@ -607,7 +607,7 @@ impl Default for OneOf {
             extensions: Default::default(),
             read_only: Default::default(),
             write_only: Default::default(),
-            defs: Default::default()
+            defs: Default::default(),
         }
     }
 }
@@ -805,7 +805,7 @@ impl Default for AllOf {
             examples: Default::default(),
             discriminator: Default::default(),
             extensions: Default::default(),
-            defs: Default::default()
+            defs: Default::default(),
         }
     }
 }
@@ -993,7 +993,7 @@ impl Default for AnyOf {
             examples: Default::default(),
             discriminator: Default::default(),
             extensions: Default::default(),
-            defs: Default::default()
+            defs: Default::default(),
         }
     }
 }
@@ -3161,12 +3161,5 @@ mod tests {
 
         let value = serde_json::to_value(&json_value).unwrap();
         assert_eq!(value.get("x-some-extension"), Some(&expected));
-    }
-
-    #[test]
-    fn object_with_defs() {
-        let expected = json!("value");
-        let json_value = ObjectBuilder::new().defs(Defs::default()).build();
-        //TODO
     }
 }

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -471,6 +471,26 @@ impl ConstBuilder {
     }
 }
 
+impl From<Const> for Schema {
+    fn from(const_: Const) -> Self {
+        Self::Const(const_)
+    }
+}
+
+impl From<ConstBuilder> for RefOr<Schema> {
+    fn from(const_: ConstBuilder) -> Self {
+        Self::T(Schema::Const(const_.build()))
+    }
+}
+
+impl From<ConstBuilder> for ArrayItems {
+    fn from(value: ConstBuilder) -> Self {
+        Self::RefOrSchema(Box::new(value.into()))
+    }
+}
+
+component_from_builder!(ConstBuilder);
+
 builder! {
     OneOfBuilder;
 

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -1116,6 +1116,14 @@ builder! {
         /// See more details at <https://json-schema.org/understanding-json-schema/reference/non_json_data#contentmediatype>
         #[serde(skip_serializing_if = "String::is_empty", default)]
         pub content_media_type: String,
+
+        /// The "$defs" keyword reserves a location for schema authors to inline re-usable JSON Schemas into a more general schema. The keyword does not directly affect the validation result.
+        ///
+        ///  This keyword's value MUST be an object. Each member value of this object MUST be a valid JSON Schema.
+        ///
+        /// See more: <https://json-schema.org/draft/2020-12/json-schema-core#name-schema-re-use-with-defs>
+        #[serde(skip_serializing_if = "BTreeMap::is_empty", default, rename = "#defs")]
+        pub defs: BTreeMap<String, Schema>,
     }
 }
 
@@ -1336,6 +1344,11 @@ impl ObjectBuilder {
     /// `application/json`.
     pub fn content_media_type<S: Into<String>>(mut self, content_media_type: S) -> Self {
         set_value!(self content_media_type content_media_type.into())
+    }
+
+    /// Set definitons for the object [`Object::defs`].
+    pub fn defs<S: Into<BTreeMap<String, Schema>>>(mut self, defs: S) -> Self {
+        set_value!(self defs defs.into())
     }
 
     to_array_builder!();


### PR DESCRIPTION
## Changes

* Added support for `const` type
* Added support for `$defs`
* Added methods that support changing `$ref` values from imported schemas `/#defs/` to `/#schema/components`
* Added methods allowing extraction of the subschemas from `$defs` keyword to the separate entities
* Multiple tests and docs

### Additional changes
* Fix for the missing title keyword within `AnyOf`

## Why?

Sometimes part of the code has been generated from jsonschema files. In that
case (for the generated structures) `ToSchema` can be implemented by just
loading proper jsonschema file.

## Notes

* I'm aware of #1509, but it was not conforming the jsonschema spec. This PR focuses on closer resemblance of the 2020 spec document
* As of now this PR is built on top of the #1578, due to the usage of the tools
defined there
