### PR TITLE
Add content_type attribute to IntoParams params

### DIFF
--- a/utoipa-gen/CHANGELOG.md
+++ b/utoipa-gen/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+* Add `content_type = ...` attribute to `IntoParams` `#[param(...)]` to render the parameter schema under `content`
 * Add support for the media type `item_schema = ...` attribute in `responses(...)`/`request_body(...)`, mapping to OpenAPI 3.2's `itemSchema` keyword for streaming/event-based media types such as `text/event-stream`
 * Add support for selecting the OpenAPI document version via the `version = "..."` attribute in `#[derive(OpenApi)]` (accepts `"3.1.0"` or `"3.2.0"`, mapping to `OpenApiVersion`)
 * Add support for generic types with `IntoParams` (https://github.com/juhaku/utoipa/pull/1588)

--- a/utoipa-gen/src/component/features.rs
+++ b/utoipa-gen/src/component/features.rs
@@ -102,6 +102,7 @@ pub enum Feature {
     Required(attributes::Required),
     ContentEncoding(attributes::ContentEncoding),
     ContentMediaType(attributes::ContentMediaType),
+    ContentType(attributes::ContentType),
     Discriminator(attributes::Discriminator),
     Bound(attributes::Bound),
     Ignore(attributes::Ignore),
@@ -217,6 +218,10 @@ impl ToTokensDiagnostics for Feature {
             }
             Feature::ContentEncoding(content_encoding) => quote! { .content_encoding(#content_encoding) },
             Feature::ContentMediaType(content_media_type) => quote! { .content_media_type(#content_media_type) },
+            Feature::ContentType(_) => {
+                return Err(Diagnostics::new("ContentType does not support `ToTokens`")
+                    .help("ContentType is only used with IntoParams to render the parameter schema as `content`."))
+            }
             Feature::Discriminator(discriminator) => quote! { .discriminator(Some(#discriminator)) },
             Feature::Bound(_) => {
                 // specially handled on generating impl blocks.
@@ -306,6 +311,7 @@ impl Display for Feature {
             Feature::Required(required) => required.fmt(f),
             Feature::ContentEncoding(content_encoding) => content_encoding.fmt(f),
             Feature::ContentMediaType(content_media_type) => content_media_type.fmt(f),
+            Feature::ContentType(content_type) => content_type.fmt(f),
             Feature::Discriminator(discriminator) => discriminator.fmt(f),
             Feature::Bound(bound) => bound.fmt(f),
             Feature::Ignore(ignore) => ignore.fmt(f),
@@ -358,6 +364,7 @@ impl Validatable for Feature {
             Feature::Required(required) => required.is_validatable(),
             Feature::ContentEncoding(content_encoding) => content_encoding.is_validatable(),
             Feature::ContentMediaType(content_media_type) => content_media_type.is_validatable(),
+            Feature::ContentType(content_type) => content_type.is_validatable(),
             Feature::Discriminator(discriminator) => discriminator.is_validatable(),
             Feature::Bound(bound) => bound.is_validatable(),
             Feature::Ignore(ignore) => ignore.is_validatable(),
@@ -408,6 +415,7 @@ is_validatable! {
     attributes::Required,
     attributes::ContentEncoding,
     attributes::ContentMediaType,
+    attributes::ContentType,
     attributes::Discriminator,
     attributes::Bound,
     attributes::Ignore,
@@ -639,6 +647,7 @@ impl_feature_into_inner! {
     attributes::As,
     attributes::Required,
     attributes::AdditionalProperties,
+    attributes::ContentType,
     attributes::Discriminator,
     attributes::Bound,
     attributes::Ignore,

--- a/utoipa-gen/src/component/features/attributes.rs
+++ b/utoipa-gen/src/component/features/attributes.rs
@@ -838,6 +838,33 @@ impl From<ContentMediaType> for Feature {
     }
 }
 
+impl_feature! {
+    #[derive(Clone)]
+    #[cfg_attr(feature = "debug", derive(Debug))]
+    pub struct ContentType(String);
+}
+
+impl Parse for ContentType {
+    fn parse(input: ParseStream, _: Ident) -> syn::Result<Self>
+    where
+        Self: std::marker::Sized,
+    {
+        parse_utils::parse_next_literal_str(input).map(Self)
+    }
+}
+
+impl ToTokens for ContentType {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        self.0.to_tokens(tokens);
+    }
+}
+
+impl From<ContentType> for Feature {
+    fn from(value: ContentType) -> Self {
+        Self::ContentType(value)
+    }
+}
+
 // discriminator = ...
 // discriminator(property_name = ..., mapping(
 //      (value = ...),

--- a/utoipa-gen/src/component/into_params.rs
+++ b/utoipa-gen/src/component/into_params.rs
@@ -302,6 +302,7 @@ impl Parse for FieldFeatures {
             Explode,
             SchemaWith,
             component::features::attributes::Required,
+            component::features::attributes::ContentType,
             // param schema features
             Inline,
             Format,
@@ -398,9 +399,30 @@ impl Param {
             tokens.extend(quote! { .deprecated(Some(#deprecated)) });
         }
 
+        let content_type = pop_feature!(param_features => Feature::ContentType(_) as Option<features::attributes::ContentType>);
+        let content_example = content_type.as_ref().and_then(|_| {
+            pop_feature!(param_features => Feature::Example(_) as Option<features::attributes::Example>)
+        });
+        let schema_or_content = |schema: TokenStream| match &content_type {
+            Some(content_type) => {
+                let example = content_example
+                    .as_ref()
+                    .map(|example| quote! { .example(Some(#example)) });
+                quote! {
+                    .content(#content_type, utoipa::openapi::content::ContentBuilder::new()
+                        .schema(Some(#schema))
+                        #example
+                        .build())
+                }
+            }
+            None => quote! { .schema(Some(#schema)) },
+        };
+
         let schema_with = pop_feature!(param_features => Feature::SchemaWith(_));
         if let Some(schema_with) = schema_with {
-            tokens.extend(quote_diagnostics! { .schema(Some(@schema_with)).build() }?);
+            let schema_with = quote_diagnostics! { @schema_with }?;
+            let schema_or_content = schema_or_content(schema_with);
+            tokens.extend(quote! { #schema_or_content.build() });
         } else {
             let description =
                 CommentAttributes::from_attributes(&field.attrs).as_formatted_string();
@@ -444,9 +466,9 @@ impl Param {
                 },
                 option_is_nullable,
             )?;
-            let schema_tokens = schema.to_token_stream();
+            let schema_or_content = schema_or_content(schema.to_token_stream());
 
-            tokens.extend(quote! { .schema(Some(#schema_tokens)).build() });
+            tokens.extend(quote! { #schema_or_content.build() });
         }
 
         let tokens = match ignore {

--- a/utoipa-gen/src/lib.rs
+++ b/utoipa-gen/src/lib.rs
@@ -2331,6 +2331,11 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// * `example = ...` Can be method reference or _`json!(...)`_. Given example
 ///   will override any example in underlying parameter type.
 ///
+/// * `content_type = ...` Literal string media type e.g. _`"application/json"`_. Renders the
+///   parameter's schema (and `example`) under a [`content`][content] map keyed by the media type
+///   instead of the parameter's `schema`. Use this for parameters with complex serialization, e.g.
+///   a JSON-encoded header value.
+///
 /// * `value_type = ...` Can be used to override default type derived from type of the field used in OpenAPI spec.
 ///   This is useful in cases where the default type does not correspond to the actual type e.g. when
 ///   any third-party types are used which are not [`ToSchema`][to_schema]s nor [`primitive` types][primitive].
@@ -2605,6 +2610,7 @@ pub fn openapi(input: TokenStream) -> TokenStream {
 /// [primitive]: https://doc.rust-lang.org/std/primitive/index.html
 /// [serde attributes]: https://serde.rs/attributes.html
 /// [to_schema_xml]: macro@ToSchema#xml-attribute-configuration-options
+/// [content]: https://spec.openapis.org/oas/latest.html#fixed-fields-for-use-with-content
 pub fn into_params(input: TokenStream) -> TokenStream {
     let DeriveInput {
         attrs,

--- a/utoipa-gen/tests/path_derive.rs
+++ b/utoipa-gen/tests/path_derive.rs
@@ -1144,6 +1144,41 @@ fn derive_into_params_required() {
 }
 
 #[test]
+fn derive_into_params_with_content_type() {
+    #[derive(ToSchema)]
+    #[allow(unused)]
+    struct Filter {
+        name: String,
+        limit: Option<u32>,
+    }
+
+    #[derive(IntoParams)]
+    #[into_params(parameter_in = Header)]
+    #[allow(unused)]
+    struct Params {
+        /// JSON encoded filter.
+        #[param(content_type = "application/json", example = json!({"name": "foo", "limit": 10}))]
+        filter: Option<Filter>,
+        #[param(content_type = "application/json", inline)]
+        inline_filter: Filter,
+        plain: String,
+    }
+
+    #[utoipa::path(get, path = "/params", params(Params))]
+    #[allow(unused)]
+    fn get_params() {}
+    let operation = test_api_fn_doc! {
+        get_params,
+        operation: get,
+        path: "/params"
+    };
+
+    let value = operation.pointer("/parameters");
+
+    assert_json_snapshot!(value)
+}
+
+#[test]
 fn derive_into_params_with_serde_skip() {
     #[derive(IntoParams, Serialize)]
     #[into_params(parameter_in = Query)]

--- a/utoipa-gen/tests/snapshots/path_derive__derive_into_params_with_content_type.snap
+++ b/utoipa-gen/tests/snapshots/path_derive__derive_into_params_with_content_type.snap
@@ -1,0 +1,66 @@
+---
+source: utoipa-gen/tests/path_derive.rs
+expression: value
+---
+[
+  {
+    "content": {
+      "application/json": {
+        "example": {
+          "limit": 10,
+          "name": "foo"
+        },
+        "schema": {
+          "oneOf": [
+            {
+              "$ref": "#/components/schemas/Filter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "description": "JSON encoded filter.",
+    "in": "header",
+    "name": "filter",
+    "required": false
+  },
+  {
+    "content": {
+      "application/json": {
+        "schema": {
+          "properties": {
+            "limit": {
+              "format": "int32",
+              "minimum": 0,
+              "type": [
+                "integer",
+                "null"
+              ]
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name"
+          ],
+          "type": "object"
+        }
+      }
+    },
+    "in": "header",
+    "name": "inline_filter",
+    "required": true
+  },
+  {
+    "in": "header",
+    "name": "plain",
+    "required": true,
+    "schema": {
+      "type": "string"
+    }
+  }
+]


### PR DESCRIPTION
- This PR adds a `content_type = "..."` attribute to `IntoParams #[param(...)]`
- Macro based on work done in `Parameter::content` model in #1555 