### PR TITLE
feat(gen): support item_schema attribute for streaming/SSE response types

### DIFF
--- a/examples/openapi-3_2-sse/Cargo.toml
+++ b/examples/openapi-3_2-sse/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "openapi-3_2-sse"
+description = "Axum example documenting a Server-Sent Events (SSE) endpoint using OpenAPI 3.2"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+authors = ["Drifter-J <latenytcoffee@gmail.com>"]
+
+[dependencies]
+axum = "0.8.0"
+futures-util = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1.17", features = ["full"] }
+tokio-stream = "0.1"
+utoipa = { path = "../../utoipa", features = ["axum_extras", "uuid"] }
+utoipa-axum = { path = "../../utoipa-axum" }
+utoipa-swagger-ui = { path = "../../utoipa-swagger-ui", features = ["axum"] }
+uuid = { version = "1", features = ["serde", "v4"] }
+rand = "0.8"
+
+[workspace]

--- a/examples/openapi-3_2-sse/README.md
+++ b/examples/openapi-3_2-sse/README.md
@@ -1,0 +1,15 @@
+# openapi-3_2-sse
+
+This example demonstrates documenting a Server-Sent Events endpoint using `utoipa`'s
+OpenAPI 3.2 support: opting in to `openapi: "3.2.0"` output and describing the
+`text/event-stream` response with the new `itemSchema` media type keyword.
+
+Run with:
+```bash
+cargo run
+```
+
+Then either:
+
+- Browse to `http://localhost:8080/swagger-ui/` to inspect the generated OpenAPI 3.2 document, or
+- Stream events directly with `curl -N http://localhost:8080/pets/events`

--- a/examples/openapi-3_2-sse/src/main.rs
+++ b/examples/openapi-3_2-sse/src/main.rs
@@ -72,17 +72,14 @@ async fn pet_events() -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
 }
 
-/// Opt the whole document in to OpenAPI 3.2 output via `ApiDoc::openapi().openapi(...)`
+/// Opt the whole document in to OpenAPI 3.2 output with `version = "3.2.0"`
 #[derive(OpenApi)]
