### PR TITLE
Refactor documentation in lib.rs

### DIFF
--- a/utoipa-axum/src/lib.rs
+++ b/utoipa-axum/src/lib.rs
@@ -24,9 +24,10 @@
 //! _**Use [`OpenApiRouter`][router] to collect handlers with _`#[utoipa::path]`_ macro to compose service and form OpenAPI spec.**_
 //!
 //! ```rust
-//! # use axum::Json;
-//! # use utoipa::openapi::OpenApi;
-//! # use utoipa_axum::{routes, PathItemExt, router::OpenApiRouter};
+//!  use axum::Json;
+//!  use utoipa::openapi::OpenApi;
+//!  use utoipa_axum::{routes, PathItemExt, router::OpenApiRouter};
+//!
 //!  #[derive(utoipa::ToSchema, serde::Serialize)]
 //!  struct User {
 //!      id: i32,


### PR DESCRIPTION
Updated documentation comments to remove commented-out code.

The goal is to show `use utoipa::openapi::OpenApi;`

Because if we use `use utoipa::OpenApi;` (a trait) this code produces an error