### PR TITLE
Bump base64 from 22.1 to 23.1

### DIFF
--- a/utoipa-swagger-ui/Cargo.toml
+++ b/utoipa-swagger-ui/Cargo.toml
@@ -40,7 +40,7 @@ utoipa = { version = "5.0.0", path = "../utoipa", default-features = false, feat
 ] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = { version = "1.0" }
-base64 = { version = "0.22.1" }
+base64 = { version = "0.23.1" }
 
 [dev-dependencies]
 http = "1.4"


### PR DESCRIPTION
https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md#0231

> Update MSRV to 1.71.0

This new MSRV is still lower than the current one (1.88)