### PR TITLE
fix: emit vec![] instead of array literals to avoid large stack arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,14 @@ members = [
 [workspace.dependencies]
 time = { version = ">=0.3, <0.3.52" }
 
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+
+[workspace.lints.clippy]
+# Enforced to guard against regressions of large stack allocations in generated
+# code (see https://github.com/juhaku/utoipa/issues/1454).
+large_stack_arrays = "deny"
+
 [workspace.metadata.publish]
 order = [
     "utoipa-config",

--- a/utoipa-actix-web/Cargo.toml
+++ b/utoipa-actix-web/Cargo.toml
@@ -29,5 +29,5 @@ serde = "1"
 features = []
 rustdoc-args = ["--cfg", "doc_cfg"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true

--- a/utoipa-axum/Cargo.toml
+++ b/utoipa-axum/Cargo.toml
@@ -43,5 +43,5 @@ tower = "0.5"
 features = []
 rustdoc-args = ["--cfg", "doc_cfg"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true

--- a/utoipa-config/Cargo.toml
+++ b/utoipa-config/Cargo.toml
@@ -19,5 +19,5 @@ serde_json = { version = "1.0" }
 features = []
 rustdoc-args = ["--cfg", "doc_cfg"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Fixed
 
+* Emit `vec![...]` instead of stack allocated array literals in generated `ToSchema`/`IntoParams` code to avoid `clippy::large_stack_arrays` and stack overflows for types with many fields (https://github.com/juhaku/utoipa/issues/1454)
 * Avoid degenerate `oneOf` for `Option<_>` with `nullable = false` and `default`/`title`/`description` (https://github.com/juhaku/utoipa/pull/1380)
 * Fix `jiff` type detection when only the `jiff_0_2` feature is enabled (https://github.com/juhaku/utoipa/pull/1575)
 

--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -83,5 +83,5 @@ config = ["dep:utoipa-config", "dep:once_cell"]
 # EXPERIEMENTAL! use with cauntion
 auto_into_responses = []
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -27,7 +27,7 @@ use crate::{
     doc_comment::CommentAttributes,
     parse_utils::LitBoolOrExprPath,
     token_stream::{quote_diagnostics, Diagnostics, ToTokensDiagnostics},
-    Array, OptionExt, Required,
+    OptionExt, Required,
 };
 
 use super::{
@@ -155,12 +155,12 @@ impl ToTokensDiagnostics for IntoParams {
 
                 Ok(param.to_token_stream())
             })
-            .collect::<Result<Array<TokenStream>, Diagnostics>>()?;
+            .collect::<Result<Vec<TokenStream>, Diagnostics>>()?;
 
         tokens.extend(quote! {
             impl #impl_generics utoipa::IntoParams for #ident #ty_generics #where_clause {
                 fn into_params(parameter_in_provider: impl Fn() -> Option<utoipa::openapi::path::ParameterIn>) -> Vec<utoipa::openapi::path::Parameter> {
-                    #params.into_iter().filter(Option::is_some).flatten().collect()
+                    vec![#(#params),*].into_iter().filter(Option::is_some).flatten().collect()
                 }
             }
         });

--- a/utoipa-gen/src/component/schema/enums.rs
+++ b/utoipa-gen/src/component/schema/enums.rs
@@ -969,11 +969,10 @@ impl PlainSchema {
         let schema_type = schema_type.to_token_stream();
         let enum_type = enum_type.as_ref();
         let items = Array::Borrowed(items);
-        let len = items.len();
 
         let plain_enum = quote! {
                 .schema_type(#schema_type)
-                .enum_values::<[#enum_type; #len], #enum_type>(Some(#items))
+                .enum_values::<Vec<#enum_type>, #enum_type>(Some(#items))
         };
 
         Self(plain_enum.to_token_stream())

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -32,9 +32,9 @@ use component::into_params::IntoParams;
 use ext::{PathOperationResolver, PathOperations, PathResolver};
 use openapi::OpenApi;
 use proc_macro::TokenStream;
-use quote::{quote, ToTokens, TokenStreamExt};
+use quote::{quote, ToTokens};
 
-use proc_macro2::{Group, Ident, Punct, TokenStream as TokenStream2};
+use proc_macro2::{Ident, Punct, TokenStream as TokenStream2};
 use syn::{
     bracketed,
     parse::{Parse, ParseStream},
@@ -3164,17 +3164,18 @@ where
             Self::Borrowed(values) => values.iter(),
         };
 
-        tokens.append(Group::new(
-            proc_macro2::Delimiter::Bracket,
-            values
-                .fold(Punctuated::new(), |mut punctuated, item| {
-                    punctuated.push_value(item);
-                    punctuated.push_punct(Punct::new(',', proc_macro2::Spacing::Alone));
+        // Emit `vec![...]` rather than a stack array literal `[...]` to avoid
+        // large stack allocations for wide types (juhaku/utoipa#1454).
+        let items = values
+            .fold(Punctuated::new(), |mut punctuated, item| {
+                punctuated.push_value(item);
+                punctuated.push_punct(Punct::new(',', proc_macro2::Spacing::Alone));
 
-                    punctuated
-                })
-                .to_token_stream(),
-        ));
+                punctuated
+            })
+            .to_token_stream();
+
+        tokens.extend(quote! { vec![#items] });
     }
 }
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3651,3 +3651,35 @@ fn derive_inline_option_ref_with_nullable_false_and_default() {
 
     assert_json_snapshot!(schema);
 }
+
+// Deriving on a wide type must not emit a large stack array (juhaku/utoipa#1454).
+#[test]
+fn derive_schema_with_many_fields_does_not_use_large_stack_arrays() {
+    #![allow(unused)]
+
+    macro_rules! wide_struct {
+        ($name:ident; $($field:ident),+ $(,)?) => {
+            #[derive(ToSchema)]
+            struct $name {
+                $($field: String,)+
+            }
+        };
+    }
+
+    wide_struct!(WideStruct;
+        f000, f001, f002, f003, f004, f005, f006, f007, f008, f009,
+        f010, f011, f012, f013, f014, f015, f016, f017, f018, f019,
+        f020, f021, f022, f023, f024, f025, f026, f027, f028, f029,
+        f030, f031, f032, f033, f034, f035, f036, f037, f038, f039,
+        f040, f041, f042, f043, f044, f045, f046, f047, f048, f049,
+        f050, f051, f052, f053, f054, f055, f056, f057, f058, f059,
+        f060, f061, f062, f063, f064, f065, f066, f067, f068, f069,
+        f070, f071, f072, f073, f074, f075, f076, f077, f078, f079,
+        f080, f081, f082, f083, f084, f085, f086, f087, f088, f089,
+        f090, f091, f092, f093, f094, f095, f096, f097, f098, f099,
+    );
+
+    use utoipa::PartialSchema;
+    let schema = <WideStruct as PartialSchema>::schema();
+    serde_json::to_value(schema).expect("wide schema is JSON serializable");
+}

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -3652,9 +3652,10 @@ fn derive_inline_option_ref_with_nullable_false_and_default() {
     assert_json_snapshot!(schema);
 }
 
-// Deriving on a wide type must not emit a large stack array (juhaku/utoipa#1454).
+// Smoke test: deriving `ToSchema` on a wide struct keeps compiling and produces
+// a valid schema. Related to the large stack array fix (juhaku/utoipa#1454).
 #[test]
-fn derive_schema_with_many_fields_does_not_use_large_stack_arrays() {
+fn derive_schema_with_many_fields_compiles() {
     #![allow(unused)]
 
     macro_rules! wide_struct {

--- a/utoipa-rapidoc/Cargo.toml
+++ b/utoipa-rapidoc/Cargo.toml
@@ -35,5 +35,5 @@ axum = { version = "0.8.4", default-features = false, features = [
 [dev-dependencies]
 utoipa-rapidoc = { path = ".", features = ["actix-web", "axum", "rocket"] }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true

--- a/utoipa-redoc/Cargo.toml
+++ b/utoipa-redoc/Cargo.toml
@@ -33,5 +33,5 @@ axum = { version = "0.8.4", default-features = false, optional = true }
 [dev-dependencies]
 utoipa-redoc = { path = ".", features = ["actix-web", "axum", "rocket"] }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true

--- a/utoipa-scalar/Cargo.toml
+++ b/utoipa-scalar/Cargo.toml
@@ -33,5 +33,5 @@ axum = { version = "0.8.4", default-features = false, optional = true }
 [dev-dependencies]
 utoipa-scalar = { path = ".", features = ["actix-web", "axum", "rocket"] }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true

--- a/utoipa-swagger-ui-vendored/Cargo.toml
+++ b/utoipa-swagger-ui-vendored/Cargo.toml
@@ -11,4 +11,7 @@ categories = ["web-programming"]
 authors = ["Juha Kukkonen <juha7kukkonen@gmail.com>"]
 rust-version.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]

--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -72,5 +72,5 @@ reqwest = { version = "0.13", features = [
 url = { version = "2", optional = true }
 utoipa-swagger-ui-vendored = { version = "0.1", path = "../utoipa-swagger-ui-vendored", optional = true }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true

--- a/utoipa/Cargo.toml
+++ b/utoipa/Cargo.toml
@@ -83,5 +83,5 @@ features = [
 ]
 rustdoc-args = ["--cfg", "doc_cfg"]
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(doc_cfg)'] }
+[lints]
+workspace = true


### PR DESCRIPTION
## This is not a breaking change.

## Summary

Fixes the `clippy::large_stack_arrays` warning and runtime stack overflow when deriving `ToSchema` / `IntoParams` on types with many fields (#1454, #1505).

Builds on #1504 (qarmin's `IntoParams` fix, included here rebased onto latest `master`) and extends it to **all** generated code, including `ToSchema` - the derive users actually hit the overflow with.

## Changes

- **`utoipa-gen/src/lib.rs`** - the shared `Array` tokenizer now emits `vec![...]` instead of a stack array literal `[...]`. One central change covering every call site (`ToSchema`, `IntoParams`, path/openapi builders).
- **`utoipa-gen/src/component/schema/enums.rs`** - `PlainSchema` used `.enum_values::<[T; N], T>(...)`, a turbofish pinning the type to a fixed-size array; updated to `Vec<T>`.
- **`Cargo.toml` + per-crate manifests** - enforce `clippy::large_stack_arrays = "deny"` via `[workspace.lints]`; crates inherit with `[lints] workspace = true`.
- **`utoipa-gen/tests/schema_derive_test.rs`** - regression test deriving a wide (100-field) struct.
- **`utoipa-gen/CHANGELOG.md`** - changelog entry.

Credit to @qarmin for the original `IntoParams` fix in #1504.