### PR TITLE
chore: Update CHANGELOG.md

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### Fixed
 
+* Recursively discover flattened fields in maps for `#[serde(flatten)]`. (https://github.com/juhaku/utoipa/pull/1582)
 * Emit `vec![...]` instead of stack allocated array literals in generated `ToSchema`/`IntoParams` code to avoid `clippy::large_stack_arrays` and stack overflows for types with many fields (https://github.com/juhaku/utoipa/issues/1454)
 * Avoid degenerate `oneOf` for `Option<_>` with `nullable = false` and `default`/`title`/`description` (https://github.com/juhaku/utoipa/pull/1380)
 * Fix `jiff` type detection when only the `jiff_0_2` feature is enabled (https://github.com/juhaku/utoipa/pull/1575)


### PR DESCRIPTION
Add the following entry in utoipa-gen/CHANGELOG.md

* Recursively discover flattened fields in maps for `#[serde(flatten)]`. (https://github.com/juhaku/utoipa/pull/1582)