-#[openapi(components(schemas(PetEvent)))]
+#[openapi(version = "3.2.0", components(schemas(PetEvent)))]
 struct ApiDoc;
 
 #[tokio::main]
 async fn main() {
-    let mut api = ApiDoc::openapi();
-    api.openapi = utoipa::openapi::OpenApiVersion::Version32;
-
-    let (router, api) = OpenApiRouter::with_openapi(api)
+    let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
         .routes(routes!(pet_events))
         .split_for_parts();
 
@@ -102,10 +99,7 @@ mod tests {
 
     #[test]
     fn sse_response_documents_item_schema() {
-        let mut api = ApiDoc::openapi();
-        api.openapi = utoipa::openapi::OpenApiVersion::Version32;
-
-        let (_, api) = OpenApiRouter::<()>::with_openapi(api)
+        let (_, api) = OpenApiRouter::<()>::with_openapi(ApiDoc::openapi())
             .routes(routes!(pet_events))
             .split_for_parts();
 

--- a/examples/openapi-3_2-sse/src/main.rs
+++ b/examples/openapi-3_2-sse/src/main.rs
@@ -72,14 +72,17 @@ async fn pet_events() -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
     Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
 }
 
-/// Opt the whole document in to OpenAPI 3.2 output with `version = "3.2.0"`
+/// Opt the whole document in to OpenAPI 3.2 output via `ApiDoc::openapi().openapi(...)`
 #[derive(OpenApi)]
-#[openapi(version = "3.2.0", components(schemas(PetEvent)))]
+#[openapi(components(schemas(PetEvent)))]
 struct ApiDoc;
 
 #[tokio::main]
 async fn main() {
-    let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
+    let mut api = ApiDoc::openapi();
+    api.openapi = utoipa::openapi::OpenApiVersion::Version32;
+
+    let (router, api) = OpenApiRouter::with_openapi(api)
         .routes(routes!(pet_events))
         .split_for_parts();
 
@@ -99,7 +102,10 @@ mod tests {
 
     #[test]
     fn sse_response_documents_item_schema() {
-        let (_, api) = OpenApiRouter::<()>::with_openapi(ApiDoc::openapi())
+        let mut api = ApiDoc::openapi();
+        api.openapi = utoipa::openapi::OpenApiVersion::Version32;
+
+        let (_, api) = OpenApiRouter::<()>::with_openapi(api)
             .routes(routes!(pet_events))
             .split_for_parts();
 

--- a/examples/openapi-3_2-sse/src/main.rs
+++ b/examples/openapi-3_2-sse/src/main.rs
@@ -1,0 +1,124 @@
+//! Server-Sent Events (SSE) example documented with OpenAPI 3.2.
+//!
+//! OpenAPI 3.2 adds support for streaming/sequential media types such as `text/event-stream`,
+//! `application/jsonl` and `application/json-seq`.
+//! Refer to [Announcing OpenAPI v3.2](https://www.openapis.org/blog/2025/09/23/announcing-openapi-v3-2)
+//!
+//! This example shows how to:
+//!
+//! - opt in to `utoipa`'s OpenAPI 3.2 output via the `#[openapi(version = "3.2.0")]` derive attribute
+//! - describe a `text/event-stream` SSE endpoint using the new `itemSchema` media type keyword
+//!   introduced in OpenAPI 3.2, so consumers know the shape of each event pushed down the stream
+//! - serve the endpoint for real with axum's [`axum::response::sse::Sse`] type
+
+use std::convert::Infallible;
+use std::time::Duration;
+
+use axum::response::sse::{Event, KeepAlive, Sse};
+use futures_util::stream::Stream;
+use rand::Rng;
+use serde::Serialize;
+use tokio_stream::StreamExt;
+use utoipa::{OpenApi, ToSchema};
+use utoipa_axum::router::OpenApiRouter;
+use utoipa_axum::routes;
+use utoipa_swagger_ui::SwaggerUi;
+use uuid::Uuid;
+
+/// A single pet status update pushed to subscribers of the `/pets/events` stream.
+#[derive(Serialize, ToSchema)]
+struct PetEvent {
+    /// Identifier of the pet the event relates to.
+    pet_id: Uuid,
+    /// New status of the pet, e.g. `"adopted"`, `"vaccinated"` or `"groomed"`.
+    status: String,
+}
+
+/// Stream status updates for pets as Server-Sent Events.
+///
+/// The `text/event-stream` response describes the shape of each streamed event with the
+/// `item_schema` attribute, which maps to OpenAPI 3.2's `itemSchema` media type keyword. Because
+/// `item_schema = PetEvent` produces a `$ref`, `PetEvent` is registered as a reusable component via
+/// `#[openapi(components(schemas(PetEvent)))]` on [`ApiDoc`].
+#[utoipa::path(
+    get,
+    path = "/pets/events",
+    responses(
+        (
+            status = 200,
+            description = "Stream of pet status updates",
+            content_type = "text/event-stream",
+            item_schema = PetEvent,
+        )
+    )
+)]
+async fn pet_events() -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let uuids = [Uuid::new_v4(), Uuid::new_v4(), Uuid::new_v4()];
+    let statuses = ["vaccinated", "groomed", "adopted"];
+    // Emit a finite number of events (one per second) so clients that buffer the whole
+    // response body
+    let stream = tokio_stream::iter(0u64..10)
+        .map(move |i| {
+            let mut rng = rand::thread_rng();
+            let uuid_idx = rng.gen_range(0..3);
+            let event = PetEvent {
+                pet_id: uuids[uuid_idx],
+                status: statuses[(i % statuses.len() as u64) as usize].to_string(),
+            };
+            Ok(Event::default().json_data(&event).unwrap())
+        })
+        .throttle(Duration::from_secs(1));
+
+    Sse::new(stream).keep_alive(KeepAlive::new().interval(Duration::from_secs(15)))
+}
+
+/// Opt the whole document in to OpenAPI 3.2 output with `version = "3.2.0"`
+#[derive(OpenApi)]
+#[openapi(version = "3.2.0", components(schemas(PetEvent)))]
+struct ApiDoc;
+
+#[tokio::main]
+async fn main() {
+    let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
+        .routes(routes!(pet_events))
+        .split_for_parts();
+
+    let router = router.merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", api));
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:8080")
+        .await
+        .unwrap();
+    axum::serve(listener, router.into_make_service())
+        .await
+        .unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sse_response_documents_item_schema() {
+        let (_, api) = OpenApiRouter::<()>::with_openapi(ApiDoc::openapi())
+            .routes(routes!(pet_events))
+            .split_for_parts();
+
+        let json = serde_json::to_value(&api).unwrap();
+
+        assert_eq!(
+            json["openapi"],
+            serde_json::json!("3.2.0"),
+            "expected document to opt in to OpenAPI 3.2, got: {}",
+            json["openapi"]
+        );
+
+        let content = &json["paths"]["/pets/events"]["get"]["responses"]["200"]["content"]
+            ["text/event-stream"];
+
+        assert_eq!(
+            content["itemSchema"]["$ref"],
+            serde_json::json!("#/components/schemas/PetEvent"),
+            "expected text/event-stream response to carry an itemSchema $ref to PetEvent, got: {content:#}"
+        );
+    }
+}

--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Add support for the media type `item_schema = ...` attribute in `responses(...)`/`request_body(...)`, mapping to OpenAPI 3.2's `itemSchema` keyword for streaming/event-based media types such as `text/event-stream`
 * Add macro/derive support for OpenAPI 3.2 (https://github.com/juhaku/utoipa/pull/1555)
   - Supports `summary`, `parent`, and `kind` in `#[derive(OpenApi)]` tag parsing
   - Supports `querystring` and `cookie` style in path parameter parsing

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -1154,6 +1154,14 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 ///   for [primitive Rust types][primitive], `application/octet-stream` for _`[u8]`_ and _`application/json`_
 ///   for struct and mixed enum types.
 ///
+/// * `item_schema = ...` Optional schema describing each item of a streaming or event-based media
+///   type such as `text/event-stream`, `application/jsonl` or `application/json-seq`. It maps to
+///   OpenAPI 3.2's `itemSchema` media type keyword and accepts the same syntax as `body`, i.e.
+///   _`item_schema = Type`_, _`item_schema = inline(Type)`_ or _`item_schema = ref("...")`_.
+///   This attribute only emits the `itemSchema` keyword; opting the document in to OpenAPI 3.2
+///   output (`openapi: 3.2.0`) is a separate, deliberate step done via
+///   [`OpenApiVersion::Version32`][openapi_version].
+///
 /// * `headers(...)` Slice of response headers that are returned back to a caller.
 ///
 /// * `example = ...` Can be _`json!(...)`_. _`json!(...)`_ should be something that
@@ -1880,6 +1888,7 @@ pub fn derive_to_schema(input: TokenStream) -> TokenStream {
 /// [into_params_derive]: derive.IntoParams.html
 /// [to_response_trait]: trait.ToResponse.html
 /// [known_format]: openapi/schema/enum.KnownFormat.html
+/// [openapi_version]: openapi/enum.OpenApiVersion.html
 /// [xml]: openapi/xml/struct.Xml.html
 /// [to_schema_xml]: macro@ToSchema#xml-attribute-configuration-options
 /// [relative_references]: https://spec.openapis.org/oas/latest.html#relative-references-in-uris
@@ -2221,6 +2230,7 @@ pub fn path(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// [openapi]: trait.OpenApi.html
 /// [openapi_struct]: openapi/struct.OpenApi.html
+/// [openapi_version]: openapi/enum.OpenApiVersion.html
 /// [to_schema]: derive.ToSchema.html
 /// [path]: attr.path.html
 /// [modify]: trait.Modify.html

--- a/utoipa-gen/src/path/media_type.rs
+++ b/utoipa-gen/src/path/media_type.rs
@@ -25,16 +25,29 @@ pub mod encoding;
 
 use encoding::Encoding;
 
-/// Parse OpenAPI Media Type object params
-/// ( Schema )
-/// ( Schema = "content/type" )
-/// ( "content/type", ),
-/// ( "content/type", example = ..., examples(..., ...), encoding(("exampleField" = (...)), ...), extensions(("x-ext" = json!(...))) )
+/// Parsed representation of OpenAPI Media Type object attributes.
+///
+/// Maps to configuration options for request body content or response content,
+/// e.g. within `responses(...)` or `request_body(...)`.
+///
+/// Supports the following configuration styles:
+/// * **Shorthand type form:** `Schema` (e.g. `Pet` or `inline(Pet)`)
+/// * **Shorthand type + content type form:** `Schema = "content/type"` (e.g. `Pet = "application/json"`)
+/// * **Shorthand content type only:** `"content/type"` (e.g. `"text/event-stream"`)
+/// * **Full attribute form:** `"content/type"`, `item_schema = ...`, `example = ...`, `examples(...)`, etc.
+///
+/// Supported named attributes:
+/// * **item_schema** Optional schema describing each item of a streaming media type (OpenAPI 3.2 `itemSchema`).
+/// * **example** Optional single example of the media type value.
+/// * **examples** Optional multiple examples of the media type value.
+/// * **encoding** Optional map between property names and their encoding information.
+/// * **extensions** Optional custom extensions prefixing with `x-`.#[derive(Default)]
 #[derive(Default)]
 #[cfg_attr(feature = "debug", derive(Debug))]
 pub struct MediaTypeAttr<'m> {
     pub content_type: Option<parse_utils::LitStrOrExpr>, // if none, true guess
     pub schema: Schema<'m>,
+    pub item_schema: Schema<'m>,
     pub example: Option<AnyValue>,
     pub examples: Punctuated<Example, Comma>,
     pub encoding: BTreeMap<String, Encoding>,
@@ -107,6 +120,10 @@ impl<'m> MediaTypeAttr<'m> {
         let name = &*attribute.to_string();
 
         match name {
+            "item_schema" => {
+                let schema = parse_utils::parse_next(input, || Self::parse_schema(input))?;
+                self.item_schema = Schema::Default(schema);
+            }
             "example" => {
                 self.example = Some(parse_utils::parse_next(input, || {
                     AnyValue::parse_any(input)
@@ -152,7 +169,7 @@ impl<'m> MediaTypeAttr<'m> {
                 return Err(syn::Error::new(
                     attribute.span(),
                     format!(
-                        "unexpected attribute: {unexpected}, expected any of: example, examples, encoding(...), extensions(...)"
+                        "unexpected attribute: {unexpected}, expected any of: item_schema, example, examples, encoding(...), extensions(...)"
                     ),
                 ))
             }
@@ -173,6 +190,12 @@ impl ToTokensDiagnostics for MediaTypeAttr<'_> {
             None
         } else {
             Some(quote! { .schema(Some(#schema)) })
+        };
+        let item_schema = &self.item_schema.try_to_token_stream()?;
+        let item_schema_tokens = if item_schema.is_empty() {
+            None
+        } else {
+            Some(quote! { .item_schema(Some(#item_schema)) })
         };
         let example = self
             .example
@@ -204,6 +227,7 @@ impl ToTokensDiagnostics for MediaTypeAttr<'_> {
         tokens.extend(quote! {
             utoipa::openapi::content::ContentBuilder::new()
                 #schema_tokens
+                #item_schema_tokens
                 #example
                 #examples
                 #(#encoding)*

--- a/utoipa-gen/src/path/response.rs
+++ b/utoipa-gen/src/path/response.rs
@@ -267,7 +267,7 @@ impl Parse for ResponseValue<'_> {
 
 impl<'r> ResponseValue<'r> {
     const EXPECTED_ATTRIBUTES: &'static str =
-        "description, body, content_type, headers, example, examples";
+        "description, body, content_type, item_schema, headers, example, examples";
 
     fn parse_named_attributes(&mut self, input: ParseStream, attribute: &Ident) -> syn::Result<()> {
         let attribute_name = &*attribute.to_string();
@@ -441,6 +441,7 @@ impl ToTokensDiagnostics for ResponseTuple<'_> {
 
                 for media_type in value.content.iter().filter(|media_type| {
                     !(matches!(media_type.schema, Schema::Default(DefaultSchema::None))
+                        && matches!(media_type.item_schema, Schema::Default(DefaultSchema::None))
                         && media_type.content_type.is_none())
                 }) {
                     let default_content_type = media_type.schema.get_default_content_type()?;


### PR DESCRIPTION
## Summary
* Adds support for the media type `item_schema = ...` attribute in `responses(...)` and `request_body(...)`.
* Maps to OpenAPI 3.2's [`itemSchema`](https://spec.openapis.org/oas/v3.2.0.html#fixed-fields-11) media type keyword for streaming, sequential, or event-based media types such as `text/event-stream`.
* Documents the new `item_schema` attribute and adds a fully compiling `openapi-3_2-sse` Server-Sent Events example using axum.
* Change `MediaTypeAttr` Docs to be prettier and informative. 

## Reverted SSE example but you can see the stream of infinite pet events.
https://github.com/user-attachments/assets/fa711c34-7542-40f2-9f91-bf44f1413904

## Current version
<img width="492" height="618" alt="Screenshot 2026-08-09 at 23 34 46" src="https://github.com/user-attachments/assets/f7ddda65-5db0-4e0b-861e-ef93294b19f2" />

Reason why I reverted infinite stream;
* Swagger-UI `Execute` button buffers the entire response body before rendering it, so it cannot display an SSE stream incrementally (it only shows a spinner until the stream completes). So now, the example emits a finite-number-of-events (10, one per-second) so, `Execute` eventually returns :)