### PR TITLE
Recursively discover flattened fields in maps

### DIFF
--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1576,7 +1576,7 @@ impl<'a, T> Iterator for ChildRefIter<'a, T> {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct FlattenedMapSchema {
     tokens: TokenStream,
-    pub schema_references: Vec<SchemaReference>,
+    schema_references: Vec<SchemaReference>,
 }
 
 impl FlattenedMapSchema {

--- a/utoipa-gen/src/component.rs
+++ b/utoipa-gen/src/component.rs
@@ -1576,6 +1576,7 @@ impl<'a, T> Iterator for ChildRefIter<'a, T> {
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct FlattenedMapSchema {
     tokens: TokenStream,
+    pub schema_references: Vec<SchemaReference>,
 }
 
 impl FlattenedMapSchema {
@@ -1598,7 +1599,7 @@ impl FlattenedMapSchema {
         // additionalProperties denoting the type
         // maps have 2 child schemas and we are interested the second one of them
         // which is used to determine the additional properties
-        let schema_property = ComponentSchema::new(ComponentSchemaProps {
+        let mut schema_property = ComponentSchema::new(ComponentSchemaProps {
             container,
             type_tree: type_tree
                 .children
@@ -1609,6 +1610,7 @@ impl FlattenedMapSchema {
             features,
             description: None,
         })?;
+        let schema_references = std::mem::take(&mut schema_property.schema_references);
         let schema_tokens = schema_property.to_token_stream();
 
         tokens.extend(quote_diagnostics! {
@@ -1621,7 +1623,10 @@ impl FlattenedMapSchema {
         example.to_tokens(&mut tokens)?;
         nullable.to_tokens(&mut tokens)?;
 
-        Ok(Self { tokens })
+        Ok(Self {
+            tokens,
+            schema_references,
+        })
     }
 }
 

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -388,6 +388,9 @@ impl NamedStructSchema {
                     (Property::Schema(schema), false) => {
                         Some(std::mem::take(&mut schema.schema_references))
                     }
+                    (Property::FlattenedMap(schema), false) => {
+                        Some(std::mem::take(&mut schema.schema_references))
+                    }
                     _ => None,
                 }
             })

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -124,39 +124,14 @@ fn derive_flattened_map_ref_property_collects_recursive_schema() {
     struct ApiDoc;
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
-    let schemas = doc
-        .pointer("/components/schemas")
-        .and_then(Value::as_object)
-        .expect("schemas object exists");
 
-    // `Bar` referenced through the flattened `HashMap` must be discovered recursively.
-    assert!(
-        schemas.contains_key("Bar"),
-        "expected `Bar` to be collected recursively, got: {:?}",
-        schemas.keys().collect::<Vec<_>>()
-    );
-    assert_json_snapshot!(schemas, @r###"
-    {
-      "Bar": {
-        "properties": {
-          "value": {
-            "format": "int64",
-            "type": "integer"
-          }
-        },
-        "required": [
-          "value"
-        ],
-        "type": "object"
-      },
-      "Foo": {
-        "additionalProperties": {
-          "$ref": "#/components/schemas/Bar"
-        },
-        "type": "object"
-      }
-    }
-    "###);
+    // `Bar` referenced through the flattened `HashMap` must be discovered recursively
+    // and appear in `components.schemas` without being listed explicitly.
+    assert_value! { doc =>
+        "components.schemas.Foo.additionalProperties.$ref" = r##""#/components/schemas/Bar""##, "Foo flattened map additional properties ref"
+        "components.schemas.Bar.type" = r#""object""#, "Bar recursively discovered type"
+        "components.schemas.Bar.properties.value.format" = r#""int64""#, "Bar value format"
+    };
 }
 
 #[test]

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -105,6 +105,61 @@ fn derive_flattened_map_ref_property() {
 }
 
 #[test]
+fn derive_flattened_map_ref_property_collects_recursive_schema() {
+    #![allow(unused)]
+
+    #[derive(ToSchema)]
+    struct Bar {
+        value: i64,
+    }
+
+    #[derive(ToSchema)]
+    struct Foo {
+        #[serde(flatten)]
+        data: HashMap<String, Bar>,
+    }
+
+    #[derive(OpenApi)]
+    #[openapi(components(schemas(Foo)))]
+    struct ApiDoc;
+
+    let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
+    let schemas = doc
+        .pointer("/components/schemas")
+        .and_then(Value::as_object)
+        .expect("schemas object exists");
+
+    // `Bar` referenced through the flattened `HashMap` must be discovered recursively.
+    assert!(
+        schemas.contains_key("Bar"),
+        "expected `Bar` to be collected recursively, got: {:?}",
+        schemas.keys().collect::<Vec<_>>()
+    );
+    assert_json_snapshot!(schemas, @r###"
+    {
+      "Bar": {
+        "properties": {
+          "value": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "value"
+        ],
+        "type": "object"
+      },
+      "Foo": {
+        "additionalProperties": {
+          "$ref": "#/components/schemas/Bar"
+        },
+        "type": "object"
+      }
+    }
+    "###);
+}
+
+#[test]
 fn derive_enum_with_additional_properties_success() {
     let mode = api_doc! {
         #[schema(default = "Mode1", example = "Mode2")]

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -125,8 +125,6 @@ fn derive_flattened_map_ref_property_collects_recursive_schema() {
 
     let doc = serde_json::to_value(ApiDoc::openapi()).unwrap();
 
-    // `Bar` referenced through the flattened `HashMap` must be discovered recursively
-    // and appear in `components.schemas` without being listed explicitly.
     assert_value! { doc =>
         "components.schemas.Foo.additionalProperties.$ref" = r##""#/components/schemas/Bar""##, "Foo flattened map additional properties ref"
         "components.schemas.Bar.type" = r#""object""#, "Bar recursively discovered type"


### PR DESCRIPTION
This allows the discovered fields to appear in component.schemas without having to explicitly list it as a workaround.

Ran into this issue in our codebase, and confirmed that patching in this fixes.

Fixes #1330