### PR TITLE
docs: add examples and changelog for PR-1555

### DIFF
--- a/utoipa-actix-web/testdata/app_generated_openapi
+++ b/utoipa-actix-web/testdata/app_generated_openapi
@@ -10,7 +10,6 @@
         "operationId": "inner_handler",
         "responses": {
           "200": {
-            "description": "",
             "content": {
               "application/json": {
                 "schema": {
@@ -33,7 +32,6 @@
         "operationId": "handler",
         "responses": {
           "200": {
-            "description": "",
             "content": {
               "application/json": {
                 "schema": {
@@ -50,7 +48,6 @@
         "operationId": "handler3",
         "responses": {
           "200": {
-            "description": "",
             "content": {
               "application/json": {
                 "schema": {
@@ -67,7 +64,6 @@
         "operationId": "handler2",
         "responses": {
           "200": {
-            "description": "",
             "content": {
               "application/json": {
                 "schema": {

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+* Add macro/derive support for OpenAPI 3.2 (https://github.com/juhaku/utoipa/pull/1555)
+  - Supports `summary`, `parent`, and `kind` in `#[derive(OpenApi)]` tag parsing
+  - Supports `querystring` and `cookie` style in path parameter parsing
+  - Supports `data_value` and `serialized_value` in path examples
 * Add `bigdecimal` and `bigdecimal_float` feature support for `BigDecimal` type (https://github.com/juhaku/utoipa/pull/1487)
 * Expand openAPI header fields (https://github.com/juhaku/utoipa/pull/1556)
 * Expand support for validation features in `#[schema(...)]` on new type structs (https://github.com/juhaku/utoipa/pull/1427)
@@ -13,6 +17,8 @@
 
 ### Changed
 
+* Update response header generation for optional schemas and content-capable headers (https://github.com/juhaku/utoipa/pull/1555)
+* Adjust generated media type tokens to avoid ambiguous `Into` inference after content maps gained reference support (https://github.com/juhaku/utoipa/pull/1555)
 * Emit nullable_item last for OneOfBuilder (https://github.com/juhaku/utoipa/pull/1299)
 * Use pastey instead of unmaintained paste and fix some clippy warnings (https://github.com/juhaku/utoipa/pull/1452)
 

--- a/utoipa/CHANGELOG.md
+++ b/utoipa/CHANGELOG.md
@@ -7,6 +7,13 @@ to look into changes introduced to **`utoipa-gen`**.
 
 ### Added
 
+* Add support for OpenAPI 3.2.0 specification via `Version32` (https://github.com/juhaku/utoipa/pull/1555)
+  - Supports `$self` (`self_uri` field), `webhooks`, and `jsonSchemaDialect` on OpenAPI root
+  - Adds expanded components support: `mediaTypes`, `parameters`, `examples`, `requestBodies`, `headers`, `links`, `callbacks`, and `pathItems`
+  - Aligns OpenAPI 3.2 operation/path support: path item `$ref`, `query` operation, and `additionalOperations`
+  - Expands media type and streaming support: Media Type `itemSchema`, `description`, `itemEncoding`, `prefixEncoding`, and Server-Sent Events / typed streaming payload modeling
+  - Adds other OpenAPI 3.2 fixed fields: Tag `summary`, `parent`, and `kind`; Server `name`; XML `nodeType`; Response `summary`; Example `dataValue` and `serializedValue`; Parameter location `querystring`; Parameter style `cookie`; OAuth2 `deviceAuthorization` and `oauth2MetadataUrl`; `deprecated` on security schemes
+* Correct Link Object serialization to use OpenAPI camelCase fixed fields: `operationId`, `operationRef`, and `requestBody` (https://github.com/juhaku/utoipa/pull/1555)
 * Add `bigdecimal` and `bigdecimal_float` feature support for `BigDecimal` type (https://github.com/juhaku/utoipa/pull/1487)
 * Add support for `title` on `RefBuilder` (https://github.com/juhaku/utoipa/pull/1380)
 * Add support for `default` on `RefBuilder` (https://github.com/juhaku/utoipa/pull/1380)

--- a/utoipa/src/openapi.rs
+++ b/utoipa/src/openapi.rs
@@ -92,7 +92,13 @@ builder! {
         pub paths: Paths,
 
         /// Incoming requests that may be initiated by the API provider independently of an
-        /// incoming API request.
+        /// incoming API request. For example, a subscription confirmation request sent to a
+        /// consumer-provided webhook URL after they register for notifications.
+        ///
+        /// Each key is a unique identifier for the webhook, e.g. `newPet`, and the value is a
+        /// [`PathItem`][path::PathItem] describing the request that the API provider will send.
+        ///
+        /// See more details at <https://spec.openapis.org/oas/latest.html#oas-webhooks>.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub webhooks: Option<Paths>,
 
@@ -124,7 +130,11 @@ builder! {
         #[serde(skip_serializing_if = "Option::is_none")]
         pub external_docs: Option<ExternalDocs>,
 
-        /// The default JSON Schema dialect used by Schema Objects in this OpenAPI document.
+        /// The default JSON Schema dialect used by Schema Objects contained within this OpenAPI
+        /// document. Individual [`Schema`]s may still override this by declaring their own
+        /// `$schema` keyword.
+        ///
+        /// See more details at <https://spec.openapis.org/oas/latest.html#schema-object>.
         #[serde(skip_serializing_if = "Option::is_none")]
         pub json_schema_dialect: Option<String>,
 
@@ -135,7 +145,10 @@ builder! {
         #[serde(rename = "$schema", default, skip_serializing_if = "String::is_empty")]
         pub schema: String,
 
-        /// URI identifying this OpenAPI document.
+        /// URI identifying this OpenAPI document, used as the base URI for resolving relative
+        /// references (e.g. `$ref` values) within the document.
+        ///
+        /// See more details at <https://spec.openapis.org/oas/latest.html#fixed-fields>.
         #[serde(rename = "$self", skip_serializing_if = "Option::is_none")]
         pub self_uri: Option<String>,
 
@@ -338,6 +351,17 @@ impl OpenApiBuilder {
     ///
     /// Defaults to [`OpenApiVersion::Version31`]. Set [`OpenApiVersion::Version32`] to opt in to
     /// OpenAPI 3.2 output.
+    ///
+    /// # Examples
+    ///
+    /// Opt in to OpenAPI 3.2 output.
+    /// ```rust
+    /// # use utoipa::openapi::{OpenApiBuilder, OpenApiVersion, Info};
+    /// let openapi = OpenApiBuilder::new()
+    ///     .openapi(OpenApiVersion::Version32)
+    ///     .info(Info::new("my api", "0.1.0"))
+    ///     .build();
+    /// ```
     pub fn openapi(mut self, openapi: OpenApiVersion) -> Self {
         set_value!(self openapi openapi)
     }
@@ -358,6 +382,27 @@ impl OpenApiBuilder {
     }
 
     /// Add [`Paths`] to describe incoming requests that may be initiated by the API provider.
+    ///
+    /// # Examples
+    ///
+    /// Describe a `newPet` webhook that the API provider may send to a subscriber.
+    /// ```rust
+    /// # use utoipa::openapi::{
+    /// #     OpenApiBuilder, Info, Paths, PathsBuilder, PathItem, HttpMethod,
+    /// #     path::OperationBuilder, response::Response,
+    /// # };
+    /// let openapi = OpenApiBuilder::new()
+    ///     .info(Info::new("Events API", "1.0.0"))
+    ///     .paths(Paths::new())
+    ///     .webhooks(Some(PathsBuilder::new().path(
+    ///         "newPet",
+    ///         PathItem::new(
+    ///             HttpMethod::Post,
+    ///             OperationBuilder::new().response("200", Response::new("Webhook received")),
+    ///         ),
+    ///     )))
+    ///     .build();
+    /// ```
     pub fn webhooks<P: Into<Paths>>(mut self, webhooks: Option<P>) -> Self {
         set_value!(self webhooks webhooks.map(Into::into))
     }
@@ -401,11 +446,29 @@ impl OpenApiBuilder {
     }
 
     /// Add or change the default JSON Schema dialect for Schema Objects.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::OpenApiBuilder;
+    /// let _ = OpenApiBuilder::new()
+    ///     .json_schema_dialect(Some("https://spec.openapis.org/oas/3.2/dialect/2025-09-17"))
+    ///     .build();
+    /// ```
     pub fn json_schema_dialect<S: Into<String>>(mut self, json_schema_dialect: Option<S>) -> Self {
         set_value!(self json_schema_dialect json_schema_dialect.map(Into::into))
     }
 
     /// Add or change the URI identifying this OpenAPI document.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::OpenApiBuilder;
+    /// let _ = OpenApiBuilder::new()
+    ///     .self_uri(Some("https://example.com/openapi.json"))
+    ///     .build();
+    /// ```
     pub fn self_uri<S: Into<String>>(mut self, self_uri: Option<S>) -> Self {
         set_value!(self self_uri self_uri.map(Into::into))
     }

--- a/utoipa/src/openapi/path.rs
+++ b/utoipa/src/openapi/path.rs
@@ -466,8 +466,8 @@ impl PathItemBuilder {
     }
 
     /// Append list of parameter references common to all [`Operation`]s to this [`PathItem`].
-    pub fn parameter_refs<I: IntoIterator<Item = Ref>>(mut self, parameters: Option<I>) -> Self {
-        set_value!(self parameters parameters.map(|parameters| parameters.into_iter().map(RefOr::Ref).collect()))
+    pub fn parameter_refs<I: IntoIterator<Item = Ref>>(mut self, refs: Option<I>) -> Self {
+        set_value!(self parameters refs.map(|refs| refs.into_iter().map(RefOr::Ref).collect()))
     }
 
     /// Add openapi extensions (x-something) to this [`PathItem`].

--- a/utoipa/src/openapi/schema.rs
+++ b/utoipa/src/openapi/schema.rs
@@ -267,6 +267,25 @@ impl ComponentsBuilder {
     }
 
     /// Add [`Content`] to [`Components`] as a reusable media type object.
+    ///
+    /// Reusable media types are an OpenAPI 3.2 addition, added to the `mediaTypes` map of
+    /// [`Components`]. They can then be referenced by name from `content` maps using
+    /// [`RefOr::Ref`], instead of repeating the same media type definition across multiple
+    /// operations.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::{ComponentsBuilder, ContentBuilder, ObjectBuilder, Type};
+    /// let components = ComponentsBuilder::new()
+    ///     .media_type(
+    ///         "PetJson",
+    ///         ContentBuilder::new()
+    ///             .schema(Some(ObjectBuilder::new().schema_type(Type::Object)))
+    ///             .build(),
+    ///     )
+    ///     .build();
+    /// ```
     pub fn media_type<S: Into<String>, C: Into<RefOr<Content>>>(
         mut self,
         name: S,
@@ -277,6 +296,22 @@ impl ComponentsBuilder {
     }
 
     /// Add multiple reusable media type objects from an iterator.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::{ComponentsBuilder, ContentBuilder, ObjectBuilder, Type};
+    /// let components = ComponentsBuilder::new()
+    ///     .media_types_from_iter([
+    ///         (
+    ///             "PetJson",
+    ///             ContentBuilder::new()
+    ///                 .schema(Some(ObjectBuilder::new().schema_type(Type::Object)))
+    ///                 .build(),
+    ///         ),
+    ///     ])
+    ///     .build();
+    /// ```
     pub fn media_types_from_iter<
         I: IntoIterator<Item = (S, C)>,
         S: Into<String>,
@@ -295,6 +330,22 @@ impl ComponentsBuilder {
     }
 
     /// Add reusable [`Parameter`] to [`Components`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::{ComponentsBuilder, path::{ParameterBuilder, ParameterIn}, ObjectBuilder, Type};
+    /// let components = ComponentsBuilder::new()
+    ///     .parameter(
+    ///         "Limit",
+    ///         ParameterBuilder::new()
+    ///             .name("limit")
+    ///             .parameter_in(ParameterIn::Query)
+    ///             .schema(Some(ObjectBuilder::new().schema_type(Type::Integer)))
+    ///             .build(),
+    ///     )
+    ///     .build();
+    /// ```
     pub fn parameter<S: Into<String>, P: Into<RefOr<Parameter>>>(
         mut self,
         name: S,
@@ -305,6 +356,15 @@ impl ComponentsBuilder {
     }
 
     /// Add reusable [`Example`] to [`Components`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::{ComponentsBuilder, example::ExampleBuilder};
+    /// let components = ComponentsBuilder::new()
+    ///     .example("Accepted", ExampleBuilder::new().summary("Accepted").build())
+    ///     .build();
+    /// ```
     pub fn example<S: Into<String>, E: Into<RefOr<Example>>>(
         mut self,
         name: S,
@@ -315,6 +375,25 @@ impl ComponentsBuilder {
     }
 
     /// Add reusable [`RequestBody`] to [`Components`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::{ComponentsBuilder, request_body::RequestBodyBuilder, ContentBuilder, Ref};
+    /// let components = ComponentsBuilder::new()
+    ///     .request_body(
+    ///         "EventRequest",
+    ///         RequestBodyBuilder::new()
+    ///             .content(
+    ///                 "application/json",
+    ///                 ContentBuilder::new()
+    ///                     .schema(Some(Ref::from_schema_name("EventPayload")))
+    ///                     .build(),
+    ///             )
+    ///             .build(),
+    ///     )
+    ///     .build();
+    /// ```
     pub fn request_body<S: Into<String>, R: Into<RefOr<RequestBody>>>(
         mut self,
         name: S,
@@ -325,18 +404,62 @@ impl ComponentsBuilder {
     }
 
     /// Add reusable [`Header`] to [`Components`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::{ComponentsBuilder, header::HeaderBuilder, ObjectBuilder, Type};
+    /// let components = ComponentsBuilder::new()
+    ///     .header(
+    ///         "RateLimit",
+    ///         HeaderBuilder::new()
+    ///             .schema(Some(ObjectBuilder::new().schema_type(Type::Integer)))
+    ///             .build(),
+    ///     )
+    ///     .build();
+    /// ```
     pub fn header<S: Into<String>, H: Into<RefOr<Header>>>(mut self, name: S, header: H) -> Self {
         self.headers.insert(name.into(), header.into());
         self
     }
 
     /// Add reusable [`Link`] to [`Components`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::{ComponentsBuilder, link::LinkBuilder};
+    /// let components = ComponentsBuilder::new()
+    ///     .link("GetEvent", LinkBuilder::new().operation_id("getEvent").build())
+    ///     .build();
+    /// ```
     pub fn link<S: Into<String>, L: Into<RefOr<Link>>>(mut self, name: S, link: L) -> Self {
         self.links.insert(name.into(), link.into());
         self
     }
 
     /// Add reusable [`Callback`] to [`Components`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::{ComponentsBuilder, path::{PathItemBuilder, OperationBuilder}, response::ResponseBuilder};
+    /// # use std::collections::BTreeMap;
+    /// let callback_path = PathItemBuilder::new()
+    ///     .query(Some(
+    ///         OperationBuilder::new().response("200", ResponseBuilder::new()),
+    ///     ))
+    ///     .build();
+    /// let components = ComponentsBuilder::new()
+    ///     .callback(
+    ///         "EventCallback",
+    ///         BTreeMap::from([(
+    ///             "{$request.body#/callbackUrl}".to_string(),
+    ///             callback_path.into(),
+    ///         )]),
+    ///     )
+    ///     .build();
+    /// ```
     pub fn callback<S: Into<String>, C: Into<RefOr<Callback>>>(
         mut self,
         name: S,
@@ -347,6 +470,20 @@ impl ComponentsBuilder {
     }
 
     /// Add reusable [`PathItem`] to [`Components`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use utoipa::openapi::{ComponentsBuilder, path::{PathItemBuilder, OperationBuilder}, response::ResponseBuilder};
+    /// let path_item = PathItemBuilder::new()
+    ///     .query(Some(
+    ///         OperationBuilder::new().response("200", ResponseBuilder::new()),
+    ///     ))
+    ///     .build();
+    /// let components = ComponentsBuilder::new()
+    ///     .path_item("EventPath", path_item)
+    ///     .build();
+    /// ```
     pub fn path_item<S: Into<String>, P: Into<PathItem>>(mut self, name: S, path_item: P) -> Self {
         self.path_items.insert(name.into(), path_item.into());
         self

--- a/utoipa/src/openapi/security.rs
+++ b/utoipa/src/openapi/security.rs
@@ -180,12 +180,25 @@ pub enum SecurityScheme {
     /// Authentication is done via client side certificate.
     ///
     /// OpenApi 3.1 type
+    ///
+    /// # Examples
+    ///
+    /// Declare mutual TLS authentication with a description.
+    /// ```rust
+    /// # use utoipa::openapi::security::SecurityScheme;
+    /// SecurityScheme::MutualTls {
+    ///     description: Some("Client certificate required".to_string()),
+    ///     deprecated: None,
+    ///     extensions: None,
+    /// };
+    /// ```
     #[serde(rename = "mutualTLS")]
     MutualTls {
-        #[allow(missing_docs)]
+        /// Optional description explaining how the mutual TLS certificate should be obtained
+        /// and used. Description supports markdown syntax.
         #[serde(skip_serializing_if = "Option::is_none")]
         description: Option<String>,
-        #[allow(missing_docs)]
+        /// Declares whether the security scheme is deprecated.
         #[serde(skip_serializing_if = "Option::is_none")]
         deprecated: Option<Deprecated>,
         /// Optional extensions "x-something".
@@ -266,6 +279,15 @@ impl ApiKeyValue {
     }
 
     /// Add or change deprecated status.
+    ///
+    /// # Examples
+    ///
+    /// Mark an api key security scheme as deprecated.
+    /// ```rust
+    /// # use utoipa::openapi::security::ApiKeyValue;
+    /// # use utoipa::openapi::Deprecated;
+    /// ApiKeyValue::new("api_key").deprecated(Some(Deprecated::True));
+    /// ```
     pub fn deprecated(mut self, deprecated: Option<Deprecated>) -> Self {
         self.deprecated = deprecated;
         self
@@ -369,6 +391,19 @@ impl HttpBuilder {
     }
 
     /// Add or change deprecated status.
+    ///
+    /// # Examples
+    ///
+    /// Mark a bearer HTTP authentication scheme as deprecated.
+    /// ```rust
+    /// # use utoipa::openapi::security::{HttpBuilder, HttpAuthScheme};
+    /// # use utoipa::openapi::Deprecated;
+    /// HttpBuilder::new()
+    ///     .scheme(HttpAuthScheme::Bearer)
+    ///     .bearer_format("JWT")
+    ///     .deprecated(Some(Deprecated::True))
+    ///     .build();
+    /// ```
     pub fn deprecated(mut self, deprecated: Option<Deprecated>) -> Self {
         self.deprecated = deprecated;
         self
@@ -462,6 +497,15 @@ impl OpenIdConnect {
     }
 
     /// Add or change deprecated status.
+    ///
+    /// # Examples
+    ///
+    /// Mark an OpenID Connect security scheme as deprecated.
+    /// ```rust
+    /// # use utoipa::openapi::security::OpenIdConnect;
+    /// # use utoipa::openapi::Deprecated;
+    /// OpenIdConnect::new("https://localhost/openid").deprecated(Some(Deprecated::True));
+    /// ```
     pub fn deprecated(mut self, deprecated: Option<Deprecated>) -> Self {
         self.deprecated = deprecated;
         self
@@ -584,12 +628,44 @@ impl OAuth2 {
     }
 
     /// Add OAuth2 authorization server metadata URL.
+    ///
+    /// # Examples
+    ///
+    /// Add authorization server metadata URL to an existing [`OAuth2`] security scheme.
+    /// ```rust
+    /// # use utoipa::openapi::security::{OAuth2, Flow, Password, Scopes};
+    /// OAuth2::new([Flow::Password(
+    ///     Password::new(
+    ///         "https://localhost/oauth/token",
+    ///         Scopes::from_iter([("edit:items", "edit my items")]),
+    ///     ),
+    /// )])
+    /// .with_metadata_url("https://localhost/.well-known/oauth-authorization-server");
+    /// ```
     pub fn with_metadata_url<S: Into<String>>(mut self, oauth2_metadata_url: S) -> Self {
         self.oauth2_metadata_url = Some(oauth2_metadata_url.into());
         self
     }
 
     /// Add or change deprecated status.
+    ///
+    /// Declaring a security scheme deprecated signals to API consumers that they should migrate
+    /// away from it. This is an OpenAPI 3.2 addition available on all [`SecurityScheme`] variants.
+    ///
+    /// # Examples
+    ///
+    /// Mark an [`OAuth2`] security scheme as deprecated.
+    /// ```rust
+    /// # use utoipa::openapi::security::{OAuth2, Flow, Password, Scopes};
+    /// # use utoipa::openapi::Deprecated;
+    /// OAuth2::new([Flow::Password(
+    ///     Password::new(
+    ///         "https://localhost/oauth/token",
+    ///         Scopes::from_iter([("edit:items", "edit my items")]),
+    ///     ),
+    /// )])
+    /// .deprecated(Some(Deprecated::True));
+    /// ```
     pub fn deprecated(mut self, deprecated: Option<Deprecated>) -> Self {
         self.deprecated = deprecated;
         self
@@ -846,6 +922,27 @@ pub struct DeviceAuthorization {
 
 impl DeviceAuthorization {
     /// Construct a new device authorization OAuth2 flow.
+    ///
+    /// First parameter is the device authorization endpoint URL where the client requests a
+    /// device code, second parameter is the token URL used to poll for the access token, and the
+    /// third parameter defines the scopes available for the flow.
+    ///
+    /// # Examples
+    ///
+    /// Create a device authorization flow and use it in an [`OAuth2`] security scheme.
+    /// ```rust
+    /// # use utoipa::openapi::security::{OAuth2, Flow, DeviceAuthorization, Scopes};
+    /// OAuth2::new([Flow::DeviceAuthorization(
+    ///     DeviceAuthorization::new(
+    ///         "https://localhost/oauth/device/code",
+    ///         "https://localhost/oauth/token",
+    ///         Scopes::from_iter([
+    ///             ("edit:items", "edit my items"),
+    ///             ("read:items", "read my items"),
+    ///         ]),
+    ///     ),
+    /// )]);
+    /// ```
     pub fn new<D: Into<String>, T: Into<String>>(
         device_authorization_url: D,
         token_url: T,
@@ -861,6 +958,19 @@ impl DeviceAuthorization {
     }
 
     /// Construct a new device authorization OAuth2 flow with additional refresh URL.
+    ///
+    /// # Examples
+    ///
+    /// Create a device authorization flow with a refresh token URL.
+    /// ```rust
+    /// # use utoipa::openapi::security::{DeviceAuthorization, Scopes};
+    /// DeviceAuthorization::with_refresh_url(
+    ///     "https://localhost/oauth/device/code",
+    ///     "https://localhost/oauth/token",
+    ///     Scopes::from_iter([("edit:items", "edit my items")]),
+    ///     "https://localhost/oauth/refresh",
+    /// );
+    /// ```
     pub fn with_refresh_url<S: Into<String>>(
         device_authorization_url: S,
         token_url: S,


### PR DESCRIPTION
## Description

1. Follow up with what @juhaku mentioned in PR-1555
  * Add examples to docs
  * Change argument name `parameters` from to `refs` in `parameter_refs` function

2. Add changelog

3. Fix broken tests (caused by empty description being in the results, hence removing `description=""` fixes the issue) 
<img width="1161" height="715" alt="image" src="https://github.com/user-attachments/assets/efdfb281-cf0d-455a-83ae-f8024211973a" />



## Reference
https://github.com/juhaku/utoipa/pull/1555/#pullrequestreview-4604241441

