### PR TITLE
Support partially tagged enums

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Add quote_diagnostics! and quote_diagnostics_spanned! macros (https://github.com/juhaku/utoipa/pull/1553)
 * feat(gen): support Display types for security scopes (https://github.com/juhaku/utoipa/pull/1463)
 * Emit `title` and `default` on `RefBuilder` instead of wrapping in `oneOf` when `Option<_>` is non-nullable (https://github.com/juhaku/utoipa/pull/1380)
+* Support untagged variants in enums (https://github.com/juhaku/utoipa/pull/1585)
 
 ### Changed
 

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -855,15 +855,18 @@ impl<'e> EnumSchema<'e> {
         parent: &'e Root<'e>,
         variants: &'e Punctuated<Variant, Comma>,
     ) -> Result<Self, Diagnostics> {
-        let all_unit_not_partially_tagged = variants
+        let variants_without_skipped = variants
             .iter()
-            .map(|variant| {
-                Ok(matches!(variant.fields, Fields::Unit)
-                    && !serde::parse_value(&variant.attrs)?.untagged)
+            .filter_map(|variant| match serde::parse_value(&variant.attrs) {
+                Ok(rules) if rules.skip => None,
+                Ok(rules) => Some(Ok((variant, rules))),
+                Err(diagnostics) => Some(Err(diagnostics)),
             })
-            .collect::<Result<Vec<bool>, Diagnostics>>()?
-            .into_iter()
-            .all(|is_plain| is_plain);
+            .collect::<Result<Vec<_>, Diagnostics>>()?;
+
+        let all_unit_not_partially_tagged = variants_without_skipped
+            .iter()
+            .all(|(variant, rules)| matches!(variant.fields, Fields::Unit) && !rules.untagged);
 
         if all_unit_not_partially_tagged {
             #[cfg(feature = "repr")]
@@ -909,7 +912,7 @@ impl<'e> EnumSchema<'e> {
             }
 
             Ok(Self {
-                schema_type: EnumSchemaType::Plain(PlainEnum::new(parent, variants, features)?),
+                schema_type: EnumSchemaType::Plain(PlainEnum::new(parent, variants_without_skipped, features)?),
                 schema_as,
                 schema_references: Vec::new(),
                 bound,
@@ -926,7 +929,7 @@ impl<'e> EnumSchema<'e> {
             if parent.attributes.has_deprecated() {
                 enum_features.push(Feature::Deprecated(true.into()))
             }
-            let mut mixed_enum = MixedEnum::new(parent, variants, enum_features)?;
+            let mut mixed_enum = MixedEnum::new(parent, variants_without_skipped, enum_features)?;
             let schema_references = std::mem::take(&mut mixed_enum.schema_references);
             Ok(Self {
                 schema_type: EnumSchemaType::Mixed(mixed_enum),

--- a/utoipa-gen/src/component/schema.rs
+++ b/utoipa-gen/src/component/schema.rs
@@ -855,10 +855,17 @@ impl<'e> EnumSchema<'e> {
         parent: &'e Root<'e>,
         variants: &'e Punctuated<Variant, Comma>,
     ) -> Result<Self, Diagnostics> {
-        if variants
+        let all_unit_not_partially_tagged = variants
             .iter()
-            .all(|variant| matches!(variant.fields, Fields::Unit))
-        {
+            .map(|variant| {
+                Ok(matches!(variant.fields, Fields::Unit)
+                    && !serde::parse_value(&variant.attrs)?.untagged)
+            })
+            .collect::<Result<Vec<bool>, Diagnostics>>()?
+            .into_iter()
+            .all(|is_plain| is_plain);
+
+        if all_unit_not_partially_tagged {
             #[cfg(feature = "repr")]
             let mut features = {
                 if parent

--- a/utoipa-gen/src/component/schema/enums.rs
+++ b/utoipa-gen/src/component/schema/enums.rs
@@ -499,7 +499,13 @@ impl MixedEnumContent {
             generics: root.generics,
         };
 
-        let tokens_with_schema_references = match &serde_container.enum_repr {
+        let enum_repr = if variant_serde_rules.untagged {
+            &SerdeEnumRepr::Untagged
+        } else {
+            &serde_container.enum_repr
+        };
+
+        let tokens_with_schema_references = match enum_repr {
             SerdeEnumRepr::ExternallyTagged => {
                 let (enum_features, variant_features) =
                     MixedEnumContent::split_enum_features(variant_features);
@@ -596,7 +602,13 @@ impl MixedEnumContent {
             generics: root.generics,
         };
 
-        let tokens_with_schema_reference = match &serde_container.enum_repr {
+        let enum_repr = if variant_serde_rules.untagged {
+            &SerdeEnumRepr::Untagged
+        } else {
+            &serde_container.enum_repr
+        };
+
+        let tokens_with_schema_reference = match enum_repr {
             SerdeEnumRepr::ExternallyTagged => {
                 let (enum_features, variant_features) =
                     MixedEnumContent::split_enum_features(variant_features);
@@ -682,7 +694,13 @@ impl MixedEnumContent {
         );
         let name = renamed.unwrap_or(Cow::Owned(name));
 
-        match &serde_container.enum_repr {
+        let enum_repr = if variant_serde_rules.untagged {
+            &SerdeEnumRepr::Untagged
+        } else {
+            &serde_container.enum_repr
+        };
+
+        match enum_repr {
             SerdeEnumRepr::ExternallyTagged => EnumSchema::<PlainSchema>::new(name.as_ref())
                 .features(variant_features)
                 .to_token_stream(),

--- a/utoipa-gen/src/component/schema/enums.rs
+++ b/utoipa-gen/src/component/schema/enums.rs
@@ -45,7 +45,7 @@ pub struct PlainEnum<'e> {
 impl<'e> PlainEnum<'e> {
     pub fn new(
         root: &'e Root,
-        variants: &Punctuated<Variant, Comma>,
+        variants_without_skipped: Vec<(&'e Variant, SerdeValue)>,
         mut features: Vec<Feature>,
     ) -> Result<Self, Diagnostics> {
         #[cfg(feature = "repr")]
@@ -58,21 +58,7 @@ impl<'e> PlainEnum<'e> {
         let description = pop_feature!(features => Feature::Description(_) as Option<Description>);
 
         let container_rules = serde::parse_container(root.attributes)?;
-        let variants_iter = variants
-            .iter()
-            .map(|variant| match serde::parse_value(&variant.attrs) {
-                Ok(variant_rules) => Ok((variant, variant_rules)),
-                Err(diagnostics) => Err(diagnostics),
-            })
-            .collect::<Result<Vec<_>, Diagnostics>>()?
-            .into_iter()
-            .filter_map(|(variant, variant_rules)| {
-                if variant_rules.skip {
-                    None
-                } else {
-                    Some((variant, variant_rules))
-                }
-            });
+        let variants_iter = variants_without_skipped.into_iter();
 
         let enum_variant = match repr_type_path {
             Some(repr_type_path) => PlainEnumRepr::Repr(
@@ -247,7 +233,7 @@ pub struct MixedEnum<'p> {
 impl<'p> MixedEnum<'p> {
     pub fn new(
         root: &'p Root,
-        variants: &Punctuated<Variant, Comma>,
+        variants_without_skipped: Vec<(&'p Variant, SerdeValue)>,
         mut features: Vec<Feature>,
     ) -> Result<Self, Diagnostics> {
         let attributes = root.attributes;
@@ -257,58 +243,35 @@ impl<'p> MixedEnum<'p> {
         let description = pop_feature!(features => Feature::Description(_) as Option<Description>);
         let discriminator = pop_feature!(features => Feature::Discriminator(_));
 
-        let variants = variants
-            .iter()
-            .map(|variant| match serde::parse_value(&variant.attrs) {
-                Ok(variant_rules) => Ok((variant, variant_rules)),
-                Err(diagnostics) => Err(diagnostics),
-            })
-            .collect::<Result<Vec<_>, Diagnostics>>()?
+        let variants = variants_without_skipped
             .into_iter()
-            .filter_map(|(variant, variant_rules)| {
-                if variant_rules.skip {
-                    None
-                } else {
-                    let variant_features = match &variant.fields {
-                        Fields::Named(_) => {
-                            match variant
-                                .attrs
-                                .parse_features::<EnumNamedFieldVariantFeatures>()
-                            {
-                                Ok(features) => features.into_inner().unwrap_or_default(),
-                                Err(diagnostics) => return Some(Err(diagnostics)),
-                            }
-                        }
-                        Fields::Unnamed(_) => {
-                            match variant
-                                .attrs
-                                .parse_features::<EnumUnnamedFieldVariantFeatures>()
-                            {
-                                Ok(features) => features.into_inner().unwrap_or_default(),
-                                Err(diagnostics) => return Some(Err(diagnostics)),
-                            }
-                        }
-                        Fields::Unit => {
-                            let parse_unit_features =
-                                features::parse_schema_features_with(&variant.attrs, |input| {
-                                    Ok(parse_features!(
-                                        input as Title,
-                                        Rename,
-                                        Example,
-                                        Examples,
-                                        Deprecated
-                                    ))
-                                });
+            .map(|(variant, variant_rules)| {
+                let variant_features = match &variant.fields {
+                    Fields::Named(_) => variant
+                        .attrs
+                        .parse_features::<EnumNamedFieldVariantFeatures>()?
+                        .into_inner()
+                        .unwrap_or_default(),
+                    Fields::Unnamed(_) => variant
+                        .attrs
+                        .parse_features::<EnumUnnamedFieldVariantFeatures>()?
+                        .into_inner()
+                        .unwrap_or_default(),
+                    Fields::Unit => {
+                        features::parse_schema_features_with(&variant.attrs, |input| {
+                            Ok(parse_features!(
+                                input as Title,
+                                Rename,
+                                Example,
+                                Examples,
+                                Deprecated
+                            ))
+                        })?
+                        .unwrap_or_default()
+                    }
+                };
 
-                            match parse_unit_features {
-                                Ok(features) => features.unwrap_or_default(),
-                                Err(diagnostics) => return Some(Err(diagnostics)),
-                            }
-                        }
-                    };
-
-                    Some(Ok((variant, variant_rules, variant_features)))
-                }
+                Ok((variant, variant_rules, variant_features))
             })
             .collect::<Result<Vec<_>, Diagnostics>>()?;
 

--- a/utoipa-gen/src/component/serde.rs
+++ b/utoipa-gen/src/component/serde.rs
@@ -29,6 +29,7 @@ pub struct SerdeValue {
     pub rename: Option<String>,
     pub default: bool,
     pub flatten: bool,
+    pub untagged: bool,
     pub skip_serializing_if: bool,
     pub double_option: bool,
 }
@@ -67,6 +68,7 @@ impl SerdeValue {
                             .unwrap_or(false);
                     }
                     TokenTree::Ident(ident) if ident == "flatten" => value.flatten = true,
+                    TokenTree::Ident(ident) if ident == "untagged" => value.untagged = true,
                     TokenTree::Ident(ident) if ident == "rename" => {
                         if let Some((literal, _)) = parse_next_lit_str(next) {
                             value.rename = Some(literal)
@@ -240,6 +242,9 @@ pub fn parse_value(attributes: &[Attribute]) -> Result<SerdeValue, Diagnostics> 
             }
             if value.flatten {
                 acc.flatten = value.flatten;
+            }
+            if value.untagged {
+                acc.untagged = value.untagged;
             }
             if value.default {
                 acc.default = value.default;

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -486,8 +486,9 @@ static CONFIG: once_cell::sync::Lazy<utoipa_config::Config> =
 /// * `content = "..."` Supported at the container level, allows [adjacently-tagged enums](https://serde.rs/enum-representations.html#adjacently-tagged).
 ///   This attribute requires that a `tag` is present, otherwise serde will trigger a compile-time
 ///   failure.
-/// * `untagged` Supported at the container level. Allows [untagged
-///   enum representation](https://serde.rs/enum-representations.html#untagged).
+/// * `untagged` Supported at the container level for [untagged enum
+///   representation](https://serde.rs/enum-representations.html#untagged) and at the [variant
+///   level](https://serde.rs/variant-attrs.html#untagged) for untagged variants.
 /// * `default` Supported at the container level and field level according to [serde attributes].
 /// * `deny_unknown_fields` Supported at the container level.
 /// * `flatten` Supported at the field level.

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1284,6 +1284,154 @@ fn derive_mixed_enum_with_ref_serde_untagged_named_fields() {
 }
 
 #[test]
+fn derive_mixed_enum_serde_partially_untagged() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One,
+            #[serde(untagged)]
+            Two(String),
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_untagged_named_fields() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two { m: i32 },
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_untagged_unit_variant() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two,
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn mixed_enum_serde_partially_untagged_unit_variant_proof() {
+    #[derive(Serialize)]
+    enum Foo {
+        One {
+            n: i32,
+        },
+        #[serde(untagged)]
+        Two,
+    }
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"One":{"n":3}}"#
+    );
+    assert_eq!(serde_json::to_string(&Foo::Two).unwrap(), r#"null"#);
+}
+
+#[test]
+fn mixed_enum_serde_partially_untagged_named_fields_proof() {
+    #[derive(Serialize)]
+    enum Foo {
+        One {
+            n: i32,
+        },
+        #[serde(untagged)]
+        Two {
+            m: i32,
+        },
+    }
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"One":{"n":3}}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Two { m: 3 }).unwrap(),
+        r#"{"m":3}"#
+    );
+}
+
+#[test]
+#[ignore = "not implemented"]
+fn derive_unit_variants_serde_partially_untagged() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            TaggedOne,
+            #[serde(untagged)]
+            UntaggedTwo,
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn unit_variants_serde_partially_untagged_proof() {
+    #[derive(Serialize)]
+    enum Foo {
+        TaggedOne,
+        #[serde(untagged)]
+        UntaggedTwo,
+    }
+
+    assert_eq!(
+        serde_json::to_string(&Foo::TaggedOne).unwrap(),
+        r#""TaggedOne""#
+    );
+    assert_eq!(serde_json::to_string(&Foo::UntaggedTwo).unwrap(), r#"null"#);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_untagged_partially_renamed() {
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            #[serde(rename = "First")]
+            One,
+            #[serde(untagged)]
+            Two(usize),
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn mixed_enum_serde_partially_untagged_partially_renamed_proof() {
+    #[derive(Serialize, serde::Deserialize)]
+    enum Foo {
+        #[serde(rename = "First")]
+        One,
+        #[serde(untagged)]
+        Two(usize),
+    }
+
+    assert_eq!(serde_json::to_string(&Foo::One).unwrap(), "\"First\"");
+    assert_eq!(serde_json::to_string(&Foo::Two(5)).unwrap(), "5");
+    assert!(matches!(
+        serde_json::from_str("\"First\"").unwrap(),
+        Foo::One
+    ));
+    assert!(matches!(serde_json::from_str("5").unwrap(), Foo::Two(5)));
+}
+
+#[test]
 fn derive_mixed_enum_with_ref_serde_untagged_named_fields_rename_all() {
     #[derive(Serialize, ToSchema)]
     struct Bar {

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1883,6 +1883,76 @@ fn derive_unit_variants_serde_partially_untagged() {
 }
 
 #[test]
+fn derive_unit_variants_serde_mix_skip_untagged() {
+    #[derive(Serialize)]
+    enum Foo {
+        NormalOne,
+        #[serde(skip)]
+        SkipTwo(u8),
+        #[serde(untagged)]
+        UntaggedThree,
+        #[serde(untagged)]
+        UntaggedFour,
+        #[serde(skip, untagged)]
+        SkipUntaggedFive,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            NormalOne,
+            #[serde(skip)]
+            SkipTwo(u8),
+            #[serde(untagged)]
+            UntaggedThree,
+            #[serde(untagged)]
+            UntaggedFour,
+            #[serde(skip, untagged)]
+            SkipUntaggedFive,
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::NormalOne).unwrap(),
+        r#""NormalOne""#
+    );
+    assert!(serde_json::to_string(&Foo::SkipTwo(42)).is_err());
+    assert_eq!(
+        serde_json::to_string(&Foo::UntaggedThree).unwrap(),
+        r#"null"#
+    );
+    assert!(serde_json::to_string(&Foo::SkipUntaggedFive).is_err());
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_unit_variants_serde_skip_non_unit() {
+    #[derive(Serialize)]
+    enum Foo {
+        One,
+        Two,
+        #[serde(skip)]
+        Three(u8),
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One,
+            Two,
+            #[serde(skip)]
+            Three(u8),
+        }
+    };
+
+    assert_eq!(serde_json::to_string(&Foo::One).unwrap(), r#""One""#);
+    assert!(serde_json::to_string(&Foo::Three(42)).is_err());
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
 fn derive_mixed_enum_serde_partially_untagged_partially_renamed() {
     #[derive(Serialize, Deserialize)]
     enum Foo {

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1832,8 +1832,14 @@ fn derive_mixed_enum_with_enum_ref_serde_partially_adjacently_tagged_named_field
 }
 
 #[test]
-#[ignore = "not implemented"]
 fn derive_unit_variants_serde_partially_untagged() {
+    #[derive(Serialize)]
+    enum Foo {
+        TaggedOne,
+        #[serde(untagged)]
+        UntaggedTwo,
+    }
+
     let value: Value = api_doc! {
         #[derive(Serialize)]
         enum Foo {
@@ -1843,23 +1849,13 @@ fn derive_unit_variants_serde_partially_untagged() {
         }
     };
 
-    assert_json_snapshot!(value);
-}
-
-#[test]
-fn unit_variants_serde_partially_untagged_proof() {
-    #[derive(Serialize)]
-    enum Foo {
-        TaggedOne,
-        #[serde(untagged)]
-        UntaggedTwo,
-    }
-
     assert_eq!(
         serde_json::to_string(&Foo::TaggedOne).unwrap(),
         r#""TaggedOne""#
     );
     assert_eq!(serde_json::to_string(&Foo::UntaggedTwo).unwrap(), r#"null"#);
+
+    assert_json_snapshot!(value);
 }
 
 #[test]

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1484,7 +1484,9 @@ fn derive_mixed_enum_serde_partially_adjacently_tagged_named_fields() {
 fn derive_mixed_enum_serde_partially_untagged_unit_variant() {
     #[derive(Serialize)]
     enum Foo {
-        One { n: i32 },
+        One {
+            n: i32,
+        },
         #[serde(untagged)]
         Two,
     }
@@ -1512,7 +1514,9 @@ fn derive_mixed_enum_serde_partially_internally_tagged_unit_variant() {
     #[derive(Serialize)]
     #[serde(tag = "type")]
     enum Foo {
-        One { n: i32 },
+        One {
+            n: i32,
+        },
         #[serde(untagged)]
         Two,
     }
@@ -1541,7 +1545,9 @@ fn derive_mixed_enum_serde_partially_adjacently_tagged_unit_variant() {
     #[derive(Serialize)]
     #[serde(tag = "type", content = "content")]
     enum Foo {
-        One { n: i32 },
+        One {
+            n: i32,
+        },
         #[serde(untagged)]
         Two,
     }
@@ -1575,9 +1581,13 @@ fn derive_mixed_enum_with_ref_serde_partially_untagged_named_fields() {
 
     #[derive(Serialize)]
     enum Foo {
-        One { n: i32 },
+        One {
+            n: i32,
+        },
         #[serde(untagged)]
-        Two { bar: Bar },
+        Two {
+            bar: Bar,
+        },
     }
 
     let value: Value = api_doc! {
@@ -1618,9 +1628,13 @@ fn derive_mixed_enum_with_ref_serde_partially_internally_tagged_named_fields() {
     #[derive(Serialize)]
     #[serde(tag = "type")]
     enum Foo {
-        One { n: i32 },
+        One {
+            n: i32,
+        },
         #[serde(untagged)]
-        Two { bar: Bar },
+        Two {
+            bar: Bar,
+        },
     }
 
     let value: Value = api_doc! {
@@ -1662,9 +1676,13 @@ fn derive_mixed_enum_with_ref_serde_partially_adjacently_tagged_named_fields() {
     #[derive(Serialize)]
     #[serde(tag = "type", content = "content")]
     enum Foo {
-        One { n: i32 },
+        One {
+            n: i32,
+        },
         #[serde(untagged)]
-        Two { bar: Bar },
+        Two {
+            bar: Bar,
+        },
     }
 
     let value: Value = api_doc! {
@@ -1705,7 +1723,9 @@ fn derive_mixed_enum_with_enum_ref_serde_partially_untagged_named_fields() {
 
     #[derive(Serialize)]
     enum Foo {
-        One { n: i32 },
+        One {
+            n: i32,
+        },
         #[serde(untagged)]
         Other(Bar),
     }
@@ -1731,7 +1751,7 @@ fn derive_mixed_enum_with_enum_ref_serde_partially_untagged_named_fields() {
         r#"{"One":{"n":3}}"#
     );
     assert_eq!(
-        serde_json::to_string(&Foo::Other(Bar::Two{ m: "baz".into() })).unwrap(),
+        serde_json::to_string(&Foo::Other(Bar::Two { m: "baz".into() })).unwrap(),
         r#"{"Two":{"m":"baz"}}"#
     );
 
@@ -1750,7 +1770,9 @@ fn derive_mixed_enum_with_enum_ref_serde_partially_internally_tagged_named_field
     #[derive(Serialize)]
     #[serde(tag = "type")]
     enum Foo {
-        One { n: i32 },
+        One {
+            n: i32,
+        },
         #[serde(untagged)]
         Other(Bar),
     }
@@ -1777,7 +1799,7 @@ fn derive_mixed_enum_with_enum_ref_serde_partially_internally_tagged_named_field
         r#"{"type":"One","n":3}"#
     );
     assert_eq!(
-        serde_json::to_string(&Foo::Other(Bar::Two{ m: "baz".into() })).unwrap(),
+        serde_json::to_string(&Foo::Other(Bar::Two { m: "baz".into() })).unwrap(),
         r#"{"Two":{"m":"baz"}}"#
     );
 
@@ -1796,7 +1818,9 @@ fn derive_mixed_enum_with_enum_ref_serde_partially_adjacently_tagged_named_field
     #[derive(Serialize)]
     #[serde(tag = "type", content = "content")]
     enum Foo {
-        One { n: i32 },
+        One {
+            n: i32,
+        },
         #[serde(untagged)]
         Other(Bar),
     }
@@ -1823,7 +1847,7 @@ fn derive_mixed_enum_with_enum_ref_serde_partially_adjacently_tagged_named_field
         r#"{"type":"One","content":{"n":3}}"#
     );
     assert_eq!(
-        serde_json::to_string(&Foo::Other(Bar::Two{ m: "baz".into() })).unwrap(),
+        serde_json::to_string(&Foo::Other(Bar::Two { m: "baz".into() })).unwrap(),
         r#"{"Two":{"m":"baz"}}"#
     );
 

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1285,6 +1285,13 @@ fn derive_mixed_enum_with_ref_serde_untagged_named_fields() {
 
 #[test]
 fn derive_mixed_enum_serde_partially_untagged() {
+    #[derive(Serialize)]
+    enum Foo {
+        One,
+        #[serde(untagged)]
+        Two(String),
+    }
+
     let value: Value = api_doc! {
         #[derive(Serialize)]
         enum Foo {
@@ -1293,6 +1300,76 @@ fn derive_mixed_enum_serde_partially_untagged() {
             Two(String),
         }
     };
+
+    assert_eq!(serde_json::to_string(&Foo::One).unwrap(), r#""One""#);
+    assert_eq!(
+        serde_json::to_string(&Foo::Two("baz".into())).unwrap(),
+        r#""baz""#
+    );
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_internally_tagged() {
+    #[derive(Serialize)]
+    #[serde(tag = "type")]
+    enum Foo {
+        One,
+        #[serde(untagged)]
+        Two(String),
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type")]
+        enum Foo {
+            One,
+            #[serde(untagged)]
+            Two(String),
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One).unwrap(),
+        r#"{"type":"One"}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Two("baz".into())).unwrap(),
+        r#""baz""#
+    );
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_adjacently_tagged() {
+    #[derive(Serialize)]
+    #[serde(tag = "type", content = "content")]
+    enum Foo {
+        One,
+        #[serde(untagged)]
+        Two(String),
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type", content = "content")]
+        enum Foo {
+            One,
+            #[serde(untagged)]
+            Two(String),
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One).unwrap(),
+        r#"{"type":"One"}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Two("baz".into())).unwrap(),
+        r#""baz""#
+    );
 
     assert_json_snapshot!(value);
 }
@@ -1332,6 +1409,78 @@ fn derive_mixed_enum_serde_partially_untagged_named_fields() {
 }
 
 #[test]
+fn derive_mixed_enum_serde_partially_internally_tagged_named_fields() {
+    #[derive(Serialize)]
+    #[serde(tag = "type")]
+    enum Foo {
+        One {
+            n: i32,
+        },
+        #[serde(untagged)]
+        Two {
+            m: i32,
+        },
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type")]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two { m: i32 },
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"type":"One","n":3}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Two { m: 3 }).unwrap(),
+        r#"{"m":3}"#
+    );
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_adjacently_tagged_named_fields() {
+    #[derive(Serialize)]
+    #[serde(tag = "type", content = "content")]
+    enum Foo {
+        One {
+            n: i32,
+        },
+        #[serde(untagged)]
+        Two {
+            m: i32,
+        },
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type", content = "content")]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two { m: i32 },
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"type":"One","content":{"n":3}}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Two { m: 3 }).unwrap(),
+        r#"{"m":3}"#
+    );
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
 fn derive_mixed_enum_serde_partially_untagged_unit_variant() {
     #[derive(Serialize)]
     enum Foo {
@@ -1359,11 +1508,76 @@ fn derive_mixed_enum_serde_partially_untagged_unit_variant() {
 }
 
 #[test]
+fn derive_mixed_enum_serde_partially_internally_tagged_unit_variant() {
+    #[derive(Serialize)]
+    #[serde(tag = "type")]
+    enum Foo {
+        One { n: i32 },
+        #[serde(untagged)]
+        Two,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type")]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two,
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"type":"One","n":3}"#
+    );
+    assert_eq!(serde_json::to_string(&Foo::Two).unwrap(), r#"null"#);
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_adjacently_tagged_unit_variant() {
+    #[derive(Serialize)]
+    #[serde(tag = "type", content = "content")]
+    enum Foo {
+        One { n: i32 },
+        #[serde(untagged)]
+        Two,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type", content = "content")]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two,
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"type":"One","content":{"n":3}}"#
+    );
+    assert_eq!(serde_json::to_string(&Foo::Two).unwrap(), r#"null"#);
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
 fn derive_mixed_enum_with_ref_serde_partially_untagged_named_fields() {
     #[derive(Serialize, ToSchema)]
     struct Bar {
         name: String,
         age: u32,
+    }
+
+    #[derive(Serialize)]
+    enum Foo {
+        One { n: i32 },
+        #[serde(untagged)]
+        Two { bar: Bar },
     }
 
     let value: Value = api_doc! {
@@ -1374,6 +1588,109 @@ fn derive_mixed_enum_with_ref_serde_partially_untagged_named_fields() {
             Two { bar: Bar },
         }
     };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"One":{"n":3}}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Two {
+            bar: Bar {
+                name: "baz".into(),
+                age: 13
+            }
+        })
+        .unwrap(),
+        r#"{"bar":{"name":"baz","age":13}}"#
+    );
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_with_ref_serde_partially_internally_tagged_named_fields() {
+    #[derive(Serialize, ToSchema)]
+    struct Bar {
+        name: String,
+        age: u32,
+    }
+
+    #[derive(Serialize)]
+    #[serde(tag = "type")]
+    enum Foo {
+        One { n: i32 },
+        #[serde(untagged)]
+        Two { bar: Bar },
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type")]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two { bar: Bar },
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"type":"One","n":3}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Two {
+            bar: Bar {
+                name: "baz".into(),
+                age: 13
+            }
+        })
+        .unwrap(),
+        r#"{"bar":{"name":"baz","age":13}}"#
+    );
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_with_ref_serde_partially_adjacently_tagged_named_fields() {
+    #[derive(Serialize, ToSchema)]
+    struct Bar {
+        name: String,
+        age: u32,
+    }
+
+    #[derive(Serialize)]
+    #[serde(tag = "type", content = "content")]
+    enum Foo {
+        One { n: i32 },
+        #[serde(untagged)]
+        Two { bar: Bar },
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type", content = "content")]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two { bar: Bar },
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"type":"One","content":{"n":3}}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Two {
+            bar: Bar {
+                name: "baz".into(),
+                age: 13
+            }
+        })
+        .unwrap(),
+        r#"{"bar":{"name":"baz","age":13}}"#
+    );
 
     assert_json_snapshot!(value);
 }
@@ -1412,6 +1729,98 @@ fn derive_mixed_enum_with_enum_ref_serde_partially_untagged_named_fields() {
     assert_eq!(
         serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
         r#"{"One":{"n":3}}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Other(Bar::Two{ m: "baz".into() })).unwrap(),
+        r#"{"Two":{"m":"baz"}}"#
+    );
+
+    assert_json_snapshot!(bar_value);
+    assert_json_snapshot!(foo_value);
+}
+
+#[test]
+fn derive_mixed_enum_with_enum_ref_serde_partially_internally_tagged_named_fields() {
+    #[derive(Serialize, ToSchema)]
+    enum Bar {
+        Two { m: String },
+        Three { o: u64 },
+    }
+
+    #[derive(Serialize)]
+    #[serde(tag = "type")]
+    enum Foo {
+        One { n: i32 },
+        #[serde(untagged)]
+        Other(Bar),
+    }
+
+    let bar_value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Bar {
+            Two { m: String },
+            Three { o: u64 },
+        }
+    };
+    let foo_value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type")]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Other(Bar),
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"type":"One","n":3}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Other(Bar::Two{ m: "baz".into() })).unwrap(),
+        r#"{"Two":{"m":"baz"}}"#
+    );
+
+    assert_json_snapshot!(bar_value);
+    assert_json_snapshot!(foo_value);
+}
+
+#[test]
+fn derive_mixed_enum_with_enum_ref_serde_partially_adjacently_tagged_named_fields() {
+    #[derive(Serialize, ToSchema)]
+    enum Bar {
+        Two { m: String },
+        Three { o: u64 },
+    }
+
+    #[derive(Serialize)]
+    #[serde(tag = "type", content = "content")]
+    enum Foo {
+        One { n: i32 },
+        #[serde(untagged)]
+        Other(Bar),
+    }
+
+    let bar_value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Bar {
+            Two { m: String },
+            Three { o: u64 },
+        }
+    };
+    let foo_value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type", content = "content")]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Other(Bar),
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"type":"One","content":{"n":3}}"#
     );
     assert_eq!(
         serde_json::to_string(&Foo::Other(Bar::Two{ m: "baz".into() })).unwrap(),
@@ -1477,6 +1886,78 @@ fn derive_mixed_enum_serde_partially_untagged_partially_renamed() {
     assert_eq!(serde_json::to_string(&Foo::Two(5)).unwrap(), "5");
     assert!(matches!(
         serde_json::from_str("\"First\"").unwrap(),
+        Foo::One
+    ));
+    assert!(matches!(serde_json::from_str("5").unwrap(), Foo::Two(5)));
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_internally_tagged_partially_renamed() {
+    #[derive(Serialize, Deserialize)]
+    #[serde(tag = "type")]
+    enum Foo {
+        #[serde(rename = "First")]
+        One,
+        #[serde(untagged)]
+        Two(usize),
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type")]
+        enum Foo {
+            #[serde(rename = "First")]
+            One,
+            #[serde(untagged)]
+            Two(usize),
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One).unwrap(),
+        r#"{"type":"First"}"#
+    );
+    assert_eq!(serde_json::to_string(&Foo::Two(5)).unwrap(), "5");
+    assert!(matches!(
+        serde_json::from_str(r#"{"type":"First"}"#).unwrap(),
+        Foo::One
+    ));
+    assert!(matches!(serde_json::from_str("5").unwrap(), Foo::Two(5)));
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_adjacently_tagged_partially_renamed() {
+    #[derive(Serialize, Deserialize)]
+    #[serde(tag = "type", content = "content")]
+    enum Foo {
+        #[serde(rename = "First")]
+        One,
+        #[serde(untagged)]
+        Two(usize),
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        #[serde(tag = "type", content = "content")]
+        enum Foo {
+            #[serde(rename = "First")]
+            One,
+            #[serde(untagged)]
+            Two(usize),
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One).unwrap(),
+        r#"{"type":"First"}"#
+    );
+    assert_eq!(serde_json::to_string(&Foo::Two(5)).unwrap(), "5");
+    assert!(matches!(
+        serde_json::from_str(r#"{"type":"First"}"#).unwrap(),
         Foo::One
     ));
     assert!(matches!(serde_json::from_str("5").unwrap(), Foo::Two(5)));

--- a/utoipa-gen/tests/schema_derive_test.rs
+++ b/utoipa-gen/tests/schema_derive_test.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, cell::RefCell, collections::HashMap, marker::PhantomData};
 
 use insta::assert_json_snapshot;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use utoipa::openapi::{Object, ObjectBuilder};
 use utoipa::{OpenApi, ToSchema};
@@ -1299,52 +1299,6 @@ fn derive_mixed_enum_serde_partially_untagged() {
 
 #[test]
 fn derive_mixed_enum_serde_partially_untagged_named_fields() {
-    let value: Value = api_doc! {
-        #[derive(Serialize)]
-        enum Foo {
-            One { n: i32 },
-            #[serde(untagged)]
-            Two { m: i32 },
-        }
-    };
-
-    assert_json_snapshot!(value);
-}
-
-#[test]
-fn derive_mixed_enum_serde_partially_untagged_unit_variant() {
-    let value: Value = api_doc! {
-        #[derive(Serialize)]
-        enum Foo {
-            One { n: i32 },
-            #[serde(untagged)]
-            Two,
-        }
-    };
-
-    assert_json_snapshot!(value);
-}
-
-#[test]
-fn mixed_enum_serde_partially_untagged_unit_variant_proof() {
-    #[derive(Serialize)]
-    enum Foo {
-        One {
-            n: i32,
-        },
-        #[serde(untagged)]
-        Two,
-    }
-
-    assert_eq!(
-        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
-        r#"{"One":{"n":3}}"#
-    );
-    assert_eq!(serde_json::to_string(&Foo::Two).unwrap(), r#"null"#);
-}
-
-#[test]
-fn mixed_enum_serde_partially_untagged_named_fields_proof() {
     #[derive(Serialize)]
     enum Foo {
         One {
@@ -1356,6 +1310,15 @@ fn mixed_enum_serde_partially_untagged_named_fields_proof() {
         },
     }
 
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two { m: i32 },
+        }
+    };
+
     assert_eq!(
         serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
         r#"{"One":{"n":3}}"#
@@ -1364,6 +1327,99 @@ fn mixed_enum_serde_partially_untagged_named_fields_proof() {
         serde_json::to_string(&Foo::Two { m: 3 }).unwrap(),
         r#"{"m":3}"#
     );
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_serde_partially_untagged_unit_variant() {
+    #[derive(Serialize)]
+    enum Foo {
+        One { n: i32 },
+        #[serde(untagged)]
+        Two,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two,
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"One":{"n":3}}"#
+    );
+    assert_eq!(serde_json::to_string(&Foo::Two).unwrap(), r#"null"#);
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_with_ref_serde_partially_untagged_named_fields() {
+    #[derive(Serialize, ToSchema)]
+    struct Bar {
+        name: String,
+        age: u32,
+    }
+
+    let value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Two { bar: Bar },
+        }
+    };
+
+    assert_json_snapshot!(value);
+}
+
+#[test]
+fn derive_mixed_enum_with_enum_ref_serde_partially_untagged_named_fields() {
+    #[derive(Serialize, ToSchema)]
+    enum Bar {
+        Two { m: String },
+        Three { o: u64 },
+    }
+
+    #[derive(Serialize)]
+    enum Foo {
+        One { n: i32 },
+        #[serde(untagged)]
+        Other(Bar),
+    }
+
+    let bar_value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Bar {
+            Two { m: String },
+            Three { o: u64 },
+        }
+    };
+    let foo_value: Value = api_doc! {
+        #[derive(Serialize)]
+        enum Foo {
+            One { n: i32 },
+            #[serde(untagged)]
+            Other(Bar),
+        }
+    };
+
+    assert_eq!(
+        serde_json::to_string(&Foo::One { n: 3 }).unwrap(),
+        r#"{"One":{"n":3}}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&Foo::Other(Bar::Two{ m: "baz".into() })).unwrap(),
+        r#"{"Two":{"m":"baz"}}"#
+    );
+
+    assert_json_snapshot!(bar_value);
+    assert_json_snapshot!(foo_value);
 }
 
 #[test]
@@ -1399,6 +1455,14 @@ fn unit_variants_serde_partially_untagged_proof() {
 
 #[test]
 fn derive_mixed_enum_serde_partially_untagged_partially_renamed() {
+    #[derive(Serialize, Deserialize)]
+    enum Foo {
+        #[serde(rename = "First")]
+        One,
+        #[serde(untagged)]
+        Two(usize),
+    }
+
     let value: Value = api_doc! {
         #[derive(Serialize)]
         enum Foo {
@@ -1409,19 +1473,6 @@ fn derive_mixed_enum_serde_partially_untagged_partially_renamed() {
         }
     };
 
-    assert_json_snapshot!(value);
-}
-
-#[test]
-fn mixed_enum_serde_partially_untagged_partially_renamed_proof() {
-    #[derive(Serialize, serde::Deserialize)]
-    enum Foo {
-        #[serde(rename = "First")]
-        One,
-        #[serde(untagged)]
-        Two(usize),
-    }
-
     assert_eq!(serde_json::to_string(&Foo::One).unwrap(), "\"First\"");
     assert_eq!(serde_json::to_string(&Foo::Two(5)).unwrap(), "5");
     assert!(matches!(
@@ -1429,6 +1480,8 @@ fn mixed_enum_serde_partially_untagged_partially_renamed_proof() {
         Foo::One
     ));
     assert!(matches!(serde_json::from_str("5").unwrap(), Foo::Two(5)));
+
+    assert_json_snapshot!(value);
 }
 
 #[test]

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_adjacently_tagged.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_adjacently_tagged.snap
@@ -1,0 +1,25 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_adjacently_tagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_adjacently_tagged_named_fields.snap
@@ -1,0 +1,47 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "content": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "m": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "m"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_adjacently_tagged_partially_renamed.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_adjacently_tagged_partially_renamed.snap
@@ -1,0 +1,26 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "type": {
+          "enum": [
+            "First"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "minimum": 0,
+      "type": "integer"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_adjacently_tagged_unit_variant.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_adjacently_tagged_unit_variant.snap
@@ -1,0 +1,39 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "content": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "default": null,
+      "type": "null"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_internally_tagged.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_internally_tagged.snap
@@ -1,0 +1,25 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_internally_tagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_internally_tagged_named_fields.snap
@@ -1,0 +1,39 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "n": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "n",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "m": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "m"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_internally_tagged_partially_renamed.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_internally_tagged_partially_renamed.snap
@@ -1,0 +1,26 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "type": {
+          "enum": [
+            "First"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "minimum": 0,
+      "type": "integer"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_internally_tagged_unit_variant.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_internally_tagged_unit_variant.snap
@@ -1,0 +1,31 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "n": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "n",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "default": null,
+      "type": "null"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged.snap
@@ -1,0 +1,17 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "enum": [
+        "One"
+      ],
+      "type": "string"
+    },
+    {
+      "type": "string"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_named_fields.snap
@@ -1,0 +1,40 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "One": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "One"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "m": {
+          "format": "int32",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "m"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_partially_renamed.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_partially_renamed.snap
@@ -1,0 +1,18 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "enum": [
+        "First"
+      ],
+      "type": "string"
+    },
+    {
+      "minimum": 0,
+      "type": "integer"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_unit_variant.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_serde_partially_untagged_unit_variant.snap
@@ -1,0 +1,32 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "One": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "One"
+      ],
+      "type": "object"
+    },
+    {
+      "default": null,
+      "type": "null"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_adjacently_tagged_named_fields-2.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_adjacently_tagged_named_fields-2.snap
@@ -1,0 +1,38 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: foo_value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "content": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "$ref": "#/components/schemas/Bar"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_adjacently_tagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_adjacently_tagged_named_fields.snap
@@ -1,0 +1,48 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: bar_value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "Two": {
+          "properties": {
+            "m": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "m"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "Two"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "Three": {
+          "properties": {
+            "o": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "o"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "Three"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_internally_tagged_named_fields-2.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_internally_tagged_named_fields-2.snap
@@ -1,0 +1,30 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: foo_value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "n": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "n",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "$ref": "#/components/schemas/Bar"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_internally_tagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_internally_tagged_named_fields.snap
@@ -1,0 +1,48 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: bar_value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "Two": {
+          "properties": {
+            "m": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "m"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "Two"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "Three": {
+          "properties": {
+            "o": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "o"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "Three"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_untagged_named_fields-2.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_untagged_named_fields-2.snap
@@ -1,0 +1,31 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: foo_value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "One": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "One"
+      ],
+      "type": "object"
+    },
+    {
+      "$ref": "#/components/schemas/Bar"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_untagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_enum_ref_serde_partially_untagged_named_fields.snap
@@ -1,0 +1,48 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: bar_value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "Two": {
+          "properties": {
+            "m": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "m"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "Two"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "Three": {
+          "properties": {
+            "o": {
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "o"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "Three"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_ref_serde_partially_adjacently_tagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_ref_serde_partially_adjacently_tagged_named_fields.snap
@@ -1,0 +1,46 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "content": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        },
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "content",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "bar": {
+          "$ref": "#/components/schemas/Bar"
+        }
+      },
+      "required": [
+        "bar"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_ref_serde_partially_internally_tagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_ref_serde_partially_internally_tagged_named_fields.snap
@@ -1,0 +1,38 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "n": {
+          "format": "int32",
+          "type": "integer"
+        },
+        "type": {
+          "enum": [
+            "One"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "n",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "bar": {
+          "$ref": "#/components/schemas/Bar"
+        }
+      },
+      "required": [
+        "bar"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_ref_serde_partially_untagged_named_fields.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_mixed_enum_with_ref_serde_partially_untagged_named_fields.snap
@@ -1,0 +1,39 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "properties": {
+        "One": {
+          "properties": {
+            "n": {
+              "format": "int32",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "n"
+          ],
+          "type": "object"
+        }
+      },
+      "required": [
+        "One"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "bar": {
+          "$ref": "#/components/schemas/Bar"
+        }
+      },
+      "required": [
+        "bar"
+      ],
+      "type": "object"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_unit_variants_serde_mix_skip_untagged.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_unit_variants_serde_mix_skip_untagged.snap
@@ -1,0 +1,22 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "enum": [
+        "NormalOne"
+      ],
+      "type": "string"
+    },
+    {
+      "default": null,
+      "type": "null"
+    },
+    {
+      "default": null,
+      "type": "null"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_unit_variants_serde_partially_untagged.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_unit_variants_serde_partially_untagged.snap
@@ -1,0 +1,18 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "oneOf": [
+    {
+      "enum": [
+        "TaggedOne"
+      ],
+      "type": "string"
+    },
+    {
+      "default": null,
+      "type": "null"
+    }
+  ]
+}

--- a/utoipa-gen/tests/snapshots/schema_derive_test__derive_unit_variants_serde_skip_non_unit.snap
+++ b/utoipa-gen/tests/snapshots/schema_derive_test__derive_unit_variants_serde_skip_non_unit.snap
@@ -1,0 +1,11 @@
+---
+source: utoipa-gen/tests/schema_derive_test.rs
+expression: value
+---
+{
+  "enum": [
+    "One",
+    "Two"
+  ],
+  "type": "string"
+}


### PR DESCRIPTION
Heavily based on #1521 - merge conflicts fixed, with additional tests added for the internally tagged and adjacently tagged serde options.

In addition, this now supports untagged members on plain enums, which were not implemented in the initial PR.

---

### Original PR Message

See here: https://serde.rs/variant-attrs.html#untagged

> Irrespective of the enum representation, serialize and deserialize this variant as untagged, i.e. simply as the variant's data with no record of the variant name.

For a simple example:

```rust
enum SomeEnum {
    Tagged(u32)
    #[serde(untagged)]
    Untagged(u32)
}
```

This would serialize to an optionally tagged integer:

```json
{"Tagged": 3}
3
```

With resulting JSON Schema:

```json
{
    "oneOf": [
        {"type": "object", "properties": {"Tagged": {"type": "integer"} }, "required": ["Tagged"] },
        {"type": "integer"}
    ]
}
```

---

Somewhat related, but __NOT__ implemented in this PR (as it seems like it will take some deeper refactoring of the "plain enum" handling):

```rust
enum SomeEnum {
    One,
    Two,
    #[serde(untagged)]
    Null
}
```

For this enum, serde would emit JSON values `"One"`, `"Two"` and `null`, but utoipa still generates a JSON schema for an enum:

```json
{
    "enum": ["One", "Two", "Null"],
    "type": "string"
}
```
