### PR TITLE
Upgrade utoipa-gen to syn 3

### DIFF
--- a/utoipa-gen/Cargo.toml
+++ b/utoipa-gen/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro = true
 utoipa-config = { version = "0.1", path = "../utoipa-config", optional = true }
 once_cell = { version = "1.21.4", optional = true }
 proc-macro2 = "1.0"
-syn = { version = "2.0", features = ["full", "extra-traits"] }
+syn = { version = "3", features = ["full", "extra-traits"] }
 quote = "1.0"
 regex = { version = "1.12", optional = true }
 uuid = { version = "1", features = ["serde"], optional = true }

--- a/utoipa-gen/src/path.rs
+++ b/utoipa-gen/src/path.rs
@@ -349,13 +349,10 @@ impl<'p> ToTokensDiagnostics for Path<'p> {
             .path_attr
             .operation_id
             .clone()
-            .or(Some(
-                ExprLit {
-                    attrs: vec![],
-                    lit: Lit::Str(LitStr::new(fn_name, Span::call_site())),
-                }
-                .into(),
-            ))
+            .or(Some(Expr::Lit(ExprLit {
+                attrs: vec![],
+                lit: Lit::Str(LitStr::new(fn_name, Span::call_site())),
+            })))
             .ok_or_else(|| {
                 Diagnostics::new("operation id is not defined for path")
                     .help(format!(

--- a/utoipa-gen/src/path/response/derive.rs
+++ b/utoipa-gen/src/path/response/derive.rs
@@ -208,7 +208,11 @@ impl ToTokensDiagnostics for IntoResponses {
 trait Response {
     fn to_type(ident: &Ident) -> Type {
         let path = Path::from(ident.clone());
-        let type_path = TypePath { path, qself: None };
+        let type_path = TypePath {
+            attrs: Vec::new(),
+            path,
+            qself: None,
+        };
         Type::Path(type_path)
     }
 


### PR DESCRIPTION
Can reduce dependencies if you have syn 3 already in the tree.
`syn` 3.0 has a MSRV of `1.71`, which is lower than this crate